### PR TITLE
fix: 경력 없을 경우 빈 필드 안보이게

### DIFF
--- a/components/members/main/MemberDetail/index.tsx
+++ b/components/members/main/MemberDetail/index.tsx
@@ -158,11 +158,13 @@ const MemberDetail: FC<MemberDetailProps> = ({ memberId }) => {
           })}
         </InfoContainer>
 
-        <InfoContainer style={{ gap: '20px' }}>
-          {profile?.careers.map((career, idx) => (
-            <CareerItem key={idx} career={career} />
-          ))}
-        </InfoContainer>
+        {profile?.careers && profile.careers.length > 0 && (
+          <InfoContainer style={{ gap: '20px' }}>
+            {profile.careers.map((career, idx) => (
+              <CareerItem key={idx} career={career} />
+            ))}
+          </InfoContainer>
+        )}
 
         <InfoContainer style={{ gap: '30px' }}>
           <InfoItem label='스킬' content={profile?.skill ?? ''} />


### PR DESCRIPTION
### 🤫 쉿, 나한테만 말해줘요. 이슈넘버
- close #329

### 🧐 어떤 것을 변경했어요~?
<!-- 실제로 변경한 사항을 설명해주세요.-->
경력이 없을 수 있는데, 없는 경우 빈 사각형 필드가 보이는 버그를 해결했습니다.

### 🤔 그렇다면, 어떻게 구현했어요~?
<!-- 실제로 구현한 로직에 대해 설명해주세요.-->

### ❤️‍🔥 당신이 생각하는 PR포인트, 내겐 매력포인트.
<!-- 해당 PR에서 논의가 필요한 사항을 적어주세요. -->

### 📸 스크린샷, 없으면 이것 참,, 섭섭한데요?
