### PR TITLE
feat: 메이커스 멤버 소개 최적화

### DIFF
--- a/components/makers/MakersMembers.tsx
+++ b/components/makers/MakersMembers.tsx
@@ -2,13 +2,12 @@ import { css } from '@emotion/react';
 import styled from '@emotion/styled';
 import { Tab } from '@headlessui/react';
 import Link from 'next/link';
-import { FC, Fragment } from 'react';
+import { FC, Fragment, useMemo } from 'react';
 
 import useAuth from '@/components/auth/useAuth';
 import { MakersGeneration } from '@/components/makers/data/types';
 import TeamBlock from '@/components/makers/TeamBlock';
 import MemberBlock from '@/components/members/common/MemberBlock';
-import WithMemberMetadata from '@/components/members/common/WithMemberMetadata';
 import { playgroundLink } from '@/constants/links';
 import { colors } from '@/styles/colors';
 import { MOBILE_MEDIA_QUERY } from '@/styles/mediaQuery';
@@ -17,10 +16,13 @@ import { textStyles } from '@/styles/typography';
 interface MakersMembersProps {
   className?: string;
   generations: MakersGeneration[];
+  metadataList: { id: number; profileImage: string; currentCompany: string | null; generations: number[] }[];
 }
 
-const MakersMembers: FC<MakersMembersProps> = ({ className, generations }) => {
+const MakersMembers: FC<MakersMembersProps> = ({ className, generations, metadataList }) => {
   const { isLoggedIn } = useAuth();
+
+  const metadataMap = useMemo(() => new Map(metadataList.map((member) => [member.id, member])), [metadataList]);
 
   const showNeedLogin = () => {
     alert('프로필을 보려면 로그인 해주세요.');
@@ -54,9 +56,10 @@ const MakersMembers: FC<MakersMembersProps> = ({ className, generations }) => {
                     {team.people.map((person, personIdx) => (
                       <Fragment key={personIdx}>
                         {person.type === 'member' ? (
-                          <WithMemberMetadata
-                            memberId={person.id}
-                            render={(metadata) => (
+                          (() => {
+                            const metadata = metadataMap.get(person.id);
+
+                            return (
                               <Link
                                 href={playgroundLink.memberDetail(person.id)}
                                 onClick={() => metadata && !isLoggedIn && showNeedLogin()}
@@ -71,8 +74,8 @@ const MakersMembers: FC<MakersMembersProps> = ({ className, generations }) => {
                                   ].filter((badge): badge is string => !!badge)}
                                 />
                               </Link>
-                            )}
-                          />
+                            );
+                          })()
                         ) : (
                           <MemberBlock name={person.name} />
                         )}


### PR DESCRIPTION
### 🤫 쉿, 나한테만 말해줘요. 이슈넘버
- close #379 
- clode #362 

### 🧐 어떤 것을 변경했어요~?

기존에는 메이커스 소개 페이지에서 멤버들에 대한 프로필사진, 기수, 직장 정보를 프론트엔드에서 CSR로 처리하고 있었어요. 그런데 플레이그라운드에 등록된 멤버의 수가 점점 많아지면서, 이 데이터를 불러오는 게 점점 더 큰 오버헤드가 되어갔어요. 이 문제를 궁극적으로 처리하기 위해서는 메이커스 멤버 정보를 주는 서버 API가 만들어지면 되는데, 현 상황상 새로운 API가 생기는 데에는 시간이 좀 걸릴 예정이에요. 

그래서 이 문제를 프론트엔드 쪽에서만 처리하려고 해요. Next.js에서는 [getStaticProps](https://nextjs.org/docs/basic-features/data-fetching/get-static-props)라는 기능을 제공하는데, 이를 활용하면 데이터를 페이지를 빌드할 때 가져와서 미리 집어넣을 수 있어요. 따라서 이 PR에서는 클라이언트에서 멤버의 정보를 가져오지 않고, 빌드 타임에 가져와 미리 집어 넣음으로써 로딩 속도를 최적화 하고 있어요.

이 방식을 사용했을 때, 데이터가 변경되면 매번 새로 빌드하고 배포해야 정보가 반영된다는 단점이 있어요. 그러나 메이커스에 소속된 멤버들의 정보는 아주 가끔 바뀌고, 그마저도 현재 구조 상 멤버 정보를 변경하면 어차피 새로 빌드하고 배포해야 해요. 따라서 이 단점을 상쇄할 수 있어요. 또한 멤버들의 프로필 사진, 기수, 직장 정보가 바뀌었을 때 바로 반영이 안된다는 단점이 있어요. 그러나 이 상황이 자주 일어나지도 않고, 만약 그렇다고 해도 슬랙으로 메이커스 멤버의 요청을 받아 바로 다시 빌드할 수 있기 때문에 충분히 감수할 수 있다고 판단했어요.

### 🤔 그렇다면, 어떻게 구현했어요~?

getStaticProps로 빌드 타임에 서버에서 부가적인 멤버 정보를 가져온 다음에, 페이지의 prop 으로 넘겨주고 있어요. 그리고 `MakersMembers` 컴포넌트에서 이 정보를 Map에 저장한 다음 사용하고 있어요.

### ❤️‍🔥 당신이 생각하는 PR포인트, 내겐 매력포인트.


### 📸 스크린샷, 없으면 이것 참,, 섭섭한데요?
