### PR TITLE
feat: 프로필 업로드 > 생일 유효성 검사 추가

### DIFF
--- a/components/members/upload/BasicFormSection.tsx
+++ b/components/members/upload/BasicFormSection.tsx
@@ -25,6 +25,13 @@ export default function MemberBasicFormSection() {
 
   const isEditPage = query?.edit === 'true' ? true : false;
 
+  const getBirthdayErrorMessage = () => {
+    if (errors.birthday?.year) return errors.birthday?.year.message;
+    if (errors.birthday?.month) return errors.birthday?.month.message;
+    if (errors.birthday?.day) return errors.birthday?.day.message;
+    return '';
+  };
+
   return (
     <FormSection>
       <FormHeader title='기본정보' />
@@ -45,11 +52,11 @@ export default function MemberBasicFormSection() {
         <FormItem title='이름' essential errorMessage={errors.name?.message}>
           <StyledInput {...register('name')} error={errors.hasOwnProperty('name')} />
         </FormItem>
-        <FormItem title='생년월일'>
+        <FormItem title='생년월일' errorMessage={getBirthdayErrorMessage()}>
           <StyledBirthdayInputWrapper>
-            <Input {...register('birthday.year')} placeholder='년도' />
-            <Input {...register('birthday.month')} placeholder='월' />
-            <Input {...register('birthday.day')} placeholder='일' />
+            <Input {...register('birthday.year')} placeholder='년도' error={errors.birthday?.hasOwnProperty('year')} />
+            <Input {...register('birthday.month')} placeholder='월' error={errors.birthday?.hasOwnProperty('month')} />
+            <Input {...register('birthday.day')} placeholder='일' error={errors.birthday?.hasOwnProperty('day')} />
           </StyledBirthdayInputWrapper>
         </FormItem>
         <FormItem title='연락처' errorMessage={errors.phone?.message}>

--- a/components/members/upload/constants.ts
+++ b/components/members/upload/constants.ts
@@ -43,6 +43,3 @@ export const PARTS = [
 export const TEAMS = ['운영팀', '미디어팀', '해당 없음'];
 
 export const LINK_TITLES = ['Facebook', 'Instagram', 'LinkedIn', 'GitHub', 'Behance'];
-
-export const PHONE_REG_EXP = /^01([0|1|6|7|8|9])-?([0-9]{3,4})-?([0-9]{4})$/;
-export const EMAIL_REG_EXP = /^[a-zA-Z0-9+-\_.]+@[a-zA-Z0-9-]+\.[a-zA-Z0-9-.]+$/;

--- a/components/members/upload/schema.ts
+++ b/components/members/upload/schema.ts
@@ -4,7 +4,7 @@ import { EMAIL_REG_EXP, PHONE_REG_EXP } from '@/components/members/upload/consta
 
 export const memberFormSchema = yup.object().shape({
   profileImage: yup.string(),
-  name: yup.string().required('이름을 입력해주세요'),
+  name: yup.string().required('이름을 입력해주세요.'),
   birthday: yup.object().shape({
     year: yup.string(),
     month: yup.string(),
@@ -14,22 +14,22 @@ export const memberFormSchema = yup.object().shape({
     .string()
     .when([], (_, { originalValue }) =>
       originalValue?.length
-        ? yup.string().matches(PHONE_REG_EXP, `'-'를 넣어 휴대폰 양식에 맞게 입력해주세요`)
+        ? yup.string().matches(PHONE_REG_EXP, `'-'를 넣어 휴대폰 양식에 맞게 입력해주세요.`)
         : yup.string(),
     ),
   email: yup
     .string()
     .when([], (_, { originalValue }) =>
-      originalValue?.length ? yup.string().matches(EMAIL_REG_EXP, '이메일 양식에 맞게 입력해주세요') : yup.string(),
+      originalValue?.length ? yup.string().matches(EMAIL_REG_EXP, '이메일 양식에 맞게 입력해주세요.') : yup.string(),
     ),
   address: yup.string(),
   university: yup.string(),
   major: yup.string(),
   activities: yup.array().of(
     yup.object().shape({
-      generation: yup.string().required('기수를 입력해주세요'),
-      part: yup.string().required('파트를 입력해주세요'),
-      team: yup.string().required('팀 소속 정보를 입력해주세요'),
+      generation: yup.string().required('기수를 입력해주세요.'),
+      part: yup.string().required('파트를 입력해주세요.'),
+      team: yup.string().required('팀 소속 정보를 입력해주세요.'),
     }),
   ),
   openToWork: yup.boolean(),

--- a/components/members/upload/schema.ts
+++ b/components/members/upload/schema.ts
@@ -1,14 +1,33 @@
 import * as yup from 'yup';
 
-import { EMAIL_REG_EXP, PHONE_REG_EXP } from '@/components/members/upload/constants';
+const PHONE_REG_EXP = /^01([0|1|6|7|8|9])-?([0-9]{3,4})-?([0-9]{4})$/;
+const EMAIL_REG_EXP = /^[a-zA-Z0-9+-\_.]+@[a-zA-Z0-9-]+\.[a-zA-Z0-9-.]+$/;
+const YEAR_REG_EXP = /\d{4}/;
+const MONTH_REG_EXP = /^0?[1-9]{1}$|^1{1}[0-2]{1}$/;
+const DAY_REG_EXP = /^0?[1-9]{1}$|^[1-2]{1}[0-9]{1}$|^3{1}[0-1]{1}$/;
 
 export const memberFormSchema = yup.object().shape({
   profileImage: yup.string(),
   name: yup.string().required('이름을 입력해주세요.'),
   birthday: yup.object().shape({
-    year: yup.string(),
-    month: yup.string(),
-    day: yup.string(),
+    year: yup.lazy(() =>
+      yup.string().when(['month', 'day'], {
+        is: (month: string, day: string) => month || day,
+        then: yup.string().required('연도를 입력해주세요.').matches(YEAR_REG_EXP, '연도를 숫자 4자리로 입력해주세요.'),
+      }),
+    ),
+    month: yup.lazy(() =>
+      yup.string().when(['year', 'day'], {
+        is: (year: string, day: string) => year || day,
+        then: yup.string().required('월을 입력해주세요.').matches(MONTH_REG_EXP, '월을 형식에 맞게 입력해주세요.'),
+      }),
+    ),
+    day: yup.lazy(() =>
+      yup.string().when(['year', 'month'], {
+        is: (year: string, month: string) => year || month,
+        then: yup.string().required('일을 입력해주세요.').matches(DAY_REG_EXP, '일을 형식에 맞게 입력해주세요.'),
+      }),
+    ),
   }),
   phone: yup
     .string()

--- a/components/members/upload/schema.ts
+++ b/components/members/upload/schema.ts
@@ -2,7 +2,7 @@ import * as yup from 'yup';
 
 const PHONE_REG_EXP = /^01([0|1|6|7|8|9])-?([0-9]{3,4})-?([0-9]{4})$/;
 const EMAIL_REG_EXP = /^[a-zA-Z0-9+-\_.]+@[a-zA-Z0-9-]+\.[a-zA-Z0-9-.]+$/;
-const YEAR_REG_EXP = /\d{4}/;
+const YEAR_REG_EXP = /^\d{4}$/;
 const MONTH_REG_EXP = /^0?[1-9]{1}$|^1{1}[0-2]{1}$/;
 const DAY_REG_EXP = /^0?[1-9]{1}$|^[1-2]{1}[0-9]{1}$|^3{1}[0-1]{1}$/;
 


### PR DESCRIPTION
### 🤫 쉿, 나한테만 말해줘요. 이슈넘버
- close #204 

### 🧐 어떤 것을 변경했어요~?
yup schema에 생일 필드 유효성 검사를 추가해서 잘못된 형식일 경우 유저에게 알려줄 수 있도록 했어요
(기존에는 노티 없이 올바른 형식으로 알아서 변환 후 submit)

### 🤔 그렇다면, 어떻게 구현했어요~?
년, 월, 일 중 값 하나라도 있는 경우에(생일이 필수 항목이 아니기 때문에) 아래처럼 동작하도록 스키마를 수정했습니다
- 나머지 두 가지 값 모두 required
- 각각에 맞는 정규표현식에 맞는지 검사

### 📸 스크린샷, 없으면 이것 참,, 섭섭한데요?

https://user-images.githubusercontent.com/73823388/203329100-25d6f350-6324-4af1-a080-f6f2c6325ba2.mov

