### PR TITLE
fix: 이미지가 빈 값일 경우 기본 이미지 보여지도록 대응

### DIFF
--- a/components/projects/upload/MemberForm/MemberSearch.tsx
+++ b/components/projects/upload/MemberForm/MemberSearch.tsx
@@ -41,7 +41,11 @@ const MemberSearch: FC<MemberSearchProps> = ({ value, onChange, onSearch, member
             <div style={{ display: 'flex', alignItems: 'center', columnGap: '6px' }}>
               <ProfileImage
                 style={{ width: '24px', height: '24px' }}
-                src={value.profileImage ?? '/icons/icon-member-search-default.svg'}
+                src={
+                  value.profileImage == null || value.profileImage === ''
+                    ? '/icons/icon-member-search-default.svg'
+                    : value.profileImage
+                }
                 alt='멤버의 프로필 이미지'
               />
               <Text>{value.name}</Text>


### PR DESCRIPTION
### 🤫 쉿, 나한테만 말해줘요. 이슈넘버
- close #

### 🧐 어떤 것을 변경했어요~?
<!-- 실제로 변경한 사항을 설명해주세요.-->
- `imageUrl`이 `null | string` 타입인데, 빈 스트링이 들어간 경우가 있어서 이를 대응합니다.

### 🤔 그렇다면, 어떻게 구현했어요~?
<!-- 실제로 구현한 로직에 대해 설명해주세요.-->

### ❤️‍🔥 당신이 생각하는 PR포인트, 내겐 매력포인트.
<!-- 해당 PR에서 논의가 필요한 사항을 적어주세요. -->

### 📸 스크린샷, 없으면 이것 참,, 섭섭한데요?
