### PR TITLE
fix: 드롭다운과 메뉴 닫히지 않는 버그 수정

### DIFF
--- a/components/common/Header/index.tsx
+++ b/components/common/Header/index.tsx
@@ -18,7 +18,7 @@ import { textStyles } from '@/styles/typography';
 
 const Header: FC = () => {
   const { logout } = useAuth();
-  const { pathname } = useRouter();
+  const { pathname, events } = useRouter();
 
   const [isUserDropdownOpened, setIsUserDropdownOpened] = useState(false);
   const [isMobileMenuOpened, setIsMobileMenuOpened] = useState(false);
@@ -93,49 +93,44 @@ const Header: FC = () => {
         </UserButton>
       </RightGroup>
 
-      {isUserDropdownOpened && (
-        <UserDropdown ref={dropdownRef}>
-          <Link href={me?.hasProfile ? `/members/detail?memberId=${me?.id}` : '/members/upload'}>내 프로필</Link>
-          <div onClick={logout}>로그아웃</div>
-        </UserDropdown>
-      )}
+      <UserDropdown ref={dropdownRef} isOpen={isUserDropdownOpened}>
+        <Link href={me?.hasProfile ? `/members/detail?memberId=${me?.id}` : '/members/upload'}>내 프로필</Link>
+        <div onClick={logout}>로그아웃</div>
+      </UserDropdown>
 
-      {isMobileMenuOpened && (
-        <MobileMenuWrapper ref={mobileMenuRef} onClick={() => setIsMobileMenuOpened(false)}>
-          <MobileMenu>
-            <Link href={me?.hasProfile ? `/members/detail?memberId=${me?.id}` : '/members/upload'} passHref>
-              <ProfileContainer>
-                {/* TODO: 프로필 있을 경우와 아닐 경우에 따라 분기처리 필요 */}
-                <EmptyProfileImage>
-                  <ProfileIcon width={17.29} />
-                </EmptyProfileImage>
-                <Name>{me?.name}</Name>
-                <Spacer />
-                <StyledForwardIcon />
-              </ProfileContainer>
-            </Link>
+      <DimmedBackground isOpen={isMobileMenuOpened} onClick={() => setIsMobileMenuOpened(false)} />
+      <MobileMenu isOpen={isMobileMenuOpened} ref={mobileMenuRef}>
+        <Link href={me?.hasProfile ? `/members/detail?memberId=${me?.id}` : '/members/upload'} passHref>
+          <ProfileContainer>
+            {/* TODO: 프로필 있을 경우와 아닐 경우에 따라 분기처리 필요 */}
+            <EmptyProfileImage>
+              <ProfileIcon width={17.29} />
+            </EmptyProfileImage>
+            <Name>{me?.name}</Name>
+            <Spacer />
+            <StyledForwardIcon />
+          </ProfileContainer>
+        </Link>
 
-            <RouterWrapper>
-              <Link href='/members' passHref>
-                <TextLinkButton isCurrentPath={pathname === '/members'}>멤버</TextLinkButton>
-              </Link>
-              <Link href='/projects' passHref>
-                <TextLinkButton isCurrentPath={pathname === '/projects'}>프로젝트</TextLinkButton>
-              </Link>
-            </RouterWrapper>
-            <Divider />
-            <MenuWrapper>
-              <Link href='/makers' passHref>
-                <MenuLink highlight={pathname === '/makers'}>만든 사람들</MenuLink>
-              </Link>
-              <MenuLink href={FEEDBACK_FORM_URL} target='_blank'>
-                의견 제안하기
-              </MenuLink>
-              <MenuLink onClick={logout}>로그아웃</MenuLink>
-            </MenuWrapper>
-          </MobileMenu>
-        </MobileMenuWrapper>
-      )}
+        <RouterWrapper>
+          <Link href='/members' passHref>
+            <TextLinkButton isCurrentPath={pathname === '/members'}>멤버</TextLinkButton>
+          </Link>
+          <Link href='/projects' passHref>
+            <TextLinkButton isCurrentPath={pathname === '/projects'}>프로젝트</TextLinkButton>
+          </Link>
+        </RouterWrapper>
+        <Divider />
+        <MenuWrapper>
+          <Link href='/makers' passHref>
+            <MenuLink highlight={pathname === '/makers'}>만든 사람들</MenuLink>
+          </Link>
+          <MenuLink href={FEEDBACK_FORM_URL} target='_blank'>
+            의견 제안하기
+          </MenuLink>
+          <MenuLink onClick={logout}>로그아웃</MenuLink>
+        </MenuWrapper>
+      </MobileMenu>
     </StyledHeader>
   );
 };
