### PR TITLE
fix: 토큰 없을 때 리다이렉트 시 멤버 페이지가 잠깐 나왔다 로그인 페이지로 가는 버그 수정

### DIFF
--- a/components/auth/AuthRequired.tsx
+++ b/components/auth/AuthRequired.tsx
@@ -22,6 +22,9 @@ const AuthRequired: FC<AuthRequiredProps> = ({ children }) => {
     if (router.isReady && accessToken === null) {
       lastUnauthorized.setPath(router.asPath);
       router.replace('/auth/login');
+    } else {
+      // MEMO: playground mainPage가 추가되기 전까진 멤버페이지로 redirect 시킵니다.
+      router.push('/members');
     }
   }, [router, router.isReady, accessToken, lastUnauthorized]);
 

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,19 +1,10 @@
 import type { NextPage } from 'next';
-import { useRouter } from 'next/router';
-import { useEffect } from 'react';
 
 import AuthRequired from '@/components/auth/AuthRequired';
 import Header from '@/components/common/Header';
 import { setLayout } from '@/utils/layout';
 
 const Home: NextPage = () => {
-  const router = useRouter();
-
-  useEffect(() => {
-    // MEMO: playground mainpage가 추가되기 전까진 멤버페이지로 redirect 시킵니다.
-    router.push('/members');
-  }, [router]);
-
   return <AuthRequired>{}</AuthRequired>;
 };
 


### PR DESCRIPTION
### 🤫 쉿, 나한테만 말해줘요. 이슈넘버
- close #219

### 🧐 어떤 것을 변경했어요~?
<!-- 실제로 변경한 사항을 설명해주세요.-->
- members 리다이렉트를 else 문으로 옮겼습니다.

### 🤔 그렇다면, 어떻게 구현했어요~?
<!-- 실제로 구현한 로직에 대해 설명해주세요.-->

### ❤️‍🔥 당신이 생각하는 PR포인트, 내겐 매력포인트.
<!-- 해당 PR에서 논의가 필요한 사항을 적어주세요. -->

### 📸 스크린샷, 없으면 이것 참,, 섭섭한데요?
