### PR TITLE
chore: GA에 페이지 조회수 측정되도록 설정하기

### DIFF
--- a/components/googleAnalytics/GoogleAnalyticsScript.tsx
+++ b/components/googleAnalytics/GoogleAnalyticsScript.tsx
@@ -1,0 +1,25 @@
+import Script from 'next/script';
+
+import * as gtag from '@/components/googleAnalytics/gtag';
+
+export default function GoogleAnalyticsScript() {
+  return (
+    <>
+      <Script strategy='afterInteractive' src={`https://www.googletagmanager.com/gtag/js?id=${gtag.GA_TRACKING_ID}`} />
+      <Script
+        id='gtag-init'
+        strategy='afterInteractive'
+        dangerouslySetInnerHTML={{
+          __html: `
+				window.dataLayer = window.dataLayer || [];
+				function gtag(){dataLayer.push(arguments);}
+				gtag('js', new Date());
+				gtag('config', '${gtag.GA_TRACKING_ID}', {
+					page_path: window.location.pathname,
+				});
+			`,
+        }}
+      />
+    </>
+  );
+}

--- a/components/googleAnalytics/gtag.ts
+++ b/components/googleAnalytics/gtag.ts
@@ -1,0 +1,10 @@
+export const GA_TRACKING_ID = process.env.NEXT_PUBLIC_GA_ID;
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const gtag = (window as any).gtag;
+
+export const pageview = (url: string) => {
+  gtag('config', GA_TRACKING_ID, {
+    page_path: url,
+  });
+};

--- a/components/googleAnalytics/gtag.ts
+++ b/components/googleAnalytics/gtag.ts
@@ -1,7 +1,12 @@
 export const GA_TRACKING_ID = process.env.NEXT_PUBLIC_GA_ID;
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-const gtag = (window as any).gtag;
+const gtag =
+  typeof window !== 'undefined'
+    ? // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (window as any).gtag
+    : () => {
+        // do nothing
+      };
 
 export const pageview = (url: string) => {
   gtag('config', GA_TRACKING_ID, {

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -1,9 +1,13 @@
 import type { AppProps } from 'next/app';
 import Head from 'next/head';
+import { useRouter } from 'next/router';
+import { useEffect } from 'react';
 import { QueryClient, QueryClientProvider } from 'react-query';
 import { RecoilRoot } from 'recoil';
 
 import Debugger from '@/components/debug/Debugger';
+import GoogleAnalyticsScript from '@/components/googleAnalytics/GoogleAnalyticsScript';
+import * as gtag from '@/components/googleAnalytics/gtag';
 import GlobalStyle from '@/styles/GlobalStyle';
 import { getLayout } from '@/utils/layout';
 
@@ -14,11 +18,26 @@ const queryClient = new QueryClient({
 function MyApp({ Component, pageProps }: AppProps) {
   const layout = getLayout(Component);
 
+  const router = useRouter();
+
+  useEffect(() => {
+    const handleRouteChange = (url: string) => {
+      gtag.pageview(url);
+    };
+    router.events.on('routeChangeComplete', handleRouteChange);
+    router.events.on('hashChangeComplete', handleRouteChange);
+    return () => {
+      router.events.off('routeChangeComplete', handleRouteChange);
+      router.events.off('hashChangeComplete', handleRouteChange);
+    };
+  }, [router.events]);
+
   return (
     <QueryClientProvider client={queryClient}>
       <Head>
         <title>SOPT Playground</title>
       </Head>
+      <GoogleAnalyticsScript />
       <RecoilRoot>
         <GlobalStyle />
         {layout(<Component {...pageProps} />)}

--- a/pages/_document.tsx
+++ b/pages/_document.tsx
@@ -1,0 +1,22 @@
+import { Head, Html, Main, NextScript } from 'next/document';
+
+export default function Document() {
+  return (
+    <Html>
+      <Head />
+      <body>
+        <Main />
+        <NextScript />
+        <script
+          dangerouslySetInnerHTML={{
+            __html: `
+            window.dataLayer = window.dataLayer || [];
+            function gtag(){dataLayer.push(arguments);}
+            gtag('js', new Date());
+          `,
+          }}
+        />
+      </body>
+    </Html>
+  );
+}


### PR DESCRIPTION
### 🤫 쉿, 나한테만 말해줘요. 이슈넘버
- close #77 

### 🧐 어떤 것을 변경했어요~?
<!-- 실제로 변경한 사항을 설명해주세요.-->
gtag.js를 이용해 구글 애널리틱스를 연동 시켰어요.
그리고 페이지 조회수 측정이 되도록 했어요.

### 🤔 그렇다면, 어떻게 구현했어요~?
Next.js에서 제시하는 가이드 라인대로 했습니다.
https://github.com/vercel/next.js/tree/canary/examples/with-google-analytics

### ❤️‍🔥 당신이 생각하는 PR포인트, 내겐 매력포인트.

localhost에서는 테스트 할 수 없어서 @Tekiter 가 알려준 [localtunnel](https://github.com/localtunnel/localtunnel)로 터널링을 해서 연동(테스트용 개인 계정에)하고 페이지 뷰 테스트까지 해보다가

gtag.js가 아니라 GTM 사용하는 것으로 변경하게 돼서 이 PR은 닫습니다! 


### 📸 스크린샷, 없으면 이것 참,, 섭섭한데요?

<img width="1440" alt="image" src="https://user-images.githubusercontent.com/73823388/205432171-d91c4d2c-e446-4cee-8407-b3b40bcf2bea.png">
