### PR TITLE
fix: 회원 인증 화면 포커스 문제 수정

### DIFF
--- a/components/auth/register/VerifyByEmail.tsx
+++ b/components/auth/register/VerifyByEmail.tsx
@@ -52,7 +52,7 @@ const VerifyByEmail: FC = () => {
       <ErrorMessage show={verify.isError}>
         <IconWarning /> {formatErrorMessage(verify.error)}
       </ErrorMessage>
-      <SendButton variant='primary' href='#'>
+      <SendButton as='button' variant='primary'>
         {verify.isLoading ? <ClipLoader color='#ffffff' size={25} /> : <>SOPT 회원 인증메일 전송</>}
       </SendButton>
       <ErrorNotice href='https://forms.gle/Hs9tJgMG9bNvT1rS9' target='_blank'>
@@ -79,7 +79,9 @@ const FormContainer = styled.form`
   display: flex;
   flex-direction: column;
   align-items: center;
+  padding-bottom: 100px;
   width: 420px;
+
   @media ${MOBILE_MEDIA_QUERY} {
     padding: 0 24px;
   }

--- a/components/auth/register/VerifyByEmail.tsx
+++ b/components/auth/register/VerifyByEmail.tsx
@@ -79,7 +79,6 @@ const FormContainer = styled.form`
   display: flex;
   flex-direction: column;
   align-items: center;
-  padding-bottom: 100px;
   width: 420px;
 
   @media ${MOBILE_MEDIA_QUERY} {

--- a/components/auth/register/VerifyByEmail.tsx
+++ b/components/auth/register/VerifyByEmail.tsx
@@ -1,6 +1,6 @@
 import styled from '@emotion/styled';
 import { AxiosError } from 'axios';
-import { FC, useState } from 'react';
+import { FC, FormEvent, useState } from 'react';
 import { useMutation } from 'react-query';
 import { ClipLoader } from 'react-spinners';
 
@@ -25,7 +25,9 @@ const VerifyByEmail: FC = () => {
     return postRegistrationEmail(emailInput);
   });
 
-  const handleSend = () => {
+  const handleSend = (e: FormEvent) => {
+    e.preventDefault();
+
     if (verify.isLoading) {
       return;
     }
@@ -37,7 +39,7 @@ const VerifyByEmail: FC = () => {
   }
 
   return (
-    <Container>
+    <FormContainer onSubmit={handleSend}>
       <Title>SOPT 회원인증</Title>
       <Description>SOPT 지원시 입력했던 이메일을 입력해주세요</Description>
       <Label>이메일</Label>
@@ -50,19 +52,19 @@ const VerifyByEmail: FC = () => {
       <ErrorMessage show={verify.isError}>
         <IconWarning /> {formatErrorMessage(verify.error)}
       </ErrorMessage>
-      <SendButton variant='primary' onClick={handleSend}>
+      <SendButton variant='primary' href='#'>
         {verify.isLoading ? <ClipLoader color='#ffffff' size={25} /> : <>SOPT 회원 인증메일 전송</>}
       </SendButton>
-      <ErrorNotice>
-        <GoogleFormButton onClick={() => window.open('https://forms.gle/Hs9tJgMG9bNvT1rS9', '_blank')}>
+      <ErrorNotice href='https://forms.gle/Hs9tJgMG9bNvT1rS9' target='_blank'>
+        <NoticeTitle>
           <div className='question'>이메일로 SOPT 회원 인증이 안된다면?</div>
           <IconArrowRight />
-        </GoogleFormButton>
+        </NoticeTitle>
         <ErrorNoticeDescription>
           {`SOPT 정보 등록 시 기입한 이메일의 확인이 어려운 경우,\n구글폼을 통해 가입을 도와드리고 있어요!`}{' '}
         </ErrorNoticeDescription>
       </ErrorNotice>
-    </Container>
+    </FormContainer>
   );
 };
 
@@ -73,7 +75,7 @@ function formatErrorMessage(error: AxiosError<ErrorResponse> | null) {
   return innerMessage ?? '서버와의 접속이 실패했습니다.';
 }
 
-const Container = styled.div`
+const FormContainer = styled.form`
   display: flex;
   flex-direction: column;
   align-items: center;
@@ -125,15 +127,20 @@ const SendButton = styled(SquareLink)`
   }
 `;
 
-const ErrorNotice = styled.div`
+const ErrorNotice = styled.a`
   display: flex;
   flex-direction: column;
   gap: 10px;
+  transition: background-color 0.3s;
   margin-top: 60px;
   border-radius: 6px;
   background-color: ${colors.black60};
   padding: 19px 0 18px 20px;
   width: 420px;
+
+  &:hover {
+    background-color: ${colors.black40};
+  }
 
   @media ${MOBILE_MEDIA_QUERY} {
     width: 100%;
@@ -148,7 +155,7 @@ const ErrorNoticeDescription = styled.div`
   font-weight: 500;
 `;
 
-const GoogleFormButton = styled.button`
+const NoticeTitle = styled.div`
   display: flex;
   gap: 2px;
   align-items: center;

--- a/components/common/SquareLink/index.tsx
+++ b/components/common/SquareLink/index.tsx
@@ -1,5 +1,5 @@
 import styled from '@emotion/styled';
-import { AnchorHTMLAttributes, forwardRef } from 'react';
+import { AnchorHTMLAttributes, ElementType, forwardRef } from 'react';
 
 import { ButtonSize, buttonSize, ButtonStyle, buttonStyles } from '@/components/common/SquareLink/style';
 import { textStyles } from '@/styles/typography';
@@ -7,12 +7,13 @@ import { textStyles } from '@/styles/typography';
 interface ButtonProps extends AnchorHTMLAttributes<HTMLAnchorElement> {
   variant?: ButtonStyle;
   size?: ButtonSize;
+  as?: ElementType;
 }
 
 const SquareLink = forwardRef<HTMLAnchorElement, ButtonProps>(
-  ({ variant = 'default', size = 'medium', children, ...props }, ref) => {
+  ({ variant = 'default', size = 'medium', as, children, ...props }, ref) => {
     return (
-      <StyledSquareLink variant={variant} size={size} {...props} ref={ref}>
+      <StyledSquareLink as={as} variant={variant} size={size} {...props} ref={ref}>
         {children}
       </StyledSquareLink>
     );

--- a/components/common/SquareLink/style.ts
+++ b/components/common/SquareLink/style.ts
@@ -11,8 +11,14 @@ export const buttonStyles: Record<ButtonStyle, SerializedStyles> = {
     color: ${colors.gray100};
   `,
   primary: css`
+    transition: background-color 0.3s;
     background-color: ${colors.purple100};
     color: #e2e2e2;
+
+    &:hover,
+    &:focus {
+      background-color: ${colors.purple80};
+    }
   `,
 };
 

--- a/components/debug/SideToggleButton.tsx
+++ b/components/debug/SideToggleButton.tsx
@@ -8,7 +8,11 @@ interface SideToggleButtonProps {
 }
 
 const SideToggleButton: FC<SideToggleButtonProps> = ({ onClick }) => {
-  return <StyledSideToggleButton onClick={onClick}>DEBUG</StyledSideToggleButton>;
+  return (
+    <StyledSideToggleButton onClick={onClick} tabIndex={-1}>
+      DEBUG
+    </StyledSideToggleButton>
+  );
 };
 
 export default SideToggleButton;

--- a/pages/auth/verify.tsx
+++ b/pages/auth/verify.tsx
@@ -17,5 +17,6 @@ const StyledVerifyPage = styled.div`
   display: flex;
   flex-direction: column;
   align-items: center;
-  padding-top: 200px;
+  justify-content: center;
+  min-height: 100%;
 `;


### PR DESCRIPTION
### 🤫 쉿, 나한테만 말해줘요. 이슈넘버
- close #207 

### 🧐 어떤 것을 변경했어요~?
- 가입 이메일 인증 화면에서 탭 포커스가 이상해지는 현상을 수정했어요.
- 디버그 패널 버튼이 포커스 잡히는 현상을 수정했어요.
- (겸사겸사) 가입 이메일 인증 화면이 모바일에서 가운데 나오지 않는 현상을 수정했어요.
- (겸사겸사) 버튼과 링크의 hover 트랜지션을 추가했어요.

### 🤔 그렇다면, 어떻게 구현했어요~?

a 태그에 href가 없으면 포커스가 잡히지 않는 특징이 있다고 해요.
https://ask.metafilter.com/359769/Why-is-the-tab-key-skipping-these-links

이 특징때문에 제대로 포커스가 잡히지 않았어서, button 태그로 바꿀 수 있게 만들었어요.

### ❤️‍🔥 당신이 생각하는 PR포인트, 내겐 매력포인트.
<!-- 해당 PR에서 논의가 필요한 사항을 적어주세요. -->

### 📸 스크린샷, 없으면 이것 참,, 섭섭한데요?
