### PR TITLE
fix: 프로필 상세 > 빈 항목일 경우 해당 영역 없애기

### DIFF
--- a/components/members/main/MemberDetail/index.tsx
+++ b/components/members/main/MemberDetail/index.tsx
@@ -55,6 +55,13 @@ const MemberDetail: FC<MemberDetailProps> = ({ memberId }) => {
     [profile?.activities],
   );
 
+  const isEmptyField = (field: unknown) => {
+    if (!field) {
+      return true;
+    }
+    return false;
+  };
+
   if (isLoading)
     return (
       <Container>
@@ -92,19 +99,23 @@ const MemberDetail: FC<MemberDetailProps> = ({ memberId }) => {
                 </NameWrapper>
                 <div className='intro'>{profile?.introduction}</div>
               </div>
-              <ContactWrapper>
-                <Link passHref href={`tel:${profile?.email}`} legacyBehavior>
-                  <div style={{ cursor: 'pointer' }}>
-                    <CallIcon />
-                    <div className='phone'>{profile?.phone}</div>
-                  </div>
-                </Link>
-                <Link passHref href={`mailto:${profile?.email}`} legacyBehavior>
-                  <div style={{ cursor: 'pointer' }}>
-                    <MailIcon />
-                    <div className='email'>{profile?.email}</div>
-                  </div>
-                </Link>
+              <ContactWrapper shouldDivide={!isEmptyField(profile?.phone) && !isEmptyField(profile?.email)}>
+                {profile?.phone && (
+                  <Link passHref href={`tel:${profile?.phone}`} legacyBehavior>
+                    <div style={{ cursor: 'pointer' }}>
+                      <CallIcon />
+                      <div className='phone'>{profile?.phone}</div>
+                    </div>
+                  </Link>
+                )}
+                {profile?.email && (
+                  <Link passHref href={`mailto:${profile?.email}`} legacyBehavior>
+                    <div style={{ cursor: 'pointer' }}>
+                      <MailIcon />
+                      <div className='email'>{profile?.email}</div>
+                    </div>
+                  </Link>
+                )}
               </ContactWrapper>
             </ProfileContents>
 
@@ -147,12 +158,13 @@ const MemberDetail: FC<MemberDetailProps> = ({ memberId }) => {
               )}
             </>
           )}
