### PR TITLE
feat: 프로필 업로드 > 링크 유효성 검사 추가

### DIFF
--- a/components/members/upload/AdditionalInfoFormSection.tsx
+++ b/components/members/upload/AdditionalInfoFormSection.tsx
@@ -1,5 +1,5 @@
 import styled from '@emotion/styled';
-import { useFieldArray, useFormContext, useWatch } from 'react-hook-form';
+import { FieldError, useFieldArray, useFormContext, useWatch } from 'react-hook-form';
 
 import EditableSelect from '@/components/common/EditableSelect';
 import Input from '@/components/common/Input';
@@ -22,7 +22,13 @@ import { MOBILE_MAX_WIDTH, MOBILE_MEDIA_QUERY } from '@/styles/mediaQuery';
 import { textStyles } from '@/styles/typography';
 
 export default function MemberAdditionalFormSection() {
-  const { register, control, setValue } = useFormContext<MemberUploadForm>();
+  const {
+    register,
+    control,
+    setValue,
+    trigger,
+    formState: { errors },
+  } = useFormContext<MemberUploadForm>();
   const { fields, append, remove } = useFieldArray({
     control,
     name: 'links',
@@ -32,6 +38,18 @@ export default function MemberAdditionalFormSection() {
 
   const onAppend = () => append({ title: '', url: '' });
   const onRemove = (index: number) => remove(index);
+  const getLinksErrorMessage = (
+    linksError:
+      | {
+          title?: FieldError | undefined;
+          url?: FieldError | undefined;
+        }
+      | undefined,
+  ) => {
+    if (!linksError) return;
+    if (linksError.hasOwnProperty('title')) return linksError.title?.message;
+    return linksError.url?.message;
+  };
 
   return (
     <FormSection>
@@ -47,19 +65,32 @@ export default function MemberAdditionalFormSection() {
           <FormItem title='링크' description='Github, instagram, 개인 웹사이트 등을 자유롭게 업로드해주세요'>
             <StyledAddableWrapper onAppend={onAppend}>
               {fields.map((field, index) => (
-                <AddableItem onRemove={() => onRemove(index)} key={field.id}>
+                <AddableItem
+                  onRemove={() => onRemove(index)}
+                  key={field.id}
+                  errorMessage={getLinksErrorMessage(errors.links?.[index])}
+                >
                   <StyledSelectWrapper>
                     <StyledEditableSelect
                       placeholder='링크를 입력해주세요'
                       {...register(`links.${index}.title`)}
+                      error={errors?.links?.[index]?.hasOwnProperty('title')}
                       width='100%'
                       className='category'
-                      onSelect={(value: string) => setValue(`links.${index}.title`, value)}
+                      onSelect={(value: string) => {
+                        setValue(`links.${index}.title`, value);
+                        trigger(`links.${index}.title`);
+                      }}
                       value={linkCategories[index]?.title ?? ''}
                     >
                       <SelectOptions options={LINK_TITLES} />
                     </StyledEditableSelect>
-                    <Input {...register(`links.${index}.url`)} placeholder='https://' className='link' />
+                    <Input
+                      {...register(`links.${index}.url`)}
+                      error={errors?.links?.[index]?.hasOwnProperty('url')}
+                      placeholder='https://'
+                      className='link'
+                    />
                   </StyledSelectWrapper>
                 </AddableItem>
               ))}
@@ -95,19 +126,32 @@ export default function MemberAdditionalFormSection() {
           <FormItem title='링크' description='Github, instagram, 개인 웹사이트 등을 자유롭게 업로드해주세요'>
             <StyledAddableWrapper onAppend={onAppend}>
               {fields.map((field, index) => (
-                <AddableItem onRemove={() => onRemove(index)} key={field.id}>
+                <AddableItem
+                  onRemove={() => onRemove(index)}
+                  key={field.id}
+                  errorMessage={getLinksErrorMessage(errors.links?.[index])}
+                >
                   <StyledSelectWrapper>
                     <StyledEditableSelect
                       placeholder='ex) Instagram'
                       {...register(`links.${index}.title`)}
-                      onSelect={(value: string) => setValue(`links.${index}.title`, value)}
+                      onSelect={(value: string) => {
+                        setValue(`links.${index}.title`, value);
+                        trigger(`links.${index}.title`);
+                      }}
                       value={linkCategories[index]?.title ?? ''}
+                      error={errors?.links?.[index]?.hasOwnProperty('title')}
                       width='100%'
                       className='category'
                     >
                       <SelectOptions options={LINK_TITLES} />
                     </StyledEditableSelect>
-                    <Input {...register(`links.${index}.url`)} placeholder='https://' className='link' />
+                    <Input
+                      {...register(`links.${index}.url`)}
+                      error={errors?.links?.[index]?.hasOwnProperty('url')}
+                      placeholder='https://'
+                      className='link'
+                    />
                   </StyledSelectWrapper>
                 </AddableItem>
               ))}

--- a/components/members/upload/schema.ts
+++ b/components/members/upload/schema.ts
@@ -51,6 +51,19 @@ export const memberFormSchema = yup.object().shape({
       team: yup.string().required('팀 소속 정보를 입력해주세요.'),
     }),
   ),
+  links: yup.array().of(
+    yup.object().shape({
+      title: yup.lazy(() =>
+        yup.string().when('url', { is: (url: string) => url, then: yup.string().required('링크를 선택해주세요.') }),
+      ),
+      url: yup.lazy(() =>
+        yup
+          .string()
+          .when('title', { is: (title: string) => title, then: yup.string().required('링크를 입력해주세요.') })
+          .url('url 형태로 입력해주세요.'),
+      ),
+    }),
+  ),
   openToWork: yup.boolean(),
   openToSideProject: yup.boolean(),
   allowOfficial: yup.boolean(),


### PR DESCRIPTION
### 🤫 쉿, 나한테만 말해줘요. 이슈넘버
- close #223 

### 🧐 어떤 것을 변경했어요~?
링크 유효성 검사를 추가했습니다

title과 url 중 하나라도 값이 채워져 있으면 나머지 값을 required로 만들어줬고,
url은 url 형식을 지키도록 했습니다

### 🤔 그렇다면, 어떻게 구현했어요~?
yup schema를 수정했는데,
특이 사항은 EditableSelect가 register의 onChange를 이용하지 않아서 errors 객체에 바로 반영이 안되고 새로 submit을 해야만 반영이 되는 현상이 있었습니다
이를 useForm(useFormContext)의 trigger를 이용해 해결했습니다

참고 링크 - https://github.com/react-hook-form/react-hook-form/discussions/4110

\* EditableSelect는 '직접 입력'외의 옵션들은 select event, '직접 입력'은 input event를 통해 value를 set합니다. 따라서 한 가지 타입의 이벤트를 파라미터로 받는 register의 onChange는 활용할 수 없습니다

### 📸 스크린샷, 없으면 이것 참,, 섭섭한데요?


https://user-images.githubusercontent.com/73823388/203732506-7a20c4b3-c959-4eca-bd56-b91b39607d9d.mov