@@ -182,6 +177,9 @@ const RightGroup = styled.div`
   display: flex;
   gap: 8px;
   align-items: center;
+  @media ${MOBILE_MEDIA_QUERY} {
+    visibility: collapse;
+  }
 `;
 
 const StyledLogo = styled.div`
@@ -256,7 +254,7 @@ const UserButton = styled.button`
   }
 `;
 
-const UserDropdown = styled.div`
+const UserDropdown = styled.div<{ isOpen: boolean }>`
   box-sizing: border-box;
   display: flex;
   position: absolute;
@@ -264,6 +262,8 @@ const UserDropdown = styled.div`
   right: 36px;
   flex-direction: column;
   gap: 25px;
+  transition: opacity 0.2s;
+  opacity: ${(props) => (props.isOpen ? 1 : 0)};
   z-index: 100;
   border-radius: 14px;
   background: #272828;
@@ -276,30 +276,46 @@ const UserDropdown = styled.div`
   }
 
   @media ${MOBILE_MEDIA_QUERY} {
-    top: 56px;
-    right: 20px;
-    gap: 20px;
-    padding: 22px 20px;
-    width: 144px;
-    font-size: 15px;
+    display: none;
   }
 `;
 
-const MobileMenuWrapper = styled.div`
+const DimmedBackground = styled.div<{ isOpen: boolean }>`
   position: fixed;
   top: 0;
   left: 0;
-  z-index: 300;
+  z-index: 100000;
   background-color: rgb(0 0 0 / 70%);
   width: 100%;
   height: 100vh;
+
+  ${(props) =>
+    props.isOpen
+      ? css``
+      : css`
+          visibility: hidden;
+        `}
 `;
 
-const MobileMenu = styled.div`
+const MobileMenu = styled.div<{ isOpen: boolean }>`
+  position: fixed;
+  top: 0;
+  left: 0;
+  transition: transform 0.3s;
+  z-index: 100001;
   background-color: ${colors.black80};
   padding: 57px 20px;
   width: 212px;
   height: 100vh;
+
+  ${(props) =>
+    props.isOpen
+      ? css`
+          transform: translateX(0);
+        `
+      : css`
+          transform: translateX(-100%);
+        `}
 `;
 
 const ProfileContainer = styled.a`

--- a/components/common/Header/index.tsx
+++ b/components/common/Header/index.tsx
@@ -51,6 +51,19 @@ const Header: FC = () => {
     };
   }, []);
 
+  useEffect(() => {
+    const closeDropdown = () => {
+      setIsUserDropdownOpened(false);
+      setIsMobileMenuOpened(false);
+    };
+
+    events.on('routeChangeStart', closeDropdown);
+
+    return () => {
+      events.off('routeChangeStart', closeDropdown);
+    };
+  }, [events]);
+
   return (
     <StyledHeader>
       <LeftGroup>


### PR DESCRIPTION
### 🤫 쉿, 나한테만 말해줘요. 이슈넘버
- close #201 

### 🧐 어떤 것을 변경했어요~?
- 데스크톱 화면에서 드롭다운 바깥을 누를시 닫히지 않는 현상을 수정했어요.
- 모바일 화면에서 메뉴 바깥을 누를시 닫히지 않는 현상을 수정했어요.
- route가 이동할 때 자동으로 메뉴와 드롭다운이 닫히도록 수정했어요.
- 모바일 화면에서 헤더의 사용자 버튼이 보이지 않도록 수정했어요.
  - ![image](https://user-images.githubusercontent.com/36122585/203557712-9f6c9e46-0420-4c8a-83c1-cd1f9d1d3302.png)
- (겸사겸사) 드롭다운과 헤더에 애니메이션을 추가했어요.

### 🤔 그렇다면, 어떻게 구현했어요~?
- 드롭다운이나 메뉴 바깥의 어디든지 눌러도 닫힐 수 있도록 window에 클릭 핸들러를 붙였어요.

### ❤️‍🔥 당신이 생각하는 PR포인트, 내겐 매력포인트.

### 📸 스크린샷, 없으면 이것 참,, 섭섭한데요?
![Nov-23-2022 22-26-02](https://user-images.githubusercontent.com/36122585/203558428-72d2e8b7-5005-413d-a188-83c9b26b0ecf.gif)

![Nov-23-2022 22-26-44](https://user-images.githubusercontent.com/36122585/203558406-d035462b-1d43-49a3-b8cf-cb72e97531c6.gif)

