### PR TITLE
fix: 잘못된 메이커스 멤버 정보 수정

### DIFF
--- a/components/makers/data/generation1.ts
+++ b/components/makers/data/generation1.ts
@@ -51,7 +51,7 @@ export const generation1: MakersGeneration = {
       title: 'Product Crew 팀',
       description: 'SOPT 플레이그라운드 내에서 구성원들이 하나로 모일 수 있는 모임 서비스를 만들고 있어요.',
       people: [
-        { type: 'member', id: 6, name: '김나연', position: 'PM' },
+        { type: 'member', id: 5, name: '김나연', position: 'PM' },
         { type: 'member', id: 30, name: '김인우', position: '디자이너' },
         { type: 'member', id: 38, name: '김준영', position: '디자이너' },
         { type: 'member', id: 37, name: '이동훈', position: '백엔드 개발자' },


### PR DESCRIPTION
### 🤫 쉿, 나한테만 말해줘요. 이슈넘버


### 🧐 어떤 것을 변경했어요~?
메이커스 멤버 정보가 잘못 들어가서 잘못된 사진이 노출되었던걸 수정했어요.

### 🤔 그렇다면, 어떻게 구현했어요~?

### ❤️‍🔥 당신이 생각하는 PR포인트, 내겐 매력포인트.

### 📸 스크린샷, 없으면 이것 참,, 섭섭한데요?
