### PR TITLE
fix: 프로필 수정 > 휴대폰 번호 수정 안되는 버그 fix

### DIFF
--- a/components/members/upload/BasicFormSection.tsx
+++ b/components/members/upload/BasicFormSection.tsx
@@ -78,7 +78,7 @@ export default function MemberBasicFormSection() {
           </StyledBirthdayInputWrapper>
         </FormItem>
         <FormItem title='연락처' errorMessage={errors.phone?.message}>
-          <StyledInput {...register('phone')} type='number' />
+          <StyledInput {...register('phone')} />
         </FormItem>
         <FormItem title='이메일' errorMessage={errors.email?.message}>
           <StyledInput {...register('email')} type='email' />


### PR DESCRIPTION
### 🤫 쉿, 나한테만 말해줘요. 이슈넘버


### 🧐 어떤 것을 변경했어요~?
<!-- 실제로 변경한 사항을 설명해주세요.-->
ㅠㅠ 휴대폰 번호 input에 https://github.com/sopt-makers/sopt-playground-frontend/pull/328 에서 넣었던 type=number를 삭제했어요

저는.. 이 설정 하면 숫자 아닌 값은 안 들어가는지 몰랐습니다 .......
`-`가 들어가야 하는데 `-` 넣으면 value가 바로 빈 값이 돼요 (UI 상으로는 문제 없어서 발견 못했습니다 ..)

참고로 프로젝트에도 하나 type=number로 했는데 거기는 `.` 하나가 들어가야 하고, 소수점 겨냥인지 `.` 하나는 들어간다고 하더라구요
그래서 문제가 없습니다 실제로 수정도 잘 돼요!


### 🤔 그렇다면, 어떻게 구현했어요~?
<!-- 실제로 구현한 로직에 대해 설명해주세요.-->

### ❤️‍🔥 당신이 생각하는 PR포인트, 내겐 매력포인트.
<!-- 해당 PR에서 논의가 필요한 사항을 적어주세요. -->

### 📸 스크린샷, 없으면 이것 참,, 섭섭한데요?
