### PR TITLE
fix: 인증 화면 여백 수정

### DIFF
--- a/components/auth/register/Stepper.tsx
+++ b/components/auth/register/Stepper.tsx
@@ -3,14 +3,16 @@ import { FC } from 'react';
 
 import { colors } from '@/styles/colors';
 import { MOBILE_MEDIA_QUERY } from '@/styles/mediaQuery';
+import { textStyles } from '@/styles/typography';
 
 interface StepperProps {
   step: 1 | 2;
+  className?: string;
 }
 
-const Stepper: FC<StepperProps> = ({ step }) => {
+const Stepper: FC<StepperProps> = ({ step, className }) => {
   return (
-    <Container>
+    <Container className={className}>
       <Circle isProceeding>
         1<div>SOPT 회원인증</div>
       </Circle>
@@ -26,14 +28,13 @@ export default Stepper;
 
 const Container = styled.div`
   display: flex;
-  position: absolute;
-  top: 64px;
   align-items: center;
-  font-size: 15px;
-  font-weight: 700;
+  height: 100px;
+
+  ${textStyles.SUIT_16_B};
+
   @media ${MOBILE_MEDIA_QUERY} {
-    top: 40px;
-    font-size: 11px;
+    ${textStyles.SUIT_12_B};
   }
 `;
 

--- a/components/auth/register/VerifyByEmail.tsx
+++ b/components/auth/register/VerifyByEmail.tsx
@@ -42,7 +42,7 @@ const VerifyByEmail: FC = () => {
 
   return (
     <FormContainer onSubmit={handleSend}>
-      <Stepper step={1} />
+      <StyledStepper step={1} />
       <Title>SOPT 회원인증</Title>
       <Description>SOPT 지원시 입력했던 이메일을 입력해주세요</Description>
       <Label>이메일</Label>
@@ -87,6 +87,10 @@ const FormContainer = styled.form`
   @media ${MOBILE_MEDIA_QUERY} {
     padding: 0 24px;
   }
+`;
+
+const StyledStepper = styled(Stepper)`
+  margin-bottom: 50px;
 `;
 
 const Title = styled.h2`

--- a/components/layout/FullScreenLayout.stories.tsx
+++ b/components/layout/FullScreenLayout.stories.tsx
@@ -1,0 +1,15 @@
+import { ComponentMeta, ComponentStory } from '@storybook/react';
+
+import FullScreenLayout from '@/components/layout/FullScreenLayout';
+
+export default {
+  components: FullScreenLayout,
+} as ComponentMeta<typeof FullScreenLayout>;
+
+const Template: ComponentStory<typeof FullScreenLayout> = (args) => <FullScreenLayout {...args} />;
+
+export const Default = Template.bind({});
+Default.args = {
+  children: <div style={{ backgroundColor: '#7d7d7d', textAlign: 'center', height: '100%' }}>Page Content</div>,
+};
+Default.storyName = '기본';

--- a/components/layout/FullScreenLayout.tsx
+++ b/components/layout/FullScreenLayout.tsx
@@ -1,0 +1,16 @@
+import styled from '@emotion/styled';
+import { FC, ReactNode } from 'react';
+
+interface FullScreenLayoutProps {
+  children: ReactNode;
+}
+
+const FullScreenLayout: FC<FullScreenLayoutProps> = ({ children }) => {
+  return <StyledFullScreenLayout>{children}</StyledFullScreenLayout>;
+};
+
+export default FullScreenLayout;
+
+const StyledFullScreenLayout = styled.div`
+  height: 100vh;
+`;

--- a/components/layout/index.tsx
+++ b/components/layout/index.tsx
@@ -1,4 +1,5 @@
 import EmptyLayout from '@/components/layout/EmptyLayout';
+import FullScreenLayout from '@/components/layout/FullScreenLayout';
 import HeaderFooterLayout from '@/components/layout/HeaderFooterLayout';
 import HeaderLayout from '@/components/layout/HeaderLayout';
 
@@ -6,4 +7,5 @@ export const preDefinedLayouts = {
   header: HeaderLayout,
   empty: EmptyLayout,
   headerFooter: HeaderFooterLayout,
+  fullScreen: FullScreenLayout,
 };

--- a/pages/auth/login.tsx
+++ b/pages/auth/login.tsx
@@ -50,14 +50,14 @@ const LoginPage: FC = () => {
 
 export default LoginPage;
 
-setLayout(LoginPage, 'empty');
+setLayout(LoginPage, 'fullScreen');
 
 export const StyledLoginPage = styled.div`
   display: flex;
   flex-direction: column;
   align-items: center;
   justify-content: space-around;
-  min-height: 100%;
+  height: 100%;
 
   @media ${MOBILE_MEDIA_QUERY} {
     padding: 0 20px;

--- a/pages/auth/register-finished.tsx
+++ b/pages/auth/register-finished.tsx
@@ -12,7 +12,7 @@ export const RegisterSuccessPage: FC = () => {
   );
 };
 
-setLayout(RegisterSuccessPage, 'empty');
+setLayout(RegisterSuccessPage, 'fullScreen');
 
 export default RegisterSuccessPage;
 
@@ -20,5 +20,5 @@ const StyledRegisterSuccessPage = styled.div`
   display: flex;
   flex-direction: column;
   align-items: center;
-  padding-top: 200px;
+  height: 100%;
 `;

--- a/pages/auth/register.tsx
+++ b/pages/auth/register.tsx
@@ -33,7 +33,7 @@ export const RegisterPage: FC = () => {
   );
 };
 
-setLayout(RegisterPage, 'empty');
+setLayout(RegisterPage, 'fullScreen');
 
 export default RegisterPage;
 
@@ -41,5 +41,5 @@ const StyledRegisterPage = styled.div`
   display: flex;
   flex-direction: column;
   align-items: center;
-  padding-top: 200px;
+  height: 100%;
 `;

--- a/pages/auth/verify.tsx
+++ b/pages/auth/verify.tsx
@@ -12,7 +12,7 @@ export const VerifyPage: FC = () => {
   );
 };
 
-setLayout(VerifyPage, 'empty');
+setLayout(VerifyPage, 'fullScreen');
 
 export default VerifyPage;
 
@@ -21,5 +21,5 @@ const StyledVerifyPage = styled.div`
   flex-direction: column;
   align-items: center;
   justify-content: center;
-  min-height: 100%;
+  height: 100%;
 `;


### PR DESCRIPTION
### 🤫 쉿, 나한테만 말해줘요. 이슈넘버

인증 화면에서 컴포넌트가 위로 딱 붙는 현상을 수정해요.

### 🧐 어떤 것을 변경했어요~?

### 🤔 그렇다면, 어떻게 구현했어요~?

### ❤️‍🔥 당신이 생각하는 PR포인트, 내겐 매력포인트.

### 📸 스크린샷, 없으면 이것 참,, 섭섭한데요?
![image](https://user-images.githubusercontent.com/36122585/215264061-15c82999-313b-49df-9e05-87eb3fb30362.png)