### PR TITLE
fix: 모바일 프로필 사진 오류

### DIFF
--- a/components/common/Header/mobile/MobileSideBar.tsx
+++ b/components/common/Header/mobile/MobileSideBar.tsx
@@ -135,6 +135,7 @@ const Content = styled.div`
   background-color: ${colors.black80};
   width: 212px;
   height: 100vh;
+  overflow-y: auto;
   animation: content-show 0.3s cubic-bezier(0.16, 1, 0.3, 1);
 
   @keyframes content-show {
@@ -163,6 +164,7 @@ const ProfileImageSlot = styled.div`
   background-color: ${colors.black60};
   width: 42px;
   height: 42px;
+  overflow: hidden;
 `;
 
 const ProfileNameSlot = styled.div`


### PR DESCRIPTION
### 🤫 쉿, 나한테만 말해줘요. 이슈넘버


### 🧐 어떤 것을 변경했어요~?
모바일에서 사이드바 프로필 이미지가 넘치게 나오던 현상을 수정해요.

### 🤔 그렇다면, 어떻게 구현했어요~?

### ❤️‍🔥 당신이 생각하는 PR포인트, 내겐 매력포인트.

### 📸 스크린샷, 없으면 이것 참,, 섭섭한데요?

![image](https://user-images.githubusercontent.com/36122585/215260119-b96b73c6-4577-4e9a-9533-67c9bf9f558b.png)

-> 

![image](https://user-images.githubusercontent.com/36122585/215260137-abfb1df1-9d7f-4b80-a48c-4c17802b5f9a.png)
