### PR TITLE
fix: 프로필 상세 > 프로젝트 카드 이미지 비율 깨지지 않도록

### DIFF
--- a/components/members/detail/MemberProjectCard.tsx
+++ b/components/members/detail/MemberProjectCard.tsx
@@ -118,6 +118,7 @@ const StyledThumbnail = styled.img`
   border-radius: 24px 24px 0 0;
   width: 100%;
   height: 100%;
+  object-fit: cover;
   @media ${MOBILE_MEDIA_QUERY} {
     border-radius: 20px 20px 0 0;
   }


### PR DESCRIPTION
### 🤫 쉿, 나한테만 말해줘요. 이슈넘버
- close #418 

### 🧐 어떤 것을 변경했어요~?
<!-- 실제로 변경한 사항을 설명해주세요.-->
프로필 상세 > 프로젝트 카드 이미지 스타일 변경

### 🤔 그렇다면, 어떻게 구현했어요~?
<!-- 실제로 구현한 로직에 대해 설명해주세요.-->
object-fit: cover 추가

### ❤️‍🔥 당신이 생각하는 PR포인트, 내겐 매력포인트.
<!-- 해당 PR에서 논의가 필요한 사항을 적어주세요. -->

### 📸 스크린샷, 없으면 이것 참,, 섭섭한데요?

before

<img width="487" alt="image" src="https://user-images.githubusercontent.com/73823388/215694090-d71c2d9e-c3c6-45dc-907a-b13d4ba69b72.png">

after

<img width="535" alt="image" src="https://user-images.githubusercontent.com/73823388/215694155-f6c21684-722d-490a-834d-4296966138d7.png">
