### PR TITLE
fix: 메이커스 멤버 소개 모바일 레이아웃 오류 수정

### DIFF
--- a/components/makers/MakersMembers.tsx
+++ b/components/makers/MakersMembers.tsx
@@ -185,7 +185,11 @@ const StyledTeamBlock = styled(TeamBlock)`
 
 const PeopleBox = styled.div`
   display: grid;
-  grid-template-columns: 1fr 1fr;
+  grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
   row-gap: 24px;
   column-gap: 6px;
+
+  @media ${MOBILE_MEDIA_QUERY} {
+    grid-template-columns: minmax(0, 1fr);
+  }
 `;

--- a/components/members/common/MemberBlock.tsx
+++ b/components/members/common/MemberBlock.tsx
@@ -155,6 +155,7 @@ const Po = styled.span`
 
 const BadgeContainer = styled.div`
   display: flex;
+  flex-wrap: wrap;
   margin-top: 6px;
 `;
 


### PR DESCRIPTION
### 🤫 쉿, 나한테만 말해줘요. 이슈넘버


### 🧐 어떤 것을 변경했어요~?

모바일 화면에서 메이커스 멤버 소개가 두줄에서 한줄로 나오도록 수정했어요.

### 🤔 그렇다면, 어떻게 구현했어요~?


### ❤️‍🔥 당신이 생각하는 PR포인트, 내겐 매력포인트.


### 📸 스크린샷, 없으면 이것 참,, 섭섭한데요?
