### PR TITLE
feat: 무한스크롤 구현, 필터 queryParams로 교체

### DIFF
--- a/api/members/index.ts
+++ b/api/members/index.ts
@@ -2,18 +2,20 @@ import { axiosInstance } from '@/api';
 import { Member, PostMemberCoffeeChatVariables, Profile, ProfileDetail, ProfileRequest } from '@/api/members/type';
 
 export type GetMemberProfileVariables = {
-  filter: number;
+  filter?: number;
   limit?: number;
   cursor?: number;
 };
 // 멤버 프로필 전체 조회
 export const getMemberProfile = async (variables: GetMemberProfileVariables) => {
-  const { filter, limit, cursor } = variables;
-  const limitQuery = limit ? `&?limit=${limit}` : '';
-  const cursorQuery = cursor ? `&?cursor=${cursor}` : '';
+  const url = new URL('https://api/v1/members/profile');
+  Object.entries(variables)
+    .filter(([_, value]) => Boolean(value))
+    .forEach(([query, value]) => url.searchParams.set(query, value.toString()));
+
   const { data } = await axiosInstance.request<Profile[]>({
     method: 'GET',
-    url: `api/v1/members/profile?filter=${filter}${limitQuery}${cursorQuery}`,
+    url: `${url.hostname}${url.pathname}${url.search}`,
   });
 
   return data;

--- a/api/members/index.ts
+++ b/api/members/index.ts
@@ -1,21 +1,11 @@
 import { axiosInstance } from '@/api';
 import { Member, PostMemberCoffeeChatVariables, Profile, ProfileDetail, ProfileRequest } from '@/api/members/type';
 
-export type GetMemberProfileVariables = {
-  filter?: number;
-  limit?: number;
-  cursor?: number;
-};
 // 멤버 프로필 전체 조회
-export const getMemberProfile = async (variables: GetMemberProfileVariables) => {
-  const url = new URL('https://api/v1/members/profile');
-  Object.entries(variables)
-    .filter(([_, value]) => Boolean(value))
-    .forEach(([query, value]) => url.searchParams.set(query, value.toString()));
-
+export const getMemberProfile = async (input: string) => {
   const { data } = await axiosInstance.request<Profile[]>({
     method: 'GET',
-    url: `${url.hostname}${url.pathname}${url.search}`,
+    url: `api/v1/members/profile${input}`,
   });
 
   return data;

--- a/apiHooks/members.ts
+++ b/apiHooks/members.ts
@@ -1,4 +1,3 @@
-import { useRouter } from 'next/router';
 import { useInfiniteQuery, useMutation, useQuery } from 'react-query';
 
 import {
@@ -12,23 +11,20 @@ import {
 import { PostMemberCoffeeChatVariables, Profile } from '@/api/members/type';
 
 interface Variables {
-  filter?: number;
   limit?: number;
 }
 
 // 멤버 프로필 전체 조회
 export const useGetMemberProfile = (input: Variables) => {
-  const router = useRouter();
   return useInfiniteQuery({
-    queryKey: ['getMemberProfile', input],
+    queryKey: ['getMemberProfile', input, window.location.search],
     queryFn: async ({ pageParam: cursor = 0 }) => {
       const params = { ...input, cursor };
 
-      const url = new URL(`${window.location.origin}${window.location.pathname}`);
-      Object.entries(params).forEach(([query, value]) => url.searchParams.set(query, value.toString()));
-      router.push(url);
+      const apiUrl = new URL(window.location.href);
+      Object.entries(params).forEach(([query, value]) => apiUrl.searchParams.set(query, value.toString()));
 
-      const data = await getMemberProfile(url.search);
+      const data = await getMemberProfile(apiUrl.search);
       return data;
     },
     getNextPageParam: (lastPage: Profile[]) => {

--- a/apiHooks/members.ts
+++ b/apiHooks/members.ts
@@ -15,14 +15,16 @@ interface Variables {
 }
 
 // 멤버 프로필 전체 조회
-export const useGetMemberProfile = (input: Variables) => {
+export const useGetMemberProfile = ({ limit }: Variables) => {
   return useInfiniteQuery({
     queryKey: ['getMemberProfile'],
     queryFn: async ({ pageParam: cursor = 0 }) => {
-      const params = { ...input, cursor };
+      const params = { limit, cursor };
 
       const apiUrl = new URL(window.location.href);
-      Object.entries(params).forEach(([query, value]) => apiUrl.searchParams.set(query, value.toString()));
+      Object.entries(params).forEach(
+        ([query, value]) => value !== undefined && apiUrl.searchParams.set(query, value.toString()),
+      );
 
       const data = await getMemberProfile(apiUrl.search);
       return data;

--- a/apiHooks/members.ts
+++ b/apiHooks/members.ts
@@ -17,7 +17,7 @@ interface Variables {
 // 멤버 프로필 전체 조회
 export const useGetMemberProfile = (input: Variables) => {
   return useInfiniteQuery({
-    queryKey: ['getMemberProfile', input, window.location.search],
+    queryKey: ['getMemberProfile'],
     queryFn: async ({ pageParam: cursor = 0 }) => {
       const params = { ...input, cursor };
 

--- a/components/common/ResizedImage/index.tsx
+++ b/components/common/ResizedImage/index.tsx
@@ -38,16 +38,18 @@ const ResizedImage: FC<ImageProps> = ({ className, src, width, alt, onLoad }) =>
     onLoad?.();
   };
 
-  const { ref: imgRef } = useEnterScreen<HTMLImageElement>(() => {
-    if (imgRef.current?.complete) {
-      return;
-    }
-
-    timeoutTokenRef.current = setTimeout(() => {
-      if (!imgRef.current?.complete) {
-        setIsUsingOriginal(true);
+  const { ref: imgRef } = useEnterScreen<HTMLImageElement>({
+    onEnter: () => {
+      if (imgRef.current?.complete) {
+        return;
       }
-    }, WAIT_TIME);
+
+      timeoutTokenRef.current = setTimeout(() => {
+        if (!imgRef.current?.complete) {
+          setIsUsingOriginal(true);
+        }
+      }, WAIT_TIME);
+    },
   });
 
   return (

--- a/components/makers/MakersMembers.tsx
+++ b/components/makers/MakersMembers.tsx
@@ -19,9 +19,7 @@ interface MakersMembersProps {
 }
 
 const MakersMembers: FC<MakersMembersProps> = ({ className, generations }) => {
-  const { data, isLoading } = useGetMemberProfile({
-    filter: 0,
-  });
+  const { data, isLoading } = useGetMemberProfile({});
   const { isLoggedIn } = useAuth();
 
   const memberImageMap = useMemo(() => {
@@ -29,9 +27,11 @@ const MakersMembers: FC<MakersMembersProps> = ({ className, generations }) => {
     if (!data) {
       return map;
     }
-    data.forEach((x) => {
-      map.set(x.id, x.profileImage);
-    });
+    data.pages.forEach((members) =>
+      members.forEach((member) => {
+        map.set(member.id, member.profileImage);
+      }),
+    );
 
     return map;
   }, [data]);

--- a/components/members/main/MemberList/index.tsx
+++ b/components/members/main/MemberList/index.tsx
@@ -105,7 +105,7 @@ const MemberList: FC = () => {
                 ))}
               </React.Fragment>
             ))}
-            <Observe ref={ref} />
+            <Target ref={ref} />
           </StyledCardWrapper>
         </StyledMain>
       </StyledContent>
@@ -284,4 +284,4 @@ const StyledMemberRoleDropdown = styled(MemberRoleDropdown)`
   max-width: 505px;
 `;
 
-const Observe = styled.div``;
+const Target = styled.div``;

--- a/components/members/main/MemberList/index.tsx
+++ b/components/members/main/MemberList/index.tsx
@@ -91,16 +91,14 @@ const MemberList: FC = () => {
             {profiles?.map((profiles, index) => (
               <React.Fragment key={index}>
                 {profiles.map((profile) => (
-                  <Link key={profile.id} href={playgroundLink.memberDetail(profile.id)} passHref>
-                    <a>
-                      <MemberCard
-                        name={profile.name}
-                        part={profile.part}
-                        isActiveGeneration={profile.isActive}
-                        introduction={profile.introduction}
-                        image={profile.profileImage}
-                      />
-                    </a>
+                  <Link key={profile.id} href={playgroundLink.memberDetail(profile.id)}>
+                    <MemberCard
+                      name={profile.name}
+                      part={profile.part}
+                      isActiveGeneration={profile.isActive}
+                      introduction={profile.introduction}
+                      image={profile.profileImage}
+                    />
                   </Link>
                 ))}
               </React.Fragment>

--- a/components/members/main/MemberList/index.tsx
+++ b/components/members/main/MemberList/index.tsx
@@ -3,7 +3,7 @@ import styled from '@emotion/styled';
 import uniq from 'lodash/uniq';
 import Link from 'next/link';
 import { useRouter } from 'next/router';
-import React, { FC } from 'react';
+import React, { FC, useEffect } from 'react';
 
 import { useGetMemberOfMe, useGetMemberProfile } from '@/apiHooks/members';
 import Text from '@/components/common/Text';
@@ -13,7 +13,7 @@ import MemberRoleDropdown from '@/components/members/main/MemberRoleMenu/MemberR
 import useMemberRoleMenu from '@/components/members/main/MemberRoleMenu/useMemberRoleMenu';
 import { LATEST_GENERATION } from '@/constants/generation';
 import { playgroundLink } from '@/constants/links';
-import useEnterScreen from '@/hooks/useEnterScreen';
+import useIntersectionObserver from '@/hooks/useIntersectionObserver';
 import useMediaQuery from '@/hooks/useMediaQuery';
 import { colors } from '@/styles/colors';
 import { MOBILE_MAX_WIDTH, MOBILE_MEDIA_QUERY } from '@/styles/mediaQuery';
@@ -26,12 +26,8 @@ const MemberList: FC = () => {
   const { data: memberProfileData, fetchNextPage } = useGetMemberProfile({ limit: PAGE_LIMIT });
   const { data: memberOfMeData } = useGetMemberOfMe();
   const router = useRouter();
-  const { ref } = useEnterScreen({
-    onEnter: () => {
-      console.log('[entered!]');
-      // fetchNextPage();
-    },
-  });
+  const { ref, isVisible } = useIntersectionObserver();
+
   const isMobile = useMediaQuery(MOBILE_MAX_WIDTH);
   const handleSelect = (value: MenuValue) => {
     onSelect(value);
@@ -42,6 +38,12 @@ const MemberList: FC = () => {
     }
     router.push(url);
   };
+
+  useEffect(() => {
+    if (isVisible) {
+      fetchNextPage();
+    }
+  }, [isVisible, fetchNextPage]);
 
   const profiles = memberProfileData?.pages.map((members) =>
     members.map((member) => ({
@@ -103,8 +105,8 @@ const MemberList: FC = () => {
                 ))}
               </React.Fragment>
             ))}
+            <Observe ref={ref} />
           </StyledCardWrapper>
-          <Observe ref={ref} />
         </StyledMain>
       </StyledContent>
     </StyledContainer>

--- a/components/members/main/MemberList/index.tsx
+++ b/components/members/main/MemberList/index.tsx
@@ -2,7 +2,7 @@ import { css } from '@emotion/react';
 import styled from '@emotion/styled';
 import uniq from 'lodash/uniq';
 import Link from 'next/link';
-import { FC } from 'react';
+import { FC, useRef } from 'react';
 
 import { useGetMemberOfMe, useGetMemberProfile } from '@/apiHooks/members';
 import Text from '@/components/common/Text';
@@ -12,6 +12,7 @@ import MemberRoleDropdown from '@/components/members/main/MemberRoleMenu/MemberR
 import useMemberRoleMenu from '@/components/members/main/MemberRoleMenu/useMemberRoleMenu';
 import { LATEST_GENERATION } from '@/constants/generation';
 import { playgroundLink } from '@/constants/links';
+import useIntersectionObserver from '@/hooks/useIntersectionObserver';
 import useMediaQuery from '@/hooks/useMediaQuery';
 import { colors } from '@/styles/colors';
 import { MOBILE_MAX_WIDTH, MOBILE_MEDIA_QUERY } from '@/styles/mediaQuery';
@@ -23,6 +24,8 @@ const MemberList: FC = () => {
     filter,
   });
   const { data: memberOfMeData } = useGetMemberOfMe();
+  const ref = useRef(null);
+  const { isVisible } = useIntersectionObserver(ref);
   const isMobile = useMediaQuery(MOBILE_MAX_WIDTH);
 
   const profiles = memberProfileData?.map((member) => ({
@@ -31,6 +34,11 @@ const MemberList: FC = () => {
     part: uniq(member.activities.map(({ part }) => part)).join(' / '),
   }));
   const hasProfile = !!memberOfMeData?.hasProfile;
+
+  /**
+   * limit = cursor 부터 몇개까지 내려오는가
+   * cursor = 어디서 부터 가져올 건가
+   */
 
   return (
     <StyledContainer hasProfile={hasProfile}>
@@ -77,6 +85,7 @@ const MemberList: FC = () => {
                 />
               </Link>
             ))}
+            <Observe ref={ref} />
           </StyledCardWrapper>
         </StyledMain>
       </StyledContent>
@@ -254,3 +263,5 @@ const StyledMemberRoleDropdown = styled(MemberRoleDropdown)`
   margin-bottom: 16px;
   max-width: 505px;
 `;
+
+const Observe = styled.div``;

--- a/hooks/useEnterScreen.ts
+++ b/hooks/useEnterScreen.ts
@@ -1,6 +1,10 @@
 import { useEffect, useRef } from 'react';
 
-const useEnterScreen = <T extends Element = never>(callback: () => void) => {
+interface UseEnterScreenVariables {
+  onEnter?: () => void;
+}
+const useEnterScreen = <T extends Element = never>(variables: UseEnterScreenVariables) => {
+  const { onEnter } = variables;
   const ref = useRef<T>(null);
 
   useEffect(() => {
@@ -8,9 +12,7 @@ const useEnterScreen = <T extends Element = never>(callback: () => void) => {
       if (!entry.isIntersecting) {
         return;
       }
-
-      callback();
-
+      onEnter?.();
       observer.disconnect();
     }, {});
 
@@ -21,7 +23,7 @@ const useEnterScreen = <T extends Element = never>(callback: () => void) => {
     return () => {
       observer.disconnect();
     };
-  }, [ref, callback]);
+  }, [ref, onEnter]);
 
   return {
     ref,

--- a/hooks/useIntersectionObserver.ts
+++ b/hooks/useIntersectionObserver.ts
@@ -1,16 +1,14 @@
 import { RefObject, useEffect, useState } from 'react';
 
 interface IntersectionObserverOptions extends IntersectionObserverInit {
-  freezeOnceVisible?: boolean;
+  enabled?: boolean;
 }
 
 function useIntersectionObserver(
   ref: RefObject<Element>,
-  { threshold = 0, root = null, rootMargin = '0%', freezeOnceVisible = false }: IntersectionObserverOptions = {},
+  { threshold = 0, root = null, rootMargin = '0%', enabled = false }: IntersectionObserverOptions = {},
 ) {
   const [entry, setEntry] = useState<IntersectionObserverEntry>();
-
-  const frozen = entry?.isIntersecting && freezeOnceVisible;
 
   const updateEntry = ([entry]: IntersectionObserverEntry[]): void => {
     setEntry(entry);
@@ -19,7 +17,7 @@ function useIntersectionObserver(
   useEffect(() => {
     const node = ref?.current;
 
-    if (frozen || !node) return;
+    if (enabled || !node) return;
 
     const observerParams = { threshold, root, rootMargin };
     const observer = new IntersectionObserver(updateEntry, observerParams);
@@ -29,9 +27,9 @@ function useIntersectionObserver(
     return () => observer.disconnect();
 
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [ref?.current, JSON.stringify(threshold), root, rootMargin, frozen]);
+  }, [ref?.current, JSON.stringify(threshold), root, rootMargin, enabled]);
 
-  return { entry, isVisible: Boolean(entry?.isIntersecting) };
+  return { entry, isVisible: !!entry?.isIntersecting };
 }
 
 export default useIntersectionObserver;

--- a/hooks/useIntersectionObserver.ts
+++ b/hooks/useIntersectionObserver.ts
@@ -1,14 +1,17 @@
-import { RefObject, useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 
 interface IntersectionObserverOptions extends IntersectionObserverInit {
   enabled?: boolean;
 }
 
-function useIntersectionObserver(
-  ref: RefObject<Element>,
-  { threshold = 0, root = null, rootMargin = '0%', enabled = false }: IntersectionObserverOptions = {},
-) {
+function useIntersectionObserver({
+  threshold = 0,
+  root = null,
+  rootMargin = '0%',
+  enabled = false,
+}: IntersectionObserverOptions = {}) {
   const [entry, setEntry] = useState<IntersectionObserverEntry>();
+  const ref = useRef(null);
 
   const updateEntry = ([entry]: IntersectionObserverEntry[]): void => {
     setEntry(entry);
@@ -29,7 +32,7 @@ function useIntersectionObserver(
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [ref?.current, JSON.stringify(threshold), root, rootMargin, enabled]);
 
-  return { entry, isVisible: !!entry?.isIntersecting };
+  return { ref, entry, isVisible: !!entry?.isIntersecting };
 }
 
 export default useIntersectionObserver;

--- a/hooks/useIntersectionObserver.ts
+++ b/hooks/useIntersectionObserver.ts
@@ -1,0 +1,37 @@
+import { RefObject, useEffect, useState } from 'react';
+
+interface IntersectionObserverOptions extends IntersectionObserverInit {
+  freezeOnceVisible?: boolean;
+}
+
+function useIntersectionObserver(
+  ref: RefObject<Element>,
+  { threshold = 0, root = null, rootMargin = '0%', freezeOnceVisible = false }: IntersectionObserverOptions = {},
+) {
+  const [entry, setEntry] = useState<IntersectionObserverEntry>();
+
+  const frozen = entry?.isIntersecting && freezeOnceVisible;
+
+  const updateEntry = ([entry]: IntersectionObserverEntry[]): void => {
+    setEntry(entry);
+  };
+
+  useEffect(() => {
+    const node = ref?.current;
+
+    if (frozen || !node) return;
+
+    const observerParams = { threshold, root, rootMargin };
+    const observer = new IntersectionObserver(updateEntry, observerParams);
+
+    observer.observe(node);
+
+    return () => observer.disconnect();
+
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [ref?.current, JSON.stringify(threshold), root, rootMargin, frozen]);
+
+  return { entry, isVisible: Boolean(entry?.isIntersecting) };
+}
+
+export default useIntersectionObserver;


### PR DESCRIPTION
### 🤫 쉿, 나한테만 말해줘요. 이슈넘버
- close #279 
- close #291 

### 🧐 어떤 것을 변경했어요~?
<!-- 실제로 변경한 사항을 설명해주세요.-->
- 무한스크롤을 구현했어요! 근데 서버쪽 cursor에 잘라온 마지막 멤버의 id를 넣어주어야 정상적으로 동작을 해서 이렇게 구현했어요.
- useIntersectionObserver를 추가했구, 마지막 요소가 뷰포트에 들어오게 되면 url을 바꿔주고, url의 searchParam을 읽어와서 서버쪽으로 요청하도록 했어요.
- url로 컨트롤 하는 이유는 브라우저 스택에 쌓아서 #291 와 같은 문제를 해결하기 위함입니당
- 데이터가 좀 더 많은 곳에서 테스트해보고 싶은데, 유저가 적은 시간대에 프로덕션에 배포해서 테스트 해보던가 하려구 해용..
- => 요 부분 커비가 알려준 방법으로 로컬에서 프로덕션 바라보도록 수정하여 테스트 했음! [참고 스레드](https://sopt-makers.slack.com/archives/C044JFKAE2X/p1672074217173429?thread_ts=1672073631.347749&cid=C044JFKAE2X)

### 🤔 그렇다면, 어떻게 구현했어요~?
<!-- 실제로 구현한 로직에 대해 설명해주세요.-->

### ❤️‍🔥 당신이 생각하는 PR포인트, 내겐 매력포인트.
<!-- 해당 PR에서 논의가 필요한 사항을 적어주세요. -->

### 📸 스크린샷, 없으면 이것 참,, 섭섭한데요?
요거 마지막에 api 호출을 한번 더 하는데, 서버쪽에 마지막 페이지인걸 알려달라는 값을 요청해둔 상태라서
그게 추가되면 마지막 api 호출도 막을 수 있도록 변경할게요! @Tekiter 



https://user-images.githubusercontent.com/26808056/209898739-66347598-1178-4bde-9427-a2c8e5f8506f.mov


