### PR TITLE
fix: 모바일 접속시 깜빡임 수정

### DIFF
--- a/components/common/Banner/RecruitingBanner/index.tsx
+++ b/components/common/Banner/RecruitingBanner/index.tsx
@@ -6,8 +6,7 @@ import { useState } from 'react';
 import { DEADLINE_DATE, RECRUITING_LINK, TERM } from '@/components/common/Banner/RecruitingBanner/contants';
 import CountdownTimer from '@/components/common/Banner/RecruitingBanner/CountdownTimer';
 import MobileRecruitingBanner from '@/components/common/Banner/RecruitingBanner/MobileRecruitingBanner';
-import useMediaQuery from '@/hooks/useMediaQuery';
-import { MOBILE_MAX_WIDTH } from '@/styles/mediaQuery';
+import Responsive from '@/components/common/Responsive';
 import { textStyles } from '@/styles/typography';
 
 interface RecruitingBannerProps {
@@ -16,33 +15,33 @@ interface RecruitingBannerProps {
 
 export default function RecruitingBanner({ className }: RecruitingBannerProps) {
   const [isRecruiting, setIsRecruiting] = useState(DEADLINE_DATE.getTime() - new Date().getTime() > 0);
-  const isMobile = useMediaQuery(MOBILE_MAX_WIDTH);
 
   const finishCountdown = () => {
     setIsRecruiting(false);
   };
 
-  if (isMobile) {
-    return (
-      <Link href={RECRUITING_LINK} target='_blank' className={className}>
-        <MobileRecruitingBanner />
-      </Link>
-    );
-  }
-
   return (
-    <Link href={RECRUITING_LINK} target='_blank' className={className}>
-      <Container>
-        <RecruitmentText>{`🚀 makers ${TERM}기를 모집해요`}</RecruitmentText>
-        <Deadline isRecruiting={isRecruiting}>
-          {isRecruiting ? (
-            <CountdownTimer deadlineDate={DEADLINE_DATE} finish={finishCountdown} />
-          ) : (
-            '☑️ 현재 모집이 마감되었습니다'
-          )}
-        </Deadline>
-      </Container>
-    </Link>
+    <>
+      <Responsive only='mobile'>
+        <Link href={RECRUITING_LINK} target='_blank' className={className}>
+          <MobileRecruitingBanner />
+        </Link>
+      </Responsive>
+      <Responsive only='desktop'>
+        <Link href={RECRUITING_LINK} target='_blank' className={className}>
+          <Container>
+            <RecruitmentText>{`🚀 makers ${TERM}기를 모집해요`}</RecruitmentText>
+            <Deadline isRecruiting={isRecruiting}>
+              {isRecruiting ? (
+                <CountdownTimer deadlineDate={DEADLINE_DATE} finish={finishCountdown} />
+              ) : (
+                '☑️ 현재 모집이 마감되었습니다'
+              )}
+            </Deadline>
+          </Container>
+        </Link>
+      </Responsive>
+    </>
   );
 }
 

--- a/components/common/Banner/RecruitingBanner/index.tsx
+++ b/components/common/Banner/RecruitingBanner/index.tsx
@@ -22,12 +22,12 @@ export default function RecruitingBanner({ className }: RecruitingBannerProps) {
 
   return (
     <>
-      <Responsive only='mobile'>
+      <Responsive only='mobile' asChild>
         <Link href={RECRUITING_LINK} target='_blank' className={className}>
           <MobileRecruitingBanner />
         </Link>
       </Responsive>
-      <Responsive only='desktop'>
+      <Responsive only='desktop' asChild>
         <Link href={RECRUITING_LINK} target='_blank' className={className}>
           <Container>
             <RecruitmentText>{`🚀 makers ${TERM}기를 모집해요`}</RecruitmentText>

--- a/components/common/Header/index.tsx
+++ b/components/common/Header/index.tsx
@@ -7,12 +7,10 @@ import useAuth from '@/components/auth/useAuth';
 import DesktopHeader from '@/components/common/Header/desktop/DesktopHeader';
 import MobileHeader from '@/components/common/Header/mobile/MobileHeader';
 import { LinkRenderer } from '@/components/common/Header/types';
+import Responsive from '@/components/common/Responsive';
 import { playgroundLink } from '@/constants/links';
-import useMediaQuery from '@/hooks/useMediaQuery';
-import { MOBILE_MAX_WIDTH } from '@/styles/mediaQuery';
 
 const Header: FC = () => {
-  const isMobile = useMediaQuery(MOBILE_MAX_WIDTH);
   const router = useRouter();
   const { logout } = useAuth();
 
@@ -28,10 +26,15 @@ const Header: FC = () => {
   };
   const activePathMatcher = (path: string) => router.pathname?.startsWith(path);
 
-  return isMobile ? (
-    <MobileHeader user={user} onLogout={logout} renderLink={renderLink} activePathMatcher={activePathMatcher} />
-  ) : (
-    <DesktopHeader user={user} onLogout={logout} renderLink={renderLink} activePathMatcher={activePathMatcher} />
+  return (
+    <>
+      <Responsive only='mobile'>
+        <MobileHeader user={user} onLogout={logout} renderLink={renderLink} activePathMatcher={activePathMatcher} />
+      </Responsive>
+      <Responsive only='desktop'>
+        <DesktopHeader user={user} onLogout={logout} renderLink={renderLink} activePathMatcher={activePathMatcher} />
+      </Responsive>
+    </>
   );
 };
 

--- a/components/common/Responsive/Responsive.stories.tsx
+++ b/components/common/Responsive/Responsive.stories.tsx
@@ -1,18 +1,31 @@
-import styled from '@emotion/styled';
 import { ComponentMeta, ComponentStory } from '@storybook/react';
 
 import Responsive from '@/components/common/Responsive/Responsive';
+import ResponsiveProvider from '@/components/common/Responsive/ResponsiveProvider';
 
 export default {
   component: Responsive,
+  decorators: [
+    (Story) => {
+      return (
+        <ResponsiveProvider>
+          <Story />
+        </ResponsiveProvider>
+      );
+    },
+  ],
 } as ComponentMeta<typeof Responsive>;
 
 const Template: ComponentStory<typeof Responsive> = (args) => <Responsive {...args} />;
 
-const X = styled.a``;
-
-export const Basic = Template.bind({});
-Basic.args = {
-  children: <a className='AAAA'>AAAA</a>,
+export const Desktop = Template.bind({});
+Desktop.args = {
+  children: 'Only Desktop',
+  only: 'desktop',
 };
-Basic.storyName = '기본';
+
+export const Mobile = Template.bind({});
+Mobile.args = {
+  children: 'Only Mobile',
+  only: 'mobile',
+};

--- a/components/common/Responsive/Responsive.stories.tsx
+++ b/components/common/Responsive/Responsive.stories.tsx
@@ -1,0 +1,18 @@
+import styled from '@emotion/styled';
+import { ComponentMeta, ComponentStory } from '@storybook/react';
+
+import Responsive from '@/components/common/Responsive/Responsive';
+
+export default {
+  component: Responsive,
+} as ComponentMeta<typeof Responsive>;
+
+const Template: ComponentStory<typeof Responsive> = (args) => <Responsive {...args} />;
+
+const X = styled.a``;
+
+export const Basic = Template.bind({});
+Basic.args = {
+  children: <a className='AAAA'>AAAA</a>,
+};
+Basic.storyName = '기본';

--- a/components/common/Responsive/Responsive.tsx
+++ b/components/common/Responsive/Responsive.tsx
@@ -1,0 +1,24 @@
+import { FC, ReactNode, useContext } from 'react';
+
+import { ResponsiveContext } from '@/components/common/Responsive/context';
+
+interface ResponsiveProps {
+  children: ReactNode;
+  only: 'mobile' | 'desktop';
+}
+
+const Responsive: FC<ResponsiveProps> = ({ children, only }) => {
+  const { mobileOnlyClassName, desktopOnlyClassName } = useContext(ResponsiveContext);
+
+  const selectedClassName = (() => {
+    if (only === 'desktop') {
+      return desktopOnlyClassName;
+    } else if (only === 'mobile') {
+      return mobileOnlyClassName;
+    }
+  })();
+
+  return <div className={selectedClassName}>{children}</div>;
+};
+
+export default Responsive;

--- a/components/common/Responsive/Responsive.tsx
+++ b/components/common/Responsive/Responsive.tsx
@@ -1,11 +1,14 @@
-import { FC, ReactNode, useContext } from 'react';
+import { FC, ReactNode, startTransition, useContext, useEffect, useState } from 'react';
 
 import { ResponsiveContext } from '@/components/common/Responsive/context';
+import { MOBILE_MEDIA_QUERY } from '@/styles/mediaQuery';
 
 interface ResponsiveProps {
   children: ReactNode;
-  only: 'mobile' | 'desktop';
+  only: AvailableSize;
 }
+
+type AvailableSize = 'mobile' | 'desktop';
 
 const Responsive: FC<ResponsiveProps> = ({ children, only }) => {
   const { mobileOnlyClassName, desktopOnlyClassName } = useContext(ResponsiveContext);
@@ -18,7 +21,29 @@ const Responsive: FC<ResponsiveProps> = ({ children, only }) => {
     }
   })();
 
-  return <div className={selectedClassName}>{children}</div>;
+  const [current, setCurrent] = useState<AvailableSize | null>(null);
+  useEffect(() => {
+    const mobileMedia = window.matchMedia(MOBILE_MEDIA_QUERY);
+
+    const handleChange = (e: MediaQueryListEvent) => {
+      setCurrent(e.matches ? 'mobile' : 'desktop');
+    };
+
+    mobileMedia.addEventListener('change', handleChange);
+
+    // 초기 렌더링후 비활성 컴포넌트 언마운트는 천천히 해도 되므로 startTransition 으로 렌더링 우선순위 낮추기
+    startTransition(() => {
+      if (mobileMedia.matches) {
+        setCurrent('mobile');
+      } else {
+        setCurrent('desktop');
+      }
+    });
+
+    return () => mobileMedia.removeEventListener('change', handleChange);
+  }, []);
+
+  return current === null || only === current ? <div className={selectedClassName}>{children}</div> : <></>;
 };
 
 export default Responsive;

--- a/components/common/Responsive/Responsive.tsx
+++ b/components/common/Responsive/Responsive.tsx
@@ -6,11 +6,12 @@ import { MOBILE_MEDIA_QUERY } from '@/styles/mediaQuery';
 interface ResponsiveProps {
   children: ReactNode;
   only: AvailableSize;
+  forceMount?: boolean;
 }
 
 type AvailableSize = 'mobile' | 'desktop';
 
-const Responsive: FC<ResponsiveProps> = ({ children, only }) => {
+const Responsive: FC<ResponsiveProps> = ({ children, only, forceMount = false }) => {
   const { mobileOnlyClassName, desktopOnlyClassName } = useContext(ResponsiveContext);
 
   const selectedClassName = (() => {
@@ -43,7 +44,11 @@ const Responsive: FC<ResponsiveProps> = ({ children, only }) => {
     return () => mobileMedia.removeEventListener('change', handleChange);
   }, []);
 
-  return current === null || only === current ? <div className={selectedClassName}>{children}</div> : <></>;
+  return forceMount || current === null || only === current ? (
+    <div className={selectedClassName}>{children}</div>
+  ) : (
+    <></>
+  );
 };
 
 export default Responsive;

--- a/components/common/Responsive/Responsive.tsx
+++ b/components/common/Responsive/Responsive.tsx
@@ -4,6 +4,7 @@ import { ResponsiveContext } from '@/components/common/Responsive/context';
 import { MOBILE_MEDIA_QUERY } from '@/styles/mediaQuery';
 
 interface ResponsiveProps {
+  className?: string;
   children: ReactNode;
   only: AvailableSize;
   forceMount?: boolean;
@@ -11,7 +12,7 @@ interface ResponsiveProps {
 
 type AvailableSize = 'mobile' | 'desktop';
 
-const Responsive: FC<ResponsiveProps> = ({ children, only, forceMount = false }) => {
+const Responsive: FC<ResponsiveProps> = ({ className, children, only, forceMount = false }) => {
   const { mobileOnlyClassName, desktopOnlyClassName } = useContext(ResponsiveContext);
 
   const selectedClassName = (() => {
@@ -49,7 +50,7 @@ const Responsive: FC<ResponsiveProps> = ({ children, only, forceMount = false })
   }, [forceMount]);
 
   return forceMount || current === null || only === current ? (
-    <div className={selectedClassName}>{children}</div>
+    <div className={`${selectedClassName} ${className}`}>{children}</div>
   ) : (
     <></>
   );

--- a/components/common/Responsive/Responsive.tsx
+++ b/components/common/Responsive/Responsive.tsx
@@ -1,3 +1,4 @@
+import { Slot } from '@radix-ui/react-slot';
 import { FC, ReactNode, startTransition, useContext, useEffect, useState } from 'react';
 
 import { ResponsiveContext } from '@/components/common/Responsive/context';
@@ -8,11 +9,14 @@ interface ResponsiveProps {
   children: ReactNode;
   only: AvailableSize;
   forceMount?: boolean;
+  asChild?: boolean;
 }
 
 type AvailableSize = 'mobile' | 'desktop';
 
-const Responsive: FC<ResponsiveProps> = ({ className, children, only, forceMount = false }) => {
+const Responsive: FC<ResponsiveProps> = ({ className = '', children, only, asChild, forceMount = false }) => {
+  const Comp = asChild ? Slot : 'div';
+
   const { mobileOnlyClassName, desktopOnlyClassName } = useContext(ResponsiveContext);
 
   const selectedClassName = (() => {
@@ -50,7 +54,7 @@ const Responsive: FC<ResponsiveProps> = ({ className, children, only, forceMount
   }, [forceMount]);
 
   return forceMount || current === null || only === current ? (
-    <div className={`${selectedClassName} ${className}`}>{children}</div>
+    <Comp className={`${selectedClassName} ${className}`}>{children}</Comp>
   ) : (
     <></>
   );

--- a/components/common/Responsive/Responsive.tsx
+++ b/components/common/Responsive/Responsive.tsx
@@ -24,6 +24,10 @@ const Responsive: FC<ResponsiveProps> = ({ children, only, forceMount = false })
 
   const [current, setCurrent] = useState<AvailableSize | null>(null);
   useEffect(() => {
+    if (forceMount) {
+      return;
+    }
+
     const mobileMedia = window.matchMedia(MOBILE_MEDIA_QUERY);
 
     const handleChange = (e: MediaQueryListEvent) => {
@@ -42,7 +46,7 @@ const Responsive: FC<ResponsiveProps> = ({ children, only, forceMount = false })
     });
 
     return () => mobileMedia.removeEventListener('change', handleChange);
-  }, []);
+  }, [forceMount]);
 
   return forceMount || current === null || only === current ? (
     <div className={selectedClassName}>{children}</div>

--- a/components/common/Responsive/ResponsiveProvider.tsx
+++ b/components/common/Responsive/ResponsiveProvider.tsx
@@ -1,0 +1,44 @@
+import { css, Global } from '@emotion/react';
+import { FC, ReactNode } from 'react';
+
+import { ResponsiveContext } from '@/components/common/Responsive/context';
+import { MOBILE_MEDIA_QUERY } from '@/styles/mediaQuery';
+
+interface ResponsiveProviderProps {
+  children: ReactNode;
+  classNamePrefix?: string;
+}
+
+const ResponsiveProvider: FC<ResponsiveProviderProps> = ({ children, classNamePrefix = 'responsive' }) => {
+  const mobileOnlyClassName = `${classNamePrefix}-mobile-only`;
+  const desktopOnlyClassName = `${classNamePrefix}-pc-only`;
+
+  return (
+    <ResponsiveContext.Provider value={{ mobileOnlyClassName, desktopOnlyClassName }}>
+      <Global
+        styles={css`
+          .${mobileOnlyClassName} {
+            display: none !important;
+          }
+
+          .${desktopOnlyClassName} {
+            display: block !important;
+          }
+
+          @media ${MOBILE_MEDIA_QUERY} {
+            .${mobileOnlyClassName} {
+              display: block !important;
+            }
+
+            .${desktopOnlyClassName} {
+              display: none !important;
+            }
+          }
+        `}
+      />
+      {children}
+    </ResponsiveContext.Provider>
+  );
+};
+
+export default ResponsiveProvider;

--- a/components/common/Responsive/ResponsiveProvider.tsx
+++ b/components/common/Responsive/ResponsiveProvider.tsx
@@ -11,7 +11,7 @@ interface ResponsiveProviderProps {
 
 const ResponsiveProvider: FC<ResponsiveProviderProps> = ({ children, classNamePrefix = 'responsive' }) => {
   const mobileOnlyClassName = `${classNamePrefix}-mobile-only`;
-  const desktopOnlyClassName = `${classNamePrefix}-pc-only`;
+  const desktopOnlyClassName = `${classNamePrefix}-desktop-only`;
 
   return (
     <ResponsiveContext.Provider value={{ mobileOnlyClassName, desktopOnlyClassName }}>

--- a/components/common/Responsive/context.ts
+++ b/components/common/Responsive/context.ts
@@ -1,0 +1,14 @@
+import { createContext } from 'react';
+
+interface ResponsiveContextValue {
+  mobileOnlyClassName: string;
+  desktopOnlyClassName: string;
+}
+
+export const ResponsiveContext = createContext<ResponsiveContextValue>(
+  new Proxy({} as ResponsiveContextValue, {
+    get() {
+      throw new Error('ResponsiveProvider가 필요합니다.');
+    },
+  }),
+);

--- a/components/common/Responsive/index.tsx
+++ b/components/common/Responsive/index.tsx
@@ -1,0 +1,3 @@
+import Responsive from '@/components/common/Responsive/Responsive';
+
+export default Responsive;

--- a/components/layout/HeaderFooterLayout.tsx
+++ b/components/layout/HeaderFooterLayout.tsx
@@ -4,16 +4,14 @@ import { RemoveScroll } from 'react-remove-scroll';
 
 import Footer from '@/components/common/Footer';
 import Header from '@/components/common/Header';
-import useMediaQuery from '@/hooks/useMediaQuery';
-import { MOBILE_MAX_WIDTH, MOBILE_MEDIA_QUERY } from '@/styles/mediaQuery';
+import Responsive from '@/components/common/Responsive';
+import { MOBILE_MEDIA_QUERY } from '@/styles/mediaQuery';
 
 interface HeaderLayoutProps {
   children: ReactNode;
 }
 
 const HeaderFooterLayout: FC<HeaderLayoutProps> = ({ children }) => {
-  const isMobile = useMediaQuery(MOBILE_MAX_WIDTH);
-
   return (
     <>
       {/* 드롭다운 시 화면 밀림 방지용 클래스 추가. see: https://github.com/radix-ui/primitives/discussions/1100 */}
@@ -21,7 +19,9 @@ const HeaderFooterLayout: FC<HeaderLayoutProps> = ({ children }) => {
         <Header />
       </FixedSlot>
       <StyledContainer>{children}</StyledContainer>
-      {!isMobile && <Footer />}
+      <Responsive only='desktop'>
+        <Footer />
+      </Responsive>
     </>
   );
 };

--- a/hooks/useMediaQuery.ts
+++ b/hooks/useMediaQuery.ts
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useState } from 'react';
 
+/** @deprecated @components/common/Responsive를 대신 사용하세요. 모바일에서 초기 접속시 데스크톱 뷰가 잠깐 노출되는 문제가 있어요. */
 const useMediaQuery = (width: number) => {
   const [targetReached, setTargetReached] = useState(false);
 

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "@radix-ui/react-collapsible": "^1.0.1",
     "@radix-ui/react-dialog": "^1.0.2",
     "@radix-ui/react-dropdown-menu": "^2.0.2",
+    "@radix-ui/react-slot": "^1.0.1",
     "@radix-ui/react-tabs": "^1.0.2",
     "@types/react-datepicker": "^4.8.0",
     "@typescript-eslint/eslint-plugin": "^5.38.1",

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -7,6 +7,7 @@ import { useEffect } from 'react';
 import { QueryClient, QueryClientProvider } from 'react-query';
 import { RecoilRoot } from 'recoil';
 
+import ResponsiveProvider from '@/components/common/Responsive/ResponsiveProvider';
 import ToastProvider from '@/components/common/Toast/providers/ToastProvider';
 import AmplitudeProvider from '@/components/eventLogger/providers/AmplitudeProvider';
 import * as gtm from '@/components/googleTagManager/gtm';
@@ -48,11 +49,11 @@ function MyApp({ Component, pageProps }: AppProps) {
         <RecoilRoot>
           <ToastProvider>
             <GlobalStyle />
-            <>
+            <ResponsiveProvider>
               <Layout>
                 <Component {...pageProps} />
               </Layout>
-            </>
+            </ResponsiveProvider>
             {DEBUG && <Debugger />}
           </ToastProvider>
         </RecoilRoot>

--- a/yarn.lock
+++ b/yarn.lock
@@ -3920,7 +3920,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@radix-ui/react-slot@npm:1.0.1":
+"@radix-ui/react-slot@npm:1.0.1, @radix-ui/react-slot@npm:^1.0.1":
   version: 1.0.1
   resolution: "@radix-ui/react-slot@npm:1.0.1"
   dependencies:
@@ -19045,6 +19045,7 @@ __metadata:
     "@radix-ui/react-collapsible": ^1.0.1
     "@radix-ui/react-dialog": ^1.0.2
     "@radix-ui/react-dropdown-menu": ^2.0.2
+    "@radix-ui/react-slot": ^1.0.1
     "@radix-ui/react-tabs": ^1.0.2
     "@storybook/addon-actions": ^6.5.5
     "@storybook/addon-docs": ^6.5.5


### PR DESCRIPTION
### 🤫 쉿, 나한테만 말해줘요. 이슈넘버


### 🧐 어떤 것을 변경했어요~?

기존에 모바일에서 새로고침 하거나 접속하면 데스크톱에서만 보여야 할 컴포넌트가 잠깐 노출되는 문제가 있었어요.

![Feb-04-2023 03-26-11](https://user-images.githubusercontent.com/36122585/216679303-73f0ddf0-8bc7-419e-a0a7-045c12d38eae.gif)

원인은 `useMediaQuery` 훅이었는데요, 이 훅은 useEffect에서 현재 화면 사이즈를 검사한 뒤 boolean 값을 반환하는 함수에요. 그런데 이 부분이 SSR/SSG 환경인 Next.js에서 문제가 되었어요. 서버 사이드에서는 useEffect를 실행시키지 않기 때문에 `useMediaQuery` 훅의 반환값은 항상 false 에요. 따라서 만약 `isMobile = useMediaQuery(...)` 형태로 사용했을 시, 페이지에 처음 접속 시엔 항상 데스크톱 화면의 컴포넌트가 먼저 렌더링돼요. 그래서 클라이언트에서 hydration이 일어나고 useEffect가 실행되고 변경된 state로 다시 렌더링 할 때 까지 데스크톱 화면의 컴포넌트가 노출돼요.

그런데 서버에서는 (당연히) 브라우저 화면 크기 정보가 없기 때문에 무엇을 먼저 렌더링 해 놓을지 판단할 수 없어요. 따라서 이를 해결하기 위해서는 서버 사이드에서 모든 화면에 대한 컴포넌트를 미리 렌더링 시켜놓을 필요가 있어요. 그리고 적절한 CSS 미디어 쿼리를 해당 렌더링된 두 버전의 컴포넌트에 적용해놓으면, 초기 렌더링시 유저 눈에는 알맞는 버전의 컴포넌트만 보일거에요.
그래서 이 동작을 구현하는 `Responsive` 컴포넌트를 만들었어요.

그런데 여전히 실제로는 두 버전의 컴포넌트가 DOM 트리에 존재해요. 하나는 필요 없기 때문에 useEffect가 실행될 때 다시 제거해 주면 돼요. 이때 안쓰는 컴포넌트를 제거하는 부분은 빨리 할 필요가 없기 때문에 (어차피 보이지 않으므로) React 18의 `startTransition` 함수를 사용해 느긋하게 진행해요.
만약 보이지 않는 버전의 컴포넌트를 제거하고 싶지 않으면 `forceMount` 프롭을 사용하면 돼요.

### 🤔 그렇다면, 어떻게 구현했어요~?

- ResponseProvider 컴포넌트를 구현했어요.
  - 미디어 쿼리가 포함된 CSS를 정의하고, Context로 className들을 전달해요.
- Response 컴포넌트를 구현했어요.
  - ResponseProvider의 className들을 가져와서 적용해요.
  - useEffect에서 현재 화면 크기를 감지하고, 적절하게 언마운트해요.

### ❤️‍🔥 당신이 생각하는 PR포인트, 내겐 매력포인트.


### 📸 스크린샷, 없으면 이것 참,, 섭섭한데요?

![Feb-04-2023 03-38-14](https://user-images.githubusercontent.com/36122585/216681370-76c67b54-fa14-47a0-878c-ecf57f44ed93.gif)
