### PR TITLE
fix: 누락되었던 멤버 수정 코드 복원

### DIFF
--- a/components/members/upload/AdditionalInfoFormSection.tsx
+++ b/components/members/upload/AdditionalInfoFormSection.tsx
@@ -50,7 +50,7 @@ export default function MemberAdditionalFormSection() {
                 <AddableItem onRemove={() => onRemove(index)} key={field.id}>
                   <StyledSelectWrapper>
                     <StyledEditableSelect
-                      placeholder='ex) Instagram'
+                      placeholder='링크를 입력해주세요'
                       {...register(`links.${index}.title`)}
                       width='100%'
                       className='category'

--- a/pages/members/upload.tsx
+++ b/pages/members/upload.tsx
@@ -2,6 +2,7 @@ import styled from '@emotion/styled';
 import { yupResolver } from '@hookform/resolvers/yup';
 import dayjs from 'dayjs';
 import { useRouter } from 'next/router';
+import { useEffect } from 'react';
 import { FormProvider, useForm } from 'react-hook-form';
 
 import { postMemberProfile } from '@/api/members';
@@ -35,16 +36,46 @@ export default function MemberUploadPage() {
   const { query } = useStringRouterQuery(['edit'] as const);
   const { data: myProfile, refetch: refetchMyProfile } = useGetMemberProfileOfMe();
   const { data: me, refetch: refetchMe } = useGetMemberOfMe();
-
   const { refetch: refetchProfileById } = useGetMemberProfileById(me?.id);
-
-  const isEditPage = query?.edit === 'true' ? true : false;
-
   const {
     handleSubmit,
     setValue,
     formState: { errors },
   } = formMethods;
+
+  const isEditPage = query?.edit === 'true' ? true : false;
+  const uploadType = isEditPage ? '수정' : '등록';
+
+  useEffect(() => {
+    if (isEditPage && myProfile) {
+      setValue('name', myProfile.name);
+      setValue('birthday', {
+        year: Number(myProfile.birthday.split('-')[0]).toString(),
+        month: Number(myProfile.birthday.split('-')[1]).toString(),
+        day: Number(myProfile.birthday.split('-')[2]).toString(),
+      });
+      setValue('phone', myProfile.phone);
+      setValue('email', myProfile.email);
+      setValue('address', myProfile.address);
+      setValue('university', myProfile.university);
+      setValue('major', myProfile.major);
+      setValue('introduction', myProfile.introduction);
+      setValue('skill', myProfile.skill);
+      setValue('links', myProfile.links);
+      setValue('openToWork', myProfile.openToWork);
+      setValue('openToSideProject', myProfile.openToSideProject);
+      setValue(
+        'activities',
+        myProfile.activities.map((act) => ({
+          generation: act.cardinalInfo.split(',')[0],
+          part: act.cardinalInfo.split(',')[1],
+          team: act.cardinalActivities[0].team,
+        })),
+      );
+      setValue('allowOfficial', myProfile.allowOfficial);
+      setValue('profileImage', myProfile.profileImage);
+    }
+  }, [isEditPage, myProfile, setValue]);
 
   const formatBirthday = (birthday: Birthday) => {
     const { year, month, day } = birthday;
@@ -64,10 +95,6 @@ export default function MemberUploadPage() {
 
     router.push(`/members/detail?memberId=${response.id}`);
   };
-
-  const uploadType = isEditPage ? '수정' : '등록';
-
-  console.log('[error]: ', errors);
 
   return (
     <AuthRequired>


### PR DESCRIPTION
### 🤫 쉿, 나한테만 말해줘요. 이슈넘버
- close #

### 🧐 어떤 것을 변경했어요~?
<!-- 실제로 변경한 사항을 설명해주세요.-->
- 멤버 업로드 이슈 대응하다가 코드를 날려먹어서 다시 복구합니당..ㅎ
- 링크쪽 `placeholder`가 인스타그램이 선택된줄 착각하는 유저들이 있어서 수정했어요(예린, 주영과 싱크맞춤)

### 🤔 그렇다면, 어떻게 구현했어요~?
<!-- 실제로 구현한 로직에 대해 설명해주세요.-->

### ❤️‍🔥 당신이 생각하는 PR포인트, 내겐 매력포인트.
<!-- 해당 PR에서 논의가 필요한 사항을 적어주세요. -->

### 📸 스크린샷, 없으면 이것 참,, 섭섭한데요?
