### PR TITLE
fix: dayjs custom format 추가

### DIFF
--- a/components/projects/upload/utils.ts
+++ b/components/projects/upload/utils.ts
@@ -1,4 +1,6 @@
 import dayjs from 'dayjs';
+import customParseFormat from 'dayjs/plugin/customParseFormat';
+dayjs.extend(customParseFormat);
 
 const DEFAULT_FORMAT = 'YYYY.MM';
 const INPUT_DATE_FORMAT = 'YYYY-MM-DD';


### PR DESCRIPTION
### 🤫 쉿, 나한테만 말해줘요. 이슈넘버
- close #

### 🧐 어떤 것을 변경했어요~?
<!-- 실제로 변경한 사항을 설명해주세요.-->
- 기존 클라에서의 날짜 형식(`YYYY.MM`)과 마이그레이션 한 서버의 날짜 형식(`YYYY-MM-DD`)이 상이해서 따로 유틸함수를 이용해서 형식을 맞춰주고 있었어요.
- 이 과정에서 `YYYY.MM`은 dayjs의 기본 format이 아니어서 변환하는 과정에서 `2021-01-01`로 넘어가고 있더라구요 ㅠ
- dayjs playground에선 잘 테스트가 됐었는데, 요게 [플러그인](https://day.js.org/docs/en/plugin/custom-parse-format)이 있어서 그런거였어서 이를 추가했어요. (`customParseFormat`)

### 🤔 그렇다면, 어떻게 구현했어요~?
<!-- 실제로 구현한 로직에 대해 설명해주세요.-->

### ❤️‍🔥 당신이 생각하는 PR포인트, 내겐 매력포인트.
<!-- 해당 PR에서 논의가 필요한 사항을 적어주세요. -->

### 📸 스크린샷, 없으면 이것 참,, 섭섭한데요?
![image](https://user-images.githubusercontent.com/26808056/204938451-57a9de48-a5a0-4d56-80b3-e75c90780aee.png)