-
-          <InfoContainer style={{ gap: '30px' }}>
-            <InfoItem label='생년월일' content={convertBirthdayFormat(profile?.birthday)} />
-            <InfoItem label='사는 지역' content={profile?.address ?? ''} />
-            <InfoItem label='학교 / 전공' content={`${profile?.university ?? ''} ${profile?.major ?? ''}`} />
-          </InfoContainer>
+          {profile?.birthday && profile?.address && profile?.university && (
+            <InfoContainer style={{ gap: '30px' }}>
+              <InfoItem label='생년월일' content={convertBirthdayFormat(profile?.birthday)} />
+              <InfoItem label='사는 지역' content={profile?.address ?? ''} />
+              <InfoItem label='학교 / 전공' content={`${profile?.university ?? ''} ${profile?.major ?? ''}`} />
+            </InfoContainer>
+          )}
 
           <InfoContainer style={{ gap: '34px' }}>
             {sortedActivities.map((item, idx) => {
@@ -176,22 +188,26 @@ const MemberDetail: FC<MemberDetailProps> = ({ memberId }) => {
             </InfoContainer>
           )}
 
-          <InfoContainer style={{ gap: '30px' }}>
-            <InfoItem label='스킬' content={profile?.skill ?? ''} />
-            <InfoItem
-              label='링크'
-              content={
-                <LinkItems>
-                  {profile?.links.map((item, idx) => (
-                    <Link passHref href={item.url} key={idx} target='_blank'>
-                      <LinkIcon />
-                      <span>{item.title}</span>
-                    </Link>
-                  ))}
-                </LinkItems>
-              }
-            />
-          </InfoContainer>
+          {profile?.skill && profile?.links.length > 0 && (
+            <InfoContainer style={{ gap: '30px' }}>
+              {profile?.skill && <InfoItem label='스킬' content={profile?.skill ?? ''} />}
+              {profile?.links.length > 0 && (
+                <InfoItem
+                  label='링크'
+                  content={
+                    <LinkItems>
+                      {profile?.links.map((item, idx) => (
+                        <Link passHref href={item.url} key={idx} target='_blank'>
+                          <LinkIcon />
+                          <span>{item.title}</span>
+                        </Link>
+                      ))}
+                    </LinkItems>
+                  }
+                />
+              )}
+            </InfoContainer>
+          )}
 
           <ProjectContainer>
             <ProjectTitle>{profile?.name}님이 참여한 프로젝트</ProjectTitle>
@@ -344,7 +360,7 @@ const NameWrapper = styled.div`
   }
 `;
 
-const ContactWrapper = styled.div`
+const ContactWrapper = styled.div<{ shouldDivide: boolean }>`
   display: flex;
   line-height: 100%;
   color: #808388;
@@ -362,7 +378,7 @@ const ContactWrapper = styled.div`
   .phone {
     box-sizing: border-box;
     margin-right: 13px;
-    border-right: 1.5px solid #3c3d40;
+    border-right: ${({ shouldDivide }) => (shouldDivide ? '1.5px solid #3c3d40' : 'none')};
     padding-right: 17px;
     @media ${MOBILE_MEDIA_QUERY} {
       margin: 0;

--- a/components/members/main/MemberDetail/index.tsx
+++ b/components/members/main/MemberDetail/index.tsx
@@ -151,7 +151,7 @@ const MemberDetail: FC<MemberDetailProps> = ({ memberId }) => {
               )}
             </>
           )}
-          {profile?.birthday && profile?.address && profile?.university && (
+          {(profile?.birthday || profile?.address || profile?.university) && (
             <InfoContainer style={{ gap: '30px' }}>
               <InfoItem label='생년월일' content={convertBirthdayFormat(profile?.birthday)} />
               <InfoItem label='사는 지역' content={profile?.address ?? ''} />
@@ -181,7 +181,7 @@ const MemberDetail: FC<MemberDetailProps> = ({ memberId }) => {
             </InfoContainer>
           )}
 
-          {profile?.skill && profile?.links.length > 0 && (
+          {(profile?.skill || (profile?.links && profile.links.length > 0)) && (
             <InfoContainer style={{ gap: '30px' }}>
               {profile?.skill && <InfoItem label='스킬' content={profile?.skill ?? ''} />}
               {profile?.links.length > 0 && (

--- a/components/members/main/MemberDetail/index.tsx
+++ b/components/members/main/MemberDetail/index.tsx
@@ -55,13 +55,6 @@ const MemberDetail: FC<MemberDetailProps> = ({ memberId }) => {
     [profile?.activities],
   );
 
-  const isEmptyField = (field: unknown) => {
-    if (!field) {
-      return true;
-    }
-    return false;
-  };
-
   if (isLoading)
     return (
       <Container>
@@ -99,7 +92,7 @@ const MemberDetail: FC<MemberDetailProps> = ({ memberId }) => {
                 </NameWrapper>
                 <div className='intro'>{profile?.introduction}</div>
               </div>
-              <ContactWrapper shouldDivide={!isEmptyField(profile?.phone) && !isEmptyField(profile?.email)}>
+              <ContactWrapper shouldDivide={!!profile?.phone && !!profile?.email}>
                 {profile?.phone && (
                   <Link passHref href={`tel:${profile?.phone}`} legacyBehavior>
                     <div style={{ cursor: 'pointer' }}>


### PR DESCRIPTION
### 🤫 쉿, 나한테만 말해줘요. 이슈넘버
- close #388

### 🧐 어떤 것을 변경했어요~?
<!-- 실제로 변경한 사항을 설명해주세요.-->
프로필 상세페이지에서 빈 항목일 경우 해당 영역이 보이지 않도록 했어요.

- 빈 항목일 경우 라벨 숨기기
- 섹션 전체가 빈 항목일 경우 섹션 자체를 삭제하기
- 전화번호와 이메일 사이 디바이더 둘 중 하나라도 빈 값이면 보이지 않도록 하기

### 🤔 그렇다면, 어떻게 구현했어요~?
<!-- 실제로 구현한 로직에 대해 설명해주세요.-->
- 열심히 &&로 조건부렌더링 해주었어요. 그런데 중복 코드가 많아지고 코드가 좀 더러워져서 추후에 infoContainer와 infoItem을 활용해 빈 항목일 경우 숨기는 로직은 컴포넌트 내부로 숨기도록 리팩토링 하면 좋을 것 같아요.

### ❤️‍🔥 당신이 생각하는 PR포인트, 내겐 매력포인트.
<!-- 해당 PR에서 논의가 필요한 사항을 적어주세요. -->

### 📸 스크린샷, 없으면 이것 참,, 섭섭한데요?
<img width="1437" alt="image" src="https://user-images.githubusercontent.com/73823388/215539002-9514aee0-f2de-428a-9d5b-7b089170fe61.png">
