### PR TITLE
feat: 이미지 리사이징 구현

### DIFF
--- a/components/common/ResizedImage/index.tsx
+++ b/components/common/ResizedImage/index.tsx
@@ -1,0 +1,43 @@
+import { FC, useState } from 'react';
+
+const getResizedImage = (src: string, width: number) => {
+  return `//wsrv.nl/?url=${encodeURIComponent(src)}&w=${width}`;
+};
+
+interface ImageProps {
+  className?: string;
+  src: string;
+  width: number;
+  height?: number;
+  alt?: string;
+
+  onLoad?: () => void;
+}
+
+const ResizedImage: FC<ImageProps> = ({ className, src, width, alt, onLoad }) => {
+  const [failed, setFailed] = useState(false);
+
+  const handleLoadError = () => {
+    setFailed(true);
+  };
+
+  return (
+    <>
+      {failed ? (
+        <img src={src} alt={alt} className={className} onLoad={onLoad} loading='lazy' decoding='async' />
+      ) : (
+        <img
+          src={getResizedImage(src, width)}
+          alt={alt}
+          className={className}
+          loading='lazy'
+          decoding='async'
+          onLoad={onLoad}
+          onError={handleLoadError}
+        />
+      )}
+    </>
+  );
+};
+
+export default ResizedImage;

