### PR TITLE
fix: type="number"인 input 화살표, 스피너 뜨지 않도록

### DIFF
--- a/styles/global.ts
+++ b/styles/global.ts
@@ -30,6 +30,18 @@ export const global = css`
       outline: 1px solid ${colors.purple100};
     }
 
+    /* Remove Arrows/Spinners Chrome, Safari, Edge, Opera */
+    input::-webkit-outer-spin-button,
+    input::-webkit-inner-spin-button {
+      appearance: none;
+      margin: 0;
+    }
+
+    /* Remove Arrows/Spinners Firefox */
+    input[type='number'] {
+      appearance: textfield;
+    }
+
     /* Change Autocomplete styles in Chrome */
     input:-webkit-autofill,
     input:-webkit-autofill:hover,


### PR DESCRIPTION
### 🤫 쉿, 나한테만 말해줘요. 이슈넘버
- close #340 

### 🧐 어떤 것을 변경했어요~?
<!-- 실제로 변경한 사항을 설명해주세요.-->
글로벌 스타일에 type="number"인 input 화살표, 스피너 뜨지 않도록 하는 코드를 추가했어요

### 🤔 그렇다면, 어떻게 구현했어요~?
<!-- 실제로 구현한 로직에 대해 설명해주세요.-->
[참고](https://www.w3schools.com/howto/howto_css_hide_arrow_number.asp)

### ❤️‍🔥 당신이 생각하는 PR포인트, 내겐 매력포인트.
<!-- 해당 PR에서 논의가 필요한 사항을 적어주세요. -->

### 📸 스크린샷, 없으면 이것 참,, 섭섭한데요?
크롬

<img width="242" alt="image" src="https://user-images.githubusercontent.com/73823388/211718737-befb7d33-db8f-449f-9d15-98d4bc79f079.png">

사파리

<img width="220" alt="image" src="https://user-images.githubusercontent.com/73823388/211718999-7a5333d2-5c9b-4a3e-a2cf-dd5c94929e98.png">

