### PR TITLE
feat: 프로필 업로드 폼 > 링크 카테고리 select > '직접입력' 옵션 선택 시 편집 가능하도록

### DIFF
--- a/components/common/EditableSelect.tsx
+++ b/components/common/EditableSelect.tsx
@@ -6,43 +6,26 @@ import Select from '@/components/common/Select';
 import { colors } from '@/styles/colors';
 import { textStyles } from '@/styles/typography';
 
-interface EditableSelectProps extends Omit<InputProps, 'value' | 'onChange'> {
-  onChangeSelect: (value: string) => void;
-  onChange: (e: ChangeEvent<HTMLInputElement>) => void;
+interface EditableSelectProps extends Omit<InputProps, 'value' | 'onSelect'> {
+  onSelect: (value: string) => void;
   value: string;
 }
 
 const EditableSelect = forwardRef<HTMLInputElement, EditableSelectProps>(
   (
-    {
-      width = 200,
-      height = 50,
-      disabled = false,
-      children,
-      error,
-      onChange: onChangeInput,
-      className,
-      placeholder,
-      onChangeSelect,
-      ...props
-    },
+    { width = 200, height = 50, disabled = false, children, error, className, placeholder, onSelect, ...props },
     ref,
   ) => {
     const [isEditable, setIsEditable] = useState(false);
 
     const handleSelect = (e: ChangeEvent<HTMLSelectElement>) => {
       const editableOptionIndex = (children as ReactElement).props.options.length + 1;
-      if (e.target.selectedIndex === editableOptionIndex) {
-        onChangeSelect('');
-      } else {
-        onChangeSelect(e.target.value);
-      }
       setIsEditable(e.target.selectedIndex === editableOptionIndex);
+      onSelect(e.target.selectedIndex === editableOptionIndex ? '' : e.target.value);
     };
 
     const handleInput = (e: ChangeEvent<HTMLInputElement>) => {
-      onChangeSelect(e.target.value);
-      onChangeInput(e);
+      onSelect(e.target.value);
     };
 
     return (

--- a/components/common/EditableSelect.tsx
+++ b/components/common/EditableSelect.tsx
@@ -6,13 +6,13 @@ import Select from '@/components/common/Select';
 import { colors } from '@/styles/colors';
 import { textStyles } from '@/styles/typography';
 
-interface MemberEditableSelectProps extends Omit<InputProps, 'value' | 'onChange'> {
+interface EditableSelectProps extends Omit<InputProps, 'value' | 'onChange'> {
   onChangeSelect: (value: string) => void;
   onChange: (e: ChangeEvent<HTMLInputElement>) => void;
   value: string;
 }
 
-const MemberEditableSelect = forwardRef<HTMLInputElement, MemberEditableSelectProps>(
+const EditableSelect = forwardRef<HTMLInputElement, EditableSelectProps>(
   (
     {
       width = 200,
@@ -63,7 +63,7 @@ const MemberEditableSelect = forwardRef<HTMLInputElement, MemberEditableSelectPr
   },
 );
 
-export default MemberEditableSelect;
+export default EditableSelect;
 
 const StyledContainer = styled.div<{ width: number | string; height: number | string }>`
   position: relative;

--- a/components/common/Select/index.tsx
+++ b/components/common/Select/index.tsx
@@ -6,7 +6,7 @@ import { colors } from '@/styles/colors';
 import { textStyles } from '@/styles/typography';
 
 interface SelectProps extends SelectHTMLAttributes<HTMLSelectElement> {
-  width?: number;
+  width?: number | string;
   disabled?: boolean;
   error?: boolean;
 }
@@ -35,7 +35,7 @@ const StyledSelect = styled.select<Pick<SelectProps, 'width' | 'error'>>`
   padding: 14px 34px 14px 20px;
   color: ${colors.gray100};
   ${textStyles.SUIT_16_M};
-  ${({ width }) => `width: ${width}px`};
+  ${({ width }) => `width: ${width}${typeof width === 'number' ? 'px' : ''};`}
 
   &:focus {
     border-color: ${colors.purple100};

--- a/components/members/upload/AddableItem.tsx
+++ b/components/members/upload/AddableItem.tsx
@@ -33,7 +33,6 @@ const StyledContainer = styled.div`
   align-items: center;
   @media ${MOBILE_MEDIA_QUERY} {
     flex-direction: column;
-    height: 154px;
   }
 `;
 

--- a/components/members/upload/AdditionalInfoFormSection.tsx
+++ b/components/members/upload/AdditionalInfoFormSection.tsx
@@ -1,5 +1,5 @@
 import styled from '@emotion/styled';
-import { useFieldArray, useFormContext } from 'react-hook-form';
+import { useFieldArray, useFormContext, useWatch } from 'react-hook-form';
 
 import Input from '@/components/common/Input';
 import Switch from '@/components/common/Switch';
@@ -28,6 +28,7 @@ export default function MemberAdditionalFormSection() {
     name: 'links',
   });
   const isMobile = useMediaQuery(MOBILE_MAX_WIDTH);
+  const linkCategories = useWatch({ control, name: 'links' });
 
   const onAppend = () => append({ title: '', url: '' });
   const onRemove = (index: number) => remove(index);
@@ -54,6 +55,7 @@ export default function MemberAdditionalFormSection() {
                       width='100%'
                       className='category'
                       onChangeSelect={(value: string) => setValue(`links.${index}.title`, value)}
+                      value={linkCategories[index]?.title ?? ''}
                     >
                       <SelectOptions options={LINK_TITLES} />
                     </StyledEditableSelect>
@@ -99,6 +101,7 @@ export default function MemberAdditionalFormSection() {
                       onChangeSelect={(value: string) => setValue(`links.${index}.title`, value)}
                       placeholder='ex) Instagram'
                       {...register(`links.${index}.title`)}
+                      value={linkCategories[index]?.title ?? ''}
                       width='100%'
                       className='category'
                     >

--- a/components/members/upload/AdditionalInfoFormSection.tsx
+++ b/components/members/upload/AdditionalInfoFormSection.tsx
@@ -2,7 +2,6 @@ import styled from '@emotion/styled';
 import { useFieldArray, useFormContext } from 'react-hook-form';
 
 import Input from '@/components/common/Input';
-import Select from '@/components/common/Select';
 import Switch from '@/components/common/Switch';
 import Text from '@/components/common/Text';
 import TextArea from '@/components/common/TextArea';
@@ -11,6 +10,7 @@ import AddableWrapper from '@/components/members/upload/AddableWrapper';
 import { LINK_TITLES } from '@/components/members/upload/constants';
 import CountableInput from '@/components/members/upload/forms/CountableInput';
 import CountableTextArea from '@/components/members/upload/forms/CountableTextArea';
+import EditableSelect from '@/components/members/upload/forms/EditableSelect';
 import FormHeader from '@/components/members/upload/forms/FormHeader';
 import FormItem from '@/components/members/upload/forms/FormItem';
 import { MemberFormSection as FormSection } from '@/components/members/upload/forms/FormSection';
@@ -22,7 +22,7 @@ import { MOBILE_MAX_WIDTH, MOBILE_MEDIA_QUERY } from '@/styles/mediaQuery';
 import { textStyles } from '@/styles/typography';
 
 export default function MemberAdditionalFormSection() {
-  const { register, control } = useFormContext<MemberUploadForm>();
+  const { register, control, setValue } = useFormContext<MemberUploadForm>();
   const { fields, append, remove } = useFieldArray({
     control,
     name: 'links',
@@ -48,9 +48,15 @@ export default function MemberAdditionalFormSection() {
               {fields.map((field, index) => (
                 <AddableItem onRemove={() => onRemove(index)} key={field.id}>
                   <StyledSelectWrapper>
-                    <StyledSelect {...register(`links.${index}.title`)} className='category'>
+                    <StyledEditableSelect
+                      placeholder='ex) Instagram'
+                      {...register(`links.${index}.title`)}
+                      width='100%'
+                      className='category'
+                      onChangeSelect={(value: string) => setValue(`links.${index}.title`, value)}
+                    >
                       <SelectOptions options={LINK_TITLES} />
-                    </StyledSelect>
+                    </StyledEditableSelect>
                     <Input {...register(`links.${index}.url`)} placeholder='https://' className='link' />
                   </StyledSelectWrapper>
                 </AddableItem>
@@ -89,9 +95,15 @@ export default function MemberAdditionalFormSection() {
               {fields.map((field, index) => (
                 <AddableItem onRemove={() => onRemove(index)} key={field.id}>
                   <StyledSelectWrapper>
-                    <StyledSelect {...register(`links.${index}.title`)} className='category'>
+                    <StyledEditableSelect
+                      onChangeSelect={(value: string) => setValue(`links.${index}.title`, value)}
+                      placeholder='ex) Instagram'
+                      {...register(`links.${index}.title`)}
+                      width='100%'
+                      className='category'
+                    >
                       <SelectOptions options={LINK_TITLES} />
-                    </StyledSelect>
+                    </StyledEditableSelect>
                     <Input {...register(`links.${index}.url`)} placeholder='https://' className='link' />
                   </StyledSelectWrapper>
                 </AddableItem>
@@ -160,26 +172,30 @@ const StyledSelectWrapper = styled.div`
 
   .link {
     flex: 2;
+
+    @media ${MOBILE_MEDIA_QUERY} {
+      flex: 1;
+    }
   }
 
   @media ${MOBILE_MEDIA_QUERY} {
     flex-direction: column;
     gap: 11px;
+    height: 111px;
   }
 `;
 
-const StyledSelect = styled(Select)`
+const StyledEditableSelect = styled(EditableSelect)`
   border-width: 1.5px;
   border-radius: 14px;
   padding: 16px 34px 16px 20px;
-  color: ${colors.gray80};
+  height: 50px;
 
   ${textStyles.SUIT_16_M};
 
   @media ${MOBILE_MEDIA_QUERY} {
     border-radius: 12px;
     background-color: ${colors.black80};
-    width: 100%;
   }
 `;
 

--- a/components/members/upload/AdditionalInfoFormSection.tsx
+++ b/components/members/upload/AdditionalInfoFormSection.tsx
@@ -1,6 +1,7 @@
 import styled from '@emotion/styled';
 import { useFieldArray, useFormContext, useWatch } from 'react-hook-form';
 
+import EditableSelect from '@/components/common/EditableSelect';
 import Input from '@/components/common/Input';
 import Switch from '@/components/common/Switch';
 import Text from '@/components/common/Text';
@@ -10,7 +11,6 @@ import AddableWrapper from '@/components/members/upload/AddableWrapper';
 import { LINK_TITLES } from '@/components/members/upload/constants';
 import CountableInput from '@/components/members/upload/forms/CountableInput';
 import CountableTextArea from '@/components/members/upload/forms/CountableTextArea';
-import EditableSelect from '@/components/members/upload/forms/EditableSelect';
 import FormHeader from '@/components/members/upload/forms/FormHeader';
 import FormItem from '@/components/members/upload/forms/FormItem';
 import { MemberFormSection as FormSection } from '@/components/members/upload/forms/FormSection';

--- a/components/members/upload/AdditionalInfoFormSection.tsx
+++ b/components/members/upload/AdditionalInfoFormSection.tsx
@@ -54,7 +54,7 @@ export default function MemberAdditionalFormSection() {
                       {...register(`links.${index}.title`)}
                       width='100%'
                       className='category'
-                      onChangeSelect={(value: string) => setValue(`links.${index}.title`, value)}
+                      onSelect={(value: string) => setValue(`links.${index}.title`, value)}
                       value={linkCategories[index]?.title ?? ''}
                     >
                       <SelectOptions options={LINK_TITLES} />
@@ -98,9 +98,9 @@ export default function MemberAdditionalFormSection() {
                 <AddableItem onRemove={() => onRemove(index)} key={field.id}>
                   <StyledSelectWrapper>
                     <StyledEditableSelect
-                      onChangeSelect={(value: string) => setValue(`links.${index}.title`, value)}
                       placeholder='ex) Instagram'
                       {...register(`links.${index}.title`)}
+                      onSelect={(value: string) => setValue(`links.${index}.title`, value)}
                       value={linkCategories[index]?.title ?? ''}
                       width='100%'
                       className='category'

--- a/components/members/upload/forms/EditableSelect.tsx
+++ b/components/members/upload/forms/EditableSelect.tsx
@@ -68,7 +68,6 @@ export default MemberEditableSelect;
 
 const StyledContainer = styled.div<{ width: number | string; height: number | string }>`
   position: relative;
-  background-color: red;
 
   ${({ width }) => `width: ${width}${typeof width === 'number' ? 'px' : ''};`}
   ${({ height }) => `height: ${height}${typeof height === 'number' ? 'px' : ''};`}

--- a/components/members/upload/forms/EditableSelect.tsx
+++ b/components/members/upload/forms/EditableSelect.tsx
@@ -42,7 +42,7 @@ const MemberEditableSelect = forwardRef<HTMLInputElement, MemberEditableSelectPr
 
     const handleInput = (e: ChangeEvent<HTMLInputElement>) => {
       onChangeSelect(e.target.value);
-      onChangeInput?.(e);
+      onChangeInput(e);
     };
 
     return (

--- a/components/members/upload/forms/EditableSelect.tsx
+++ b/components/members/upload/forms/EditableSelect.tsx
@@ -26,26 +26,20 @@ const MemberEditableSelect = forwardRef<HTMLInputElement, MemberEditableSelectPr
     },
     ref,
   ) => {
-    const [visibleValue, setVisibleValue] = useState('');
     const [isEditable, setIsEditable] = useState(false);
-
-    const setValue = (value: string) => {
-      onChangeSelect(value);
-      setVisibleValue(value);
-    };
 
     const handleSelect = (e: ChangeEvent<HTMLSelectElement>) => {
       const editableOptionIndex = (children as ReactElement).props.options.length + 1;
       if (e.target.selectedIndex === editableOptionIndex) {
-        setValue('');
+        onChangeSelect('');
       } else {
-        setValue(e.target.value);
+        onChangeSelect(e.target.value);
       }
       setIsEditable(e.target.selectedIndex === editableOptionIndex);
     };
 
     const handleInput = (e: ChangeEvent<HTMLInputElement>) => {
-      setValue(e.target.value);
+      onChangeSelect(e.target.value);
       onChangeInput?.(e);
     };
 
@@ -60,7 +54,6 @@ const MemberEditableSelect = forwardRef<HTMLInputElement, MemberEditableSelectPr
           placeholder={isEditable ? '직접입력' : placeholder}
           readOnly={!isEditable}
           ref={ref}
-          value={visibleValue}
           {...props}
         />
       </StyledContainer>

--- a/components/members/upload/forms/EditableSelect.tsx
+++ b/components/members/upload/forms/EditableSelect.tsx
@@ -6,8 +6,10 @@ import Select from '@/components/common/Select';
 import { colors } from '@/styles/colors';
 import { textStyles } from '@/styles/typography';
 
-interface MemberEditableSelectProps extends InputProps {
+interface MemberEditableSelectProps extends Omit<InputProps, 'value' | 'onChange'> {
   onChangeSelect: (value: string) => void;
+  onChange: (e: ChangeEvent<HTMLInputElement>) => void;
+  value: string;
 }
 
 const MemberEditableSelect = forwardRef<HTMLInputElement, MemberEditableSelectProps>(

--- a/components/members/upload/forms/EditableSelect.tsx
+++ b/components/members/upload/forms/EditableSelect.tsx
@@ -18,10 +18,10 @@ const MemberEditableSelect = forwardRef<HTMLInputElement, MemberEditableSelectPr
       disabled = false,
       children,
       error,
-      onChange,
+      onChange: onChangeInput,
       className,
       placeholder,
-      onChangeSelect: setRealValue,
+      onChangeSelect,
       ...props
     },
     ref,
@@ -30,7 +30,7 @@ const MemberEditableSelect = forwardRef<HTMLInputElement, MemberEditableSelectPr
     const [isEditable, setIsEditable] = useState(false);
 
     const setValue = (value: string) => {
-      setRealValue(value);
+      onChangeSelect(value);
       setVisibleValue(value);
     };
 
@@ -46,7 +46,7 @@ const MemberEditableSelect = forwardRef<HTMLInputElement, MemberEditableSelectPr
 
     const handleInput = (e: ChangeEvent<HTMLInputElement>) => {
       setValue(e.target.value);
-      onChange?.(e);
+      onChangeInput?.(e);
     };
 
     return (

--- a/components/members/upload/forms/EditableSelect.tsx
+++ b/components/members/upload/forms/EditableSelect.tsx
@@ -21,27 +21,31 @@ const MemberEditableSelect = forwardRef<HTMLInputElement, MemberEditableSelectPr
       onChange,
       className,
       placeholder,
-      onChangeSelect,
+      onChangeSelect: setRealValue,
       ...props
     },
     ref,
   ) => {
-    const [inputValue, setInputValue] = useState('');
+    const [visibleValue, setVisibleValue] = useState('');
     const [isEditable, setIsEditable] = useState(false);
+
+    const setValue = (value: string) => {
+      setRealValue(value);
+      setVisibleValue(value);
+    };
 
     const handleSelect = (e: ChangeEvent<HTMLSelectElement>) => {
       const editableOptionIndex = (children as ReactElement).props.options.length + 1;
       if (e.target.selectedIndex === editableOptionIndex) {
-        setInputValue('');
+        setValue('');
       } else {
-        onChangeSelect(e.target.value);
-        setInputValue(e.target.value);
+        setValue(e.target.value);
       }
       setIsEditable(e.target.selectedIndex === editableOptionIndex);
     };
 
     const handleInput = (e: ChangeEvent<HTMLInputElement>) => {
-      setInputValue(e.target.value);
+      setValue(e.target.value);
       onChange?.(e);
     };
 
@@ -56,7 +60,7 @@ const MemberEditableSelect = forwardRef<HTMLInputElement, MemberEditableSelectPr
           placeholder={isEditable ? '직접입력' : placeholder}
           readOnly={!isEditable}
           ref={ref}
-          value={inputValue}
+          value={visibleValue}
           {...props}
         />
       </StyledContainer>

--- a/components/members/upload/forms/EditableSelect.tsx
+++ b/components/members/upload/forms/EditableSelect.tsx
@@ -1,0 +1,96 @@
+import styled from '@emotion/styled';
+import { ChangeEvent, forwardRef, ReactElement, useState } from 'react';
+
+import { InputProps } from '@/components/common/Input';
+import Select from '@/components/common/Select';
+import { colors } from '@/styles/colors';
+import { textStyles } from '@/styles/typography';
+
+interface MemberEditableSelectProps extends InputProps {
+  onChangeSelect: (value: string) => void;
+}
+
+const MemberEditableSelect = forwardRef<HTMLInputElement, MemberEditableSelectProps>(
+  (
+    {
+      width = 200,
+      height = 50,
+      disabled = false,
+      children,
+      error,
+      onChange,
+      className,
+      placeholder,
+      onChangeSelect,
+      ...props
+    },
+    ref,
+  ) => {
+    const [inputValue, setInputValue] = useState('');
+    const [isEditable, setIsEditable] = useState(false);
+
+    const handleSelect = (e: ChangeEvent<HTMLSelectElement>) => {
+      const editableOptionIndex = (children as ReactElement).props.options.length + 1;
+      if (e.target.selectedIndex === editableOptionIndex) {
+        setInputValue('');
+      } else {
+        onChangeSelect(e.target.value);
+        setInputValue(e.target.value);
+      }
+      setIsEditable(e.target.selectedIndex === editableOptionIndex);
+    };
+
+    const handleInput = (e: ChangeEvent<HTMLInputElement>) => {
+      setInputValue(e.target.value);
+      onChange?.(e);
+    };
+
+    return (
+      <StyledContainer width={width} height={height} className={className}>
+        <StyledSelect width={width} className={className} onChange={handleSelect} disabled={disabled} error={error}>
+          {children}
+          <option label='직접입력' />
+        </StyledSelect>
+        <StyledInput
+          onChange={handleInput}
+          placeholder={isEditable ? '직접입력' : placeholder}
+          readOnly={!isEditable}
+          ref={ref}
+          value={inputValue}
+          {...props}
+        />
+      </StyledContainer>
+    );
+  },
+);
+
+export default MemberEditableSelect;
+
+const StyledContainer = styled.div<{ width: number | string; height: number | string }>`
+  position: relative;
+  background-color: red;
+
+  ${({ width }) => `width: ${width}${typeof width === 'number' ? 'px' : ''};`}
+  ${({ height }) => `height: ${height}${typeof height === 'number' ? 'px' : ''};`}
+`;
+
+const StyledSelect = styled(Select)`
+  position: absolute;
+  top: 0;
+  left: 0;
+  color: transparent;
+`;
+
+const StyledInput = styled.input`
+  position: absolute;
+  top: 50%;
+  left: 1.5px;
+  transform: translateY(-50%);
+  border: none;
+  background-color: transparent;
+  width: calc(100% - 42px);
+  height: calc(100% - 3px);
+  color: ${colors.gray30};
+
+  ${textStyles.SUIT_16_M};
+`;


### PR DESCRIPTION
### 🤫 쉿, 나한테만 말해줘요. 이슈넘버
- close #156 

### 🧐 어떤 것을 변경했어요~?
프로필 업로드 페이지의 링크 카테고리 select에 '직접입력' 옵션을 추가하고, 해당 옵션 선택 시 직접 편집 가능하도록 했어요

### 🤔 그렇다면, 어떻게 구현했어요~?
EditableSelect 컴포넌트 구현하여 적용
대략적인 컨셉은 아래와 같고 더 자세한 동작 방식은 코드 봐주세요!

- 마지막 옵션이 기본적으로 '직접입력'
- select 위에 input을 올려, select의 value가 input에 보이도록 함 (혹시 모를 스타일 깨짐 방지를 위해 select의 글씨는 투명색으로 설정)
- '직접입력' 옵션 선택 시 input의 `readonly`가 `false`, 그 외는 `true`

### ❤️‍🔥 당신이 생각하는 PR포인트, 내겐 매력포인트.
아무래도 select가 바뀌면 실제로 보여지는 input value를 set하다 보니 일반 select에 비해 딜레이가 조오오금 있어요

그리고 혹시 EditableSelect 컴포넌트를 더 개선해볼 수 있지 않을까 생각이 들긴 하는데 일단 동작은 잘해서 시간 관계상 이렇게 올려요 ,,
(현재 이 컴포넌트를 사용 중인 곳이랑 독립성이 보장 됐는지, 좋은 인터페이스를 가지고 있는지 고민을 덜 해본 것 같아요
나중에 개선 시도 해서 성공하면 아예 common으로 빼도 좋지 않을까 생각합니당)

\+ 커밋 몇 개 더 해서 조금씩 개선해보긴 했습니다!

### 📸 스크린샷, 없으면 이것 참,, 섭섭한데요?
UI 로직이랑 state 관리 둘 다 잘댑니다

https://user-images.githubusercontent.com/73823388/201295916-b15f93cf-5e31-4ff8-a19a-e28f24829be5.mov

### Reference
EditableSelect 아이디어 얻음
https://stackoverflow.com/questions/2141357/editable-select-element