### PR TITLE
refactor: 사이트 내 URL 모으기

### DIFF
--- a/components/auth/AuthRequired.tsx
+++ b/components/auth/AuthRequired.tsx
@@ -4,6 +4,7 @@ import { useRecoilValue } from 'recoil';
 
 import { accessTokenAtom } from '@/components/auth/states/accessTokenAtom';
 import useLastUnauthorized from '@/components/auth/util/useLastUnauthorized';
+import { playgroundLink } from '@/constants/links';
 
 interface AuthRequiredProps {
   children: ReactNode;
@@ -21,7 +22,7 @@ const AuthRequired: FC<AuthRequiredProps> = ({ children }) => {
   useEffect(() => {
     if (router.isReady && accessToken === null) {
       lastUnauthorized.setPath(router.asPath);
-      router.replace('/auth/login');
+      router.replace(playgroundLink.login());
     }
   }, [router, router.isReady, accessToken, lastUnauthorized]);
 

--- a/components/auth/register/RegisterFinished.tsx
+++ b/components/auth/register/RegisterFinished.tsx
@@ -3,6 +3,7 @@ import Link from 'next/link';
 import { FC } from 'react';
 
 import SquareLink from '@/components/common/SquareLink';
+import { playgroundLink } from '@/constants/links';
 import { textStyles } from '@/styles/typography';
 
 const RegisterFinished: FC = () => {
@@ -14,7 +15,7 @@ const RegisterFinished: FC = () => {
         <br />
         프로젝트를 등록하여 SOPT에서의 경험을 공유해보세요.
       </Description>
-      <Link href='/projects/upload' passHref>
+      <Link href={playgroundLink.projectUpload()} passHref>
         <SendButton variant='primary'>프로젝트 등록하기</SendButton>
       </Link>
     </Container>

--- a/components/auth/register/VerifyByEmail.tsx
+++ b/components/auth/register/VerifyByEmail.tsx
@@ -8,6 +8,7 @@ import { postRegistrationEmail } from '@/api/registration';
 import SendingMailSuccess from '@/components/auth/register/SendingMailSuccess';
 import Input from '@/components/common/Input';
 import SquareLink from '@/components/common/SquareLink';
+import { MEMBER_REQUEST_FORM_URL } from '@/constants/links';
 import IconArrowRight from '@/public/icons/icon-arrow-right.svg';
 import IconWarning from '@/public/icons/icon-warning.svg';
 import { colors } from '@/styles/colors';
@@ -55,7 +56,7 @@ const VerifyByEmail: FC = () => {
       <SendButton as='button' variant='primary'>
         {verify.isLoading ? <ClipLoader color='#ffffff' size={25} /> : <>SOPT 회원 인증메일 전송</>}
       </SendButton>
-      <ErrorNotice href='https://forms.gle/Hs9tJgMG9bNvT1rS9' target='_blank'>
+      <ErrorNotice href={MEMBER_REQUEST_FORM_URL} target='_blank'>
         <NoticeTitle>
           <div className='question'>이메일로 SOPT 회원 인증이 안된다면?</div>
           <IconArrowRight />

--- a/components/auth/useAuth.ts
+++ b/components/auth/useAuth.ts
@@ -3,6 +3,7 @@ import { useEffect, useState } from 'react';
 import { useRecoilValue, useResetRecoilState } from 'recoil';
 
 import { accessTokenAtom } from '@/components/auth/states/accessTokenAtom';
+import { playgroundLink } from '@/constants/links';
 
 const useAuth = () => {
   const router = useRouter();
@@ -18,7 +19,7 @@ const useAuth = () => {
   return {
     logout() {
       resetAccessToken();
-      router.push('/auth/login');
+      router.push(playgroundLink.login());
     },
     isLoggedIn,
   };

--- a/components/common/Footer/index.tsx
+++ b/components/common/Footer/index.tsx
@@ -4,7 +4,7 @@ import Link from 'next/link';
 import { useRouter } from 'next/router';
 import { FC } from 'react';
 
-import { FEEDBACK_FORM_URL } from '@/constants/links';
+import { FEEDBACK_FORM_URL, playgroundLink } from '@/constants/links';
 import useScroll from '@/hooks/useScroll';
 import { colors } from '@/styles/colors';
 import { MOBILE_MEDIA_QUERY } from '@/styles/mediaQuery';
@@ -19,8 +19,8 @@ const Footer: FC<FooterProps> = ({}) => {
 
   return (
     <StyledFooter hide={isScrollingDown && !isScrollTop}>
-      <Link href='/makers' passHref>
-        <FooterLink highlight={pathname === '/makers'}>만든 사람들</FooterLink>
+      <Link href={playgroundLink.makers()} passHref>
+        <FooterLink highlight={pathname === playgroundLink.makers()}>만든 사람들</FooterLink>
       </Link>
       <FooterLink href={FEEDBACK_FORM_URL}>의견 제안하기</FooterLink>
     </StyledFooter>

--- a/components/common/Header/index.tsx
+++ b/components/common/Header/index.tsx
@@ -10,7 +10,7 @@ import { FC, useEffect, useRef, useState } from 'react';
 
 import { useGetMemberOfMe } from '@/apiHooks/members';
 import useAuth from '@/components/auth/useAuth';
-import { FEEDBACK_FORM_URL } from '@/constants/links';
+import { FEEDBACK_FORM_URL, playgroundLink } from '@/constants/links';
 import BackIcon from '@/public/icons/icon-back.svg';
 import { colors } from '@/styles/colors';
 import { MOBILE_MEDIA_QUERY } from '@/styles/mediaQuery';
@@ -70,7 +70,7 @@ const Header: FC = () => {
         <button ref={mobileButtonRef} className='mobile-only' onClick={() => setIsMobileMenuOpened(true)}>
           <MenuIcon />
         </button>
-        <Link href='/' passHref>
+        <Link href={playgroundLink.memberList()} passHref>
           <TextLinkButton isCurrentPath={pathname === '/'}>
             <StyledLogo>
               <LogoIcon />
@@ -79,11 +79,11 @@ const Header: FC = () => {
         </Link>
 
         <MenuGroup className='pc-only'>
-          <Link href='/members' passHref>
-            <TextLinkButton isCurrentPath={pathname === '/members'}>멤버</TextLinkButton>
+          <Link href={playgroundLink.memberList()} passHref>
+            <TextLinkButton isCurrentPath={pathname === playgroundLink.memberList()}>멤버</TextLinkButton>
           </Link>
-          <Link href='/projects' passHref>
-            <TextLinkButton isCurrentPath={pathname === '/projects'}>프로젝트</TextLinkButton>
+          <Link href={playgroundLink.projectList()} passHref>
+            <TextLinkButton isCurrentPath={pathname === playgroundLink.projectList()}>프로젝트</TextLinkButton>
           </Link>
           {/* <Link href='/web-product' passHref>
           <TextLinkButton isCurrentPath={router.pathname === ''}>Web Product</TextLinkButton>
@@ -93,7 +93,7 @@ const Header: FC = () => {
 
       <RightGroup>
         <div className='pc-only'>
-          <Link href='/projects/upload' passHref>
+          <Link href={playgroundLink.projectUpload()} passHref>
             <UploadButton>
               <span>+</span>내 프로젝트 올리기
             </UploadButton>
@@ -107,13 +107,15 @@ const Header: FC = () => {
       </RightGroup>
 
       <UserDropdown ref={dropdownRef} isOpen={isUserDropdownOpened}>
-        <Link href={me?.hasProfile ? `/members?id=${me?.id}` : '/members/upload'}>내 프로필</Link>
+        <Link href={me?.hasProfile ? playgroundLink.memberDetail(me.id) : playgroundLink.memberUpload()}>
+          내 프로필
+        </Link>
         <div onClick={logout}>로그아웃</div>
       </UserDropdown>
 
       <DimmedBackground isOpen={isMobileMenuOpened} onClick={() => setIsMobileMenuOpened(false)} />
       <MobileMenu isOpen={isMobileMenuOpened} ref={mobileMenuRef}>
-        <Link href={me?.hasProfile ? `/members?id=${me?.id}` : '/members/upload'} passHref>
+        <Link href={me?.hasProfile ? playgroundLink.memberDetail(me.id) : playgroundLink.memberUpload()} passHref>
           <ProfileContainer>
             {/* TODO: 프로필 있을 경우와 아닐 경우에 따라 분기처리 필요 */}
             <EmptyProfileImage>
@@ -126,17 +128,17 @@ const Header: FC = () => {
         </Link>
 
         <RouterWrapper>
-          <Link href='/members' passHref>
-            <TextLinkButton isCurrentPath={pathname === '/members'}>멤버</TextLinkButton>
+          <Link href={playgroundLink.memberList()} passHref>
+            <TextLinkButton isCurrentPath={pathname === playgroundLink.memberList()}>멤버</TextLinkButton>
           </Link>
-          <Link href='/projects' passHref>
-            <TextLinkButton isCurrentPath={pathname === '/projects'}>프로젝트</TextLinkButton>
+          <Link href={playgroundLink.projectList()} passHref>
+            <TextLinkButton isCurrentPath={pathname === playgroundLink.projectList()}>프로젝트</TextLinkButton>
           </Link>
         </RouterWrapper>
         <Divider />
         <MenuWrapper>
-          <Link href='/makers' passHref>
-            <MenuLink highlight={pathname === '/makers'}>만든 사람들</MenuLink>
+          <Link href={playgroundLink.makers()} passHref>
+            <MenuLink highlight={pathname === playgroundLink.makers()}>만든 사람들</MenuLink>
           </Link>
           <MenuLink href={FEEDBACK_FORM_URL} target='_blank'>
             의견 제안하기

--- a/components/common/LegacyHeader/index.tsx
+++ b/components/common/LegacyHeader/index.tsx
@@ -4,6 +4,7 @@ import { FC, useState } from 'react';
 
 import Button from '@/components/common/Button';
 import Menu from '@/components/common/LegacyHeader/Menu';
+import { playgroundLink } from '@/constants/links';
 import { colors } from '@/styles/colors';
 import { MOBILE_MEDIA_QUERY } from '@/styles/mediaQuery';
 
@@ -18,20 +19,20 @@ const Header: FC = () => {
     <>
       <StyledHeader>
         <StyledContent>
-          <Link href='/' passHref>
+          <Link href={playgroundLink.memberList()} passHref>
             <a>
               <StyledIconLogo alt='logo' src='/icons/icon-logo.png' />
             </a>
           </Link>
           <Empty />
-          <Link passHref href='/projects/upload'>
+          <Link passHref href={playgroundLink.projectUpload()}>
             <a>
               <StyledUploadButton variant='primary' size='fill'>
                 + 내 프로젝트 올리기
               </StyledUploadButton>
             </a>
           </Link>
-          <Link passHref href='/auth/login'>
+          <Link passHref href={playgroundLink.login()}>
             <a>
               <StyledLoginButton size='fill'>로그인</StyledLoginButton>
             </a>

--- a/components/debug/panels/NavigationPanel.tsx
+++ b/components/debug/panels/NavigationPanel.tsx
@@ -4,15 +4,16 @@ import { FC } from 'react';
 
 import Button from '@/components/common/Button';
 import Panel from '@/components/debug/Panel';
+import { playgroundLink } from '@/constants/links';
 
 const NavigationPanel: FC = () => {
   return (
     <Panel title='주요 페이지 이동'>
       <PanelContent>
-        <Link href='/' passHref>
+        <Link href={playgroundLink.memberList()} passHref>
           <Button variant='primary'>홈</Button>
         </Link>
-        <Link href='/auth/login' passHref>
+        <Link href={playgroundLink.login()} passHref>
           <Button variant='primary'>로그인</Button>
         </Link>
       </PanelContent>

--- a/components/makers/MakersMembers.tsx
+++ b/components/makers/MakersMembers.tsx
@@ -8,6 +8,7 @@ import useAuth from '@/components/auth/useAuth';
 import { MakersGeneration, MakersPerson } from '@/components/makers/data/types';
 import PersonBlock from '@/components/makers/PersonBlock';
 import TeamBlock from '@/components/makers/TeamBlock';
+import { playgroundLink } from '@/constants/links';
 import { colors } from '@/styles/colors';
 import { textStyles } from '@/styles/typography';
 
@@ -45,7 +46,7 @@ const MakersMembers: FC<MakersMembersProps> = ({ className, generations }) => {
 
   const resolveProfileLink = (person: MakersPerson) => {
     if (person.type === 'member') {
-      return `/members?id=${person.id}`;
+      return playgroundLink.memberDetail(person.id);
     }
     return undefined;
   };

--- a/components/members/main/MemberDetail/index.tsx
+++ b/components/members/main/MemberDetail/index.tsx
@@ -14,6 +14,7 @@ import { useGetMemberProfileById } from '@/apiHooks/members';
 import InfoItem from '@/components/users/detail/InfoItem';
 import MemberProjectCard from '@/components/users/detail/MemberProjectCard';
 import PartItem from '@/components/users/detail/PartItem';
+import { playgroundLink } from '@/constants/links';
 import { DEFAULT_DATE } from '@/pages/members/upload';
 import { colors } from '@/styles/colors';
 import { MOBILE_MEDIA_QUERY } from '@/styles/mediaQuery';
@@ -104,7 +105,7 @@ const MemberDetail: FC<MemberDetailProps> = ({ memberId }) => {
           </ProfileContents>
 
           {profile?.isMine && (
-            <EditButton onClick={() => router.push(`/members/upload?edit=true`)}>
+            <EditButton onClick={() => router.push(playgroundLink.memberEdit())}>
               <EditIcon />
             </EditButton>
           )}

--- a/components/members/main/MemberList/index.tsx
+++ b/components/members/main/MemberList/index.tsx
@@ -8,6 +8,7 @@ import { useGetMemberOfMe, useGetMemberProfile } from '@/apiHooks/members';
 import Text from '@/components/common/Text';
 import MemberCard from '@/components/members/main/MemberCard';
 import { LATEST_GENERATION } from '@/constants/generation';
+import { playgroundLink } from '@/constants/links';
 import useMediaQuery from '@/hooks/useMediaQuery';
 import { colors } from '@/styles/colors';
 import { MOBILE_MAX_WIDTH, MOBILE_MEDIA_QUERY } from '@/styles/mediaQuery';
@@ -43,11 +44,11 @@ const MemberList: FC = () => {
             </TextContainer>
           </LeftContainer>
           <ButtonContainer>
-            <Link href='/projects/upload' passHref>
+            <Link href={playgroundLink.projectUpload()} passHref>
               <UploadButton>프로젝트 업로드</UploadButton>
             </Link>
             {!memberOfMeData?.hasProfile && (
-              <Link href='/members/upload' passHref>
+              <Link href={playgroundLink.memberUpload()} passHref>
                 <ProfileButton>프로필 추가</ProfileButton>
               </Link>
             )}
@@ -63,7 +64,7 @@ const MemberList: FC = () => {
             )} */}
           <StyledCardWrapper>
             {profiles?.map((profile) => (
-              <Link key={profile.id} href={`/members?id=${profile.id}`} passHref>
+              <Link key={profile.id} href={playgroundLink.memberDetail(profile.id)} passHref>
                 <a>
                   <MemberCard
                     name={profile.name}

--- a/components/projects/main/ProjectCard.tsx
+++ b/components/projects/main/ProjectCard.tsx
@@ -5,6 +5,7 @@ import { FC } from 'react';
 import { LinkTitle, Project } from '@/api/projects/type';
 import Text from '@/components/common/Text';
 import { categoryLabel, getLinkInfo } from '@/components/projects/upload/constants';
+import { playgroundLink } from '@/constants/links';
 import { colors } from '@/styles/colors';
 import { MOBILE_MEDIA_QUERY } from '@/styles/mediaQuery';
 import { textStyles } from '@/styles/typography';
@@ -24,7 +25,7 @@ const ProjectCard: FC<Project> = ({
   const filteredLinks = links.filter(({ linkId, linkTitle, linkUrl }) => linkId && linkTitle && linkUrl);
 
   return (
-    <Link passHref href={`/projects?id=${id}`}>
+    <Link passHref href={playgroundLink.projectDetail(id)}>
       <StyledCard>
         <StyledServiceTypeWrapper>
           {serviceType.map((serviceType, index) => (

--- a/components/users/detail/MemberProjectCard.tsx
+++ b/components/users/detail/MemberProjectCard.tsx
@@ -4,6 +4,7 @@ import { FC } from 'react';
 
 import { MemberProject } from '@/api/members/type';
 import { categoryLabel } from '@/components/projects/upload/constants';
+import { playgroundLink } from '@/constants/links';
 import { colors } from '@/styles/colors';
 import { MOBILE_MEDIA_QUERY } from '@/styles/mediaQuery';
 // import { textStyles } from '@/styles/typography';
@@ -24,7 +25,7 @@ const MemberProjectCard: FC<MemberProject> = ({
   // };
 
   return (
-    <Link passHref href={`/projects?id=${id}`}>
+    <Link passHref href={playgroundLink.memberDetail(id)}>
       <StyledCard>
         <StyledServiceTypeWrapper>
           {/* {serviceType.map((item, index) => (

--- a/constants/links.ts
+++ b/constants/links.ts
@@ -1,2 +1,16 @@
 export const FEEDBACK_FORM_URL = 'https://forms.gle/FCx5WJ6mDmRuneQi9';
 export const NOTIFY_2ND_GENERATION_URL = 'https://forms.gle/AKf164VXtJPGJRoo8';
+export const MEMBER_REQUEST_FORM_URL = 'https://forms.gle/Hs9tJgMG9bNvT1rS9';
+
+export const playgroundLink = {
+  memberList: () => `/members`,
+  memberDetail: (id: string | number) => `/members/${id}`,
+  memberUpload: () => `/members/upload`,
+  memberEdit: () => `/members/upload?edit=true`,
+  projectList: () => `/projects`,
+  projectDetail: (id: string | number) => `/projects/${id}`,
+  projectUpload: () => `/projects/upload`,
+  login: () => `/auth/login`,
+  register: () => `/auth/verify`,
+  makers: () => `/makers`,
+};

--- a/pages/auth/callback/facebook/login.tsx
+++ b/pages/auth/callback/facebook/login.tsx
@@ -8,8 +8,9 @@ import { useSetRecoilState } from 'recoil';
 
 import useFacebookAuth from '@/components/auth/identityProvider/useFacebookAuth';
 import { accessTokenAtom } from '@/components/auth/states/accessTokenAtom';
-import useStringRouterQuery from '@/hooks/useStringRouterQuery';
 import useLastUnauthorized from '@/components/auth/util/useLastUnauthorized';
+import { playgroundLink } from '@/constants/links';
+import useStringRouterQuery from '@/hooks/useStringRouterQuery';
 import { colors } from '@/styles/colors';
 
 const FacebookLoginCallbackPage: FC = () => {
@@ -43,7 +44,7 @@ const FacebookLoginCallbackPage: FC = () => {
     return (
       <StyledFacebookLoginCallback>
         잘못된 접근입니다.
-        <Link href='/auth/login' replace passHref>
+        <Link href={playgroundLink.login()} replace passHref>
           <RetryLink>로그인 페이지로 이동</RetryLink>
         </Link>
       </StyledFacebookLoginCallback>
@@ -75,7 +76,7 @@ const FacebookLoginCallbackPage: FC = () => {
     return (
       <StyledFacebookLoginCallback>
         <ErrorMessage>{message}</ErrorMessage>
-        <Link href='/auth/login' replace passHref>
+        <Link href={playgroundLink.login()} replace passHref>
           <RetryLink>다시 시도</RetryLink>
         </Link>
       </StyledFacebookLoginCallback>

--- a/pages/auth/callback/facebook/register.tsx
+++ b/pages/auth/callback/facebook/register.tsx
@@ -6,6 +6,7 @@ import useFacebookAuth from '@/components/auth/identityProvider/useFacebookAuth'
 import { accessTokenAtom } from '@/components/auth/states/accessTokenAtom';
 import useQueryStringParam from '@/components/auth/useQueryString';
 import useLastUnauthorized from '@/components/auth/util/useLastUnauthorized';
+import { playgroundLink } from '@/constants/links';
 
 const FacebookRegisterCallbackPage: FC = () => {
   const router = useRouter();
@@ -25,7 +26,7 @@ const FacebookRegisterCallbackPage: FC = () => {
     }
 
     setAccessToken(registerResult.accessToken);
-    router.replace(lastUnauthorized.popPath() ?? '/members/upload');
+    router.replace(lastUnauthorized.popPath() ?? playgroundLink.memberUpload());
   });
 
   return (

--- a/pages/auth/login.tsx
+++ b/pages/auth/login.tsx
@@ -6,6 +6,7 @@ import { FC } from 'react';
 import FacebookButton from '@/components/auth/identityProvider/facebook/FacebookButton';
 import useFacebookAuth from '@/components/auth/identityProvider/useFacebookAuth';
 import SquareLink from '@/components/common/SquareLink';
+import { playgroundLink } from '@/constants/links';
 import { MOBILE_MEDIA_QUERY } from '@/styles/mediaQuery';
 import { textStyles } from '@/styles/typography';
 
@@ -21,7 +22,7 @@ const LoginPage: FC = () => {
         <LoginDescription>SOPT회원만 이용할 수 있어요.</LoginDescription>
         <LinkContainer>
           <FacebookButton onClick={facebookAuth.login}>페이스북으로 로그인</FacebookButton>
-          <Link href='/auth/verify' passHref>
+          <Link href={playgroundLink.register()} passHref>
             <SquareLink
               css={css`
                 color: white;
@@ -32,7 +33,7 @@ const LoginPage: FC = () => {
           </Link>
         </LinkContainer>
       </LoginBox>
-      <Link href='/makers' passHref>
+      <Link href={playgroundLink.makers()} passHref>
         <MadeByMakersLink>
           <MadeByTitle>made by</MadeByTitle>
           <StyledMakersLogo src='/logos/logo-makers-full.svg' alt='makers-logo' />

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -5,6 +5,7 @@ import { useRecoilValue } from 'recoil';
 
 import { accessTokenAtom } from '@/components/auth/states/accessTokenAtom';
 import Header from '@/components/common/Header';
+import { playgroundLink } from '@/constants/links';
 import { setLayout } from '@/utils/layout';
 
 const Home: NextPage = () => {
@@ -13,9 +14,9 @@ const Home: NextPage = () => {
 
   useEffect(() => {
     if (router.isReady && accessToken === null) {
-      router.replace('/auth/login');
+      router.replace(playgroundLink.login());
     } else {
-      router.replace('/members');
+      router.replace(playgroundLink.memberList());
     }
   }, [accessToken, router, router.isReady]);
 

--- a/pages/makers/index.tsx
+++ b/pages/makers/index.tsx
@@ -8,6 +8,7 @@ import Header from '@/components/common/Header';
 import AboutMakers from '@/components/makers/AboutMakers';
 import { makersGenerationsData } from '@/components/makers/data';
 import MakersMembers from '@/components/makers/MakersMembers';
+import { playgroundLink } from '@/constants/links';
 import IconBack from '@/public/icons/icon-back.svg';
 import { MOBILE_MEDIA_QUERY } from '@/styles/mediaQuery';
 
@@ -20,7 +21,7 @@ const MakersPage: FC = () => {
         <Header />
       ) : (
         <NotLoggedInHeader>
-          <Link href='/auth/login' passHref>
+          <Link href={playgroundLink.login()} passHref>
             <BackLink>
               <StyledBackIcon />
               로그인하러 가기

--- a/pages/members/detail.tsx
+++ b/pages/members/detail.tsx
@@ -2,6 +2,7 @@ import { useRouter } from 'next/router';
 import { FC, useEffect } from 'react';
 
 import SiteHeader from '@/components/common/Header';
+import { playgroundLink } from '@/constants/links';
 import { setLayout } from '@/utils/layout';
 
 /** @deprecated 기존 URL 링크 호환용 리다이렉트 페이지 */
@@ -11,7 +12,7 @@ const MemberDetailPage: FC = () => {
   useEffect(() => {
     if (router.isReady) {
       const { memberId } = router.query;
-      router.replace(`/members?id=${memberId}`);
+      router.replace(playgroundLink.memberDetail(`${memberId}`));
     }
   }, [router, router.isReady]);
 

--- a/pages/members/upload.tsx
+++ b/pages/members/upload.tsx
@@ -9,7 +9,6 @@ import { postMemberProfile } from '@/api/members';
 import { ProfileRequest } from '@/api/members/type';
 import { useGetMemberOfMe, useGetMemberProfileById, useGetMemberProfileOfMe } from '@/apiHooks/members';
 import AuthRequired from '@/components/auth/AuthRequired';
-import useStringRouterQuery from '@/hooks/useStringRouterQuery';
 import Header from '@/components/common/Header';
 import AdditionalFormSection from '@/components/members/upload/AdditionalInfoFormSection';
 import BasicFormSection from '@/components/members/upload/BasicFormSection';
@@ -18,6 +17,8 @@ import PublicQuestionFormSection from '@/components/members/upload/PublicQuestio
 import { memberFormSchema } from '@/components/members/upload/schema';
 import SoptActivityFormSection from '@/components/members/upload/SoptActivityFormSection';
 import { Birthday, MemberUploadForm } from '@/components/members/upload/types';
+import { playgroundLink } from '@/constants/links';
+import useStringRouterQuery from '@/hooks/useStringRouterQuery';
 import { colors } from '@/styles/colors';
 import { MOBILE_MEDIA_QUERY } from '@/styles/mediaQuery';
 import { textStyles } from '@/styles/typography';
@@ -93,7 +94,7 @@ export default function MemberUploadPage() {
     const response = await postMemberProfile(requestBody);
     await Promise.all([refetchMyProfile(), refetchProfileById(), refetchMe()]);
 
-    router.push(`/members?id=${response.id}`);
+    router.push(playgroundLink.memberDetail(response.id));
   };
 
   return (

--- a/pages/projects/detail.tsx
+++ b/pages/projects/detail.tsx
@@ -2,6 +2,7 @@ import { useRouter } from 'next/router';
 import { FC, useEffect } from 'react';
 
 import SiteHeader from '@/components/common/Header';
+import { playgroundLink } from '@/constants/links';
 import { setLayout } from '@/utils/layout';
 
 /** @deprecated 기존 URL 링크 호환용 리다이렉트 페이지 */
@@ -11,7 +12,7 @@ const ProjectDetailPage: FC = () => {
   useEffect(() => {
     if (router.isReady) {
       const { projectId } = router.query;
-      router.replace(`/projects?id=${projectId}`);
+      router.replace(playgroundLink.projectDetail(`${projectId}`));
     }
   }, [router, router.isReady]);
 

--- a/pages/projects/upload/index.tsx
+++ b/pages/projects/upload/index.tsx
@@ -31,6 +31,7 @@ import { projectSchema } from '@/components/projects/upload/schema';
 import { ToastContext, ToastProvider } from '@/components/projects/upload/ToastProvider';
 import { Category, FormItem, Generation, Period, ServiceType, Status } from '@/components/projects/upload/types';
 import { convertPeriodFormat } from '@/components/projects/upload/utils';
+import { playgroundLink } from '@/constants/links';
 import { colors } from '@/styles/colors';
 import { MOBILE_MEDIA_QUERY } from '@/styles/mediaQuery';
 import { textStyles } from '@/styles/typography';
@@ -119,7 +120,7 @@ const ProjectUploadPage: FC = () => {
         {
           onSuccess: () => {
             showToast('프로젝트가 성공적으로 업로드 되었습니다.');
-            router.push('/projects');
+            router.push(playgroundLink.projectList());
             queryClient.invalidateQueries('getProjectListQuery');
           },
         },


### PR DESCRIPTION
### 🤫 쉿, 나한테만 말해줘요. 이슈넘버
- close #243 

### 🧐 어떤 것을 변경했어요~?

기존에 매번 리터럴로 사용하던 Playground 내부 URL 주소들을 한곳에 모았어요!

### 🤔 그렇다면, 어떻게 구현했어요~?

`constants/links.ts` 파일에 사이트 내부 URL 정보를 반환하는 함수들을 모아놓은 `playgroundLink` 객체를 생성했어요. 

### ❤️‍🔥 당신이 생각하는 PR포인트, 내겐 매력포인트.

### 📸 스크린샷, 없으면 이것 참,, 섭섭한데요?