--- a/components/common/ResizedImage/index.tsx
+++ b/components/common/ResizedImage/index.tsx
@@ -1,4 +1,6 @@
-import { FC, useState } from 'react';
+import { FC, useEffect, useRef, useState } from 'react';
+
+const WAIT_TIME = 3000;
 
 const getResizedImage = (src: string, width: number) => {
   return `https://wsrv.nl/?url=${encodeURIComponent(src)}&w=${width}&output=webp`;
@@ -15,15 +17,38 @@ interface ImageProps {
 }
 
 const ResizedImage: FC<ImageProps> = ({ className, src, width, alt, onLoad }) => {
-  const [failed, setFailed] = useState(false);
+  const [isUsingOriginal, setIsUsingOriginal] = useState(false);
 
-  const handleLoadError = () => {
-    setFailed(true);
+  const timeoutTokenRef = useRef<ReturnType<typeof setTimeout>>();
+
+  const cancelReplacementTimer = () => {
+    if (timeoutTokenRef.current !== undefined) {
+      clearTimeout(timeoutTokenRef.current);
+    }
   };
+
+  const handleResizedLoadError = () => {
+    setIsUsingOriginal(true);
+  };
+
+  const handleResizedLoaded = () => {
+    cancelReplacementTimer();
+    onLoad?.();
+  };
+
+  useEffect(() => {
+    timeoutTokenRef.current = setTimeout(() => {
+      setIsUsingOriginal(true);
+    }, WAIT_TIME);
+
+    return () => {
+      cancelReplacementTimer();
+    };
+  }, []);
 
   return (
     <>
-      {failed ? (
+      {isUsingOriginal ? (
         <img src={src} alt={alt} className={className} onLoad={onLoad} loading='lazy' decoding='async' />
       ) : (
         <img
@@ -33,8 +58,8 @@ const ResizedImage: FC<ImageProps> = ({ className, src, width, alt, onLoad }) =>
           className={className}
           loading='lazy'
           decoding='async'
-          onLoad={onLoad}
-          onError={handleLoadError}
+          onLoad={handleResizedLoaded}
+          onError={handleResizedLoadError}
         />
       )}
     </>

--- a/components/common/ResizedImage/index.tsx
+++ b/components/common/ResizedImage/index.tsx
@@ -1,7 +1,7 @@
 import { FC, useState } from 'react';
 
 const getResizedImage = (src: string, width: number) => {
-  return `//wsrv.nl/?url=${encodeURIComponent(src)}&w=${width}`;
+  return `https://wsrv.nl/?url=${encodeURIComponent(src)}&w=${width}&output=webp`;
 };
 
 interface ImageProps {
@@ -28,6 +28,7 @@ const ResizedImage: FC<ImageProps> = ({ className, src, width, alt, onLoad }) =>
       ) : (
         <img
           src={getResizedImage(src, width)}
+          srcSet={`${getResizedImage(src, width)} 1x, ${getResizedImage(src, width * 2)} 2x`}
           alt={alt}
           className={className}
           loading='lazy'

--- a/components/makers/PersonBlock.tsx
+++ b/components/makers/PersonBlock.tsx
@@ -35,7 +35,7 @@ const PersonBlock: FC<PersonBlockProps> = ({ name, position, link, onClick, imag
             alt=''
             onLoad={() => setIsImageLoaded(true)}
             hide={!isImageLoaded}
-            width={48 * 2}
+            width={48}
           />
         )}
       </ImageBox>

--- a/components/makers/PersonBlock.tsx
+++ b/components/makers/PersonBlock.tsx
@@ -3,6 +3,7 @@ import styled from '@emotion/styled';
 import Link from 'next/link';
 import { FC, useState } from 'react';
 
+import ResizedImage from '@/components/common/ResizedImage';
 import { colors } from '@/styles/colors';
 import { MOBILE_MEDIA_QUERY } from '@/styles/mediaQuery';
 import { textStyles } from '@/styles/typography';
@@ -29,13 +30,12 @@ const PersonBlock: FC<PersonBlockProps> = ({ name, position, link, onClick, imag
           hide={isImageLoaded}
         />
         {imageUrl && (
-          <StyledImage
+          <StyledResizedImage
             src={imageUrl}
             alt=''
             onLoad={() => setIsImageLoaded(true)}
             hide={!isImageLoaded}
-            loading='lazy'
-            decoding='async'
+            width={48 * 2}
           />
         )}
       </ImageBox>
@@ -83,6 +83,20 @@ const ImageBox = styled.div`
 `;
 
 const StyledImage = styled.img<{ hide?: boolean }>`
+  position: absolute;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+
+  ${(props) =>
+    props.hide
+      ? css`
+          visibility: hidden;
+        `
+      : ''};
+`;
+
+const StyledResizedImage = styled(ResizedImage)<{ hide?: boolean }>`
   position: absolute;
   width: 100%;
   height: 100%;

--- a/components/members/main/MemberCard/index.tsx
+++ b/components/members/main/MemberCard/index.tsx
@@ -21,7 +21,7 @@ const MemberCard: FC<MemberCardProps> = ({ name, part, introduction, image, isAc
       <CardHeader>
         {isActiveGeneration && <ActiveGenerationBadge>{`${LATEST_GENERATION}기 활동중`}</ActiveGenerationBadge>}
         {image ? (
-          <Image className='image' src={image} width={235 * 2} alt='member_image' />
+          <Image className='image' src={image} width={235} alt='member_image' />
         ) : (
           <DefaultImage
             className='image'

--- a/components/members/main/MemberCard/index.tsx
+++ b/components/members/main/MemberCard/index.tsx
@@ -1,6 +1,7 @@
 import styled from '@emotion/styled';
 import { FC } from 'react';
 
+import ResizedImage from '@/components/common/ResizedImage';
 import { LATEST_GENERATION } from '@/constants/generation';
 import { colors } from '@/styles/colors';
 import { MOBILE_MEDIA_QUERY } from '@/styles/mediaQuery';
@@ -20,7 +21,7 @@ const MemberCard: FC<MemberCardProps> = ({ name, part, introduction, image, isAc
       <CardHeader>
         {isActiveGeneration && <ActiveGenerationBadge>{`${LATEST_GENERATION}기 활동중`}</ActiveGenerationBadge>}
         {image ? (
-          <Image className='image' src={image} alt='member_image' loading='lazy' decoding='async' />
+          <Image className='image' src={image} width={235 * 2} alt='member_image' />
         ) : (
           <DefaultImage
             className='image'
@@ -106,7 +107,7 @@ const DefaultImage = styled.img`
   width: 56px;
 `;
 
-const Image = styled.img`
+const Image = styled(ResizedImage)`
   width: 100%;
   height: 100%;
   object-fit: cover;

--- a/components/projects/main/ProjectCard.tsx
+++ b/components/projects/main/ProjectCard.tsx
@@ -34,9 +34,9 @@ const ProjectCard: FC<Project> = ({
         </StyledServiceTypeWrapper>
         <StyledImageSection>
           {thumbnailImage ? (
-            <StyledThumbnail className='card-image' src={thumbnailImage} width={380 * 2} alt='thumbnail-image' />
+            <StyledThumbnail className='card-image' src={thumbnailImage} width={380} alt='thumbnail-image' />
           ) : (
-            <StyledLogo className='card-image' src={logoImage} width={380 * 2} alt='logo-image' />
+            <StyledLogo className='card-image' src={logoImage} width={380} alt='logo-image' />
           )}
           <ServiceLinkWrapper className='card-hover'>
             {filteredLinks.map(({ linkId, linkTitle, linkUrl }) => (

--- a/components/projects/main/ProjectCard.tsx
+++ b/components/projects/main/ProjectCard.tsx
@@ -3,6 +3,7 @@ import Link from 'next/link';
 import { FC } from 'react';
 
 import { LinkTitle, Project } from '@/api/projects/type';
+import ResizedImage from '@/components/common/ResizedImage';
 import Text from '@/components/common/Text';
 import { categoryLabel, getLinkInfo } from '@/components/projects/upload/constants';
 import { colors } from '@/styles/colors';
@@ -33,15 +34,9 @@ const ProjectCard: FC<Project> = ({
         </StyledServiceTypeWrapper>
         <StyledImageSection>
           {thumbnailImage ? (
-            <StyledThumbnail
-              className='card-image'
-              src={thumbnailImage}
-              alt='thumbnail-image'
-              loading='lazy'
-              decoding='async'
-            />
+            <StyledThumbnail className='card-image' src={thumbnailImage} width={380 * 2} alt='thumbnail-image' />
           ) : (
-            <StyledLogo className='card-image' src={logoImage} alt='logo-image' loading='lazy' decoding='async' />
+            <StyledLogo className='card-image' src={logoImage} width={380 * 2} alt='logo-image' />
           )}
           <ServiceLinkWrapper className='card-hover'>
             {filteredLinks.map(({ linkId, linkTitle, linkUrl }) => (
@@ -160,7 +155,7 @@ const StyledServiceLink = styled.a`
   align-items: center;
 `;
 
-const StyledThumbnail = styled.img`
+const StyledThumbnail = styled(ResizedImage)`
   border-radius: 6px;
   background: linear-gradient(180deg, rgb(35 35 50 / 0%) 0%, rgb(35 35 35 / 80%) 100%);
   width: 100%;
@@ -168,7 +163,7 @@ const StyledThumbnail = styled.img`
   object-fit: cover;
 `;
 
-const StyledLogo = styled.img`
+const StyledLogo = styled(ResizedImage)`
   margin: 44px 0 0;
   border-radius: 20px;
   width: 120px;


### PR DESCRIPTION
### 🤫 쉿, 나한테만 말해줘요. 이슈넘버


### 🧐 어떤 것을 변경했어요~?

- 최대한 현재 크기에 맞는 리사이징된 이미지를 가져오도록 만들었어요.
  - 다수의 이미지가 등장하는 멤버 목록, 프로젝트 목록, 메이커스 멤버 소개의 이미지가 대상이에요.
- 이미지 리사이징 프록시로는 https://images.weserv.nl/ 를 이용해요.
- 이미지 프록시가 실패하는 경우엔 원본 이미지를 가져오도록 구현했어요.
  - https://images.weserv.nl/ 서버에서 한 IP당 10분에 이미지를 최대 2500개만 가져갈 수 있도록 제한이 걸려있어요.
  - 만약 제한을 넘었을 경우에도 이미지가 표시되게 하기 위해서 이경우 원본 이미지를 로드해요.
- 이미지 프록시에서 로드가 오래 걸릴 경우(현재는 3초 이상)에는 원본 이미지를 로드해요.
    - https://images.weserv.nl/ 서버가 서버에 한번 캐싱된 이미지는 아주 빠르게 가져오는데, 캐시에 없는 이미지는 생성하는데 시간이 8초 이상 걸려요.
    - 따라서 아직 캐싱이 안되었다고 판단되는 이미지는 원본에서 가져와서 보여줘요. (이 경우 `원본 로드 시간` < `리사이징된 이미지 로드 시간`)
    - 캐싱이 된 이미지는 바로 표시해요 (이 경우 `리사이징된 이미지 로드 시간` < `원본 로드 시간`)
    - 이렇게 하면 캐시에 이미지가 모두 있는 최상의 경우에 적은 용량으로 빠르게 이미지를 로드할 수 있고, 캐시에 이미지가 모두 없는 최악의 경우에도 일정 딜레이(3초) 이후에 원본 이미지를 생성 시간보다 빠르게 가져올 수 있어요.

### 🤔 그렇다면, 어떻게 구현했어요~?

- 리사이징된 이미지를 가져오는 ResizedImage 컴포넌트를 만들었어요.
  - width 값을 기준으로 이미지 프록시 서버에서 리사이징된 이미지 가져오기를 시도해요.
  - 만약 리사이징 이미지용 img 태그가 onError 이벤트를 발생시키면, 원본용 img 태그를 활성화해요.
  - 일정 시간(현재는 3초) 동안 리사이징 이미지용 img 태그가 onLoad 이벤트를 발생시키지 않는다면, 원본용 Img 태그를 활성화해요.


### ❤️‍🔥 당신이 생각하는 PR포인트, 내겐 매력포인트.


### 📸 스크린샷, 없으면 이것 참,, 섭섭한데요?



#### members 페이지 리사이징 적용 전 
![image](https://user-images.githubusercontent.com/36122585/204627454-f6e5ed32-39fb-44c2-8a24-89682bbc7b05.png)


![image](https://user-images.githubusercontent.com/36122585/204626891-51460249-68e5-4450-a4f7-6430f06a3686.png)
페이지 전체 로드에 총 97.8MB 사용

#### members 페이지 리사이징 적용 후
![image](https://user-images.githubusercontent.com/36122585/204627542-1ef41b54-4e88-4445-b5de-d213242467f9.png)

![image](https://user-images.githubusercontent.com/36122585/204626621-adfb042a-8624-46b1-99fa-1a3eb3647ee6.png)

페이지 전체 로드에 총 11.1MB 사용

