### PR TITLE
feat: 프로젝트 정보에서 WithMemberMetadata 걷어내기

### DIFF
--- a/api/projects/type.ts
+++ b/api/projects/type.ts
@@ -36,6 +36,8 @@ export type ProjectMember = {
   isTeamMember: boolean;
   memberName: string;
   memberGeneration: number;
+  memberProfileImage: string | null;
+  memberGenerations: number[];
 };
 
 export const LINK_TITLES = ['website', 'googlePlay', 'appStore', 'github', 'instagram', 'media'] as const;

--- a/components/projects/main/ProjectDetail.tsx
+++ b/components/projects/main/ProjectDetail.tsx
@@ -9,7 +9,6 @@ import { MemberRole, ProjectMember } from '@/api/projects/type';
 import { useGetMemberOfMe } from '@/apiHooks';
 import ConfirmModal from '@/components/common/Modal/Confirm';
 import MemberBlock from '@/components/members/common/MemberBlock';
-import WithMemberMetadata from '@/components/members/common/WithMemberMetadata';
 import { getLinkInfo } from '@/components/projects/upload/constants';
 import useGetProjectListQuery from '@/components/projects/upload/hooks/useGetProjectListQuery';
 import useGetProjectQuery from '@/components/projects/upload/hooks/useGetProjectQuery';
@@ -112,29 +111,23 @@ const ProjectDetail: FC<ProjectDetailProps> = ({ projectId }) => {
           </UserInfoWrapper>
           <UserList>
             <UserNameList>
-              {sortedMembers.map((member) => (
-                <WithMemberMetadata
-                  key={member.memberId}
-                  memberId={member.memberId}
-                  render={(metadata) => {
-                    const badges = [];
-                    if (metadata && metadata.generations.length > 0) {
-                      badges.push(metadata.generations.map(String).join(', ') + '기');
-                    }
+              {sortedMembers.map((member) => {
+                const badges = [];
+                if (member.memberGenerations.length > 0) {
+                  badges.push(member.memberGenerations.map(String).join(', ') + '기');
+                }
 
-                    return (
-                      <Link href={playgroundLink.memberDetail(member.memberId)}>
-                        <MemberBlock
-                          name={member.memberName}
-                          position={MemberRoleInfo[member.memberRole]}
-                          imageUrl={metadata?.profileImage}
-                          badges={badges}
-                        />
-                      </Link>
-                    );
-                  }}
-                />
-              ))}
+                return (
+                  <Link key={member.memberId} href={playgroundLink.memberDetail(member.memberId)}>
+                    <MemberBlock
+                      name={member.memberName}
+                      position={MemberRoleInfo[member.memberRole]}
+                      imageUrl={member.memberProfileImage ?? undefined}
+                      badges={badges}
+                    />
+                  </Link>
+                );
+              })}
             </UserNameList>
           </UserList>
         </UserWrapper>


### PR DESCRIPTION
### 🤫 쉿, 나한테만 말해줘요. 이슈넘버
- close #362 

### 🧐 어떤 것을 변경했어요~?

프로젝트 정보에 유저 정보 API가 추가됨에 따라, 기존에 임시로 사용하던 `WithMemberMetadata` 컴포넌트를 사용하던 부분을 삭제해요.

### 🤔 그렇다면, 어떻게 구현했어요~?

### ❤️‍🔥 당신이 생각하는 PR포인트, 내겐 매력포인트.

### 📸 스크린샷, 없으면 이것 참,, 섭섭한데요?
