### PR TITLE
fix: 환영 메시지 밑 여백 수정

### DIFF
--- a/components/members/main/MemberList/index.tsx
+++ b/components/members/main/MemberList/index.tsx
@@ -114,6 +114,7 @@ const IntroducePanel = styled.section`
   display: flex;
   align-items: center;
   justify-content: space-between;
+  margin-bottom: 92px;
   border-radius: 42px;
   background-color: ${colors.black80};
   padding: 59px 64px;
@@ -122,6 +123,7 @@ const IntroducePanel = styled.section`
 
   @media ${MOBILE_MEDIA_QUERY} {
     display: block;
+    margin-bottom: 56px;
     background-color: ${colors.black100};
     padding: 0;
     height: auto;
@@ -207,7 +209,6 @@ const StyledMain = styled.main<{ hasProfile?: boolean }>`
     flex-direction: column;
     align-items: center;
     justify-content: center;
-    margin-top: 23px;
     padding: 0 20px;
   }
 `;


### PR DESCRIPTION
### 🤫 쉿, 나한테만 말해줘요. 이슈넘버


### 🧐 어떤 것을 변경했어요~?

멤버 프로필을 아직 등록하지 않았을 때 표시하는 환영 메세지의 하단 여백 버그를 수정했어요!

@juno7803 가 작업했던 부분이지만, 수정에 필요한 작업량이 많지 않아서 빠르게 대신 수정했어요!

### 🤔 그렇다면, 어떻게 구현했어요~?

### ❤️‍🔥 당신이 생각하는 PR포인트, 내겐 매력포인트.

### 📸 스크린샷, 없으면 이것 참,, 섭섭한데요?

**Before**
![image](https://user-images.githubusercontent.com/36122585/208903596-4b558bcf-ff8b-4618-9061-59f9f74466ee.png)

**After**
![image](https://user-images.githubusercontent.com/36122585/208903665-49056686-158d-44f1-9faa-9a594248ef65.png)
