### PR TITLE
fix: 메이커스 멤버 정보 데이터 최적화

### DIFF
--- a/pages/makers/index.tsx
+++ b/pages/makers/index.tsx
@@ -8,6 +8,7 @@ import Footer from '@/components/common/Footer';
 import SwitchableHeader from '@/components/common/Header/SwitchableHeader';
 import AboutMakers from '@/components/makers/AboutMakers';
 import { makersGenerationsData } from '@/components/makers/data';
+import { MakersPerson } from '@/components/makers/data/types';
 import MakersMembers from '@/components/makers/MakersMembers';
 import { MOBILE_MEDIA_QUERY } from '@/styles/mediaQuery';
 import { setLayout } from '@/utils/layout';
@@ -34,7 +35,19 @@ const MakersPage: FC<MakersPageProps> = ({ memberMetadataList }) => {
 export const getStaticProps: GetStaticProps<MakersPageProps> = async () => {
   const memberList = await getMemberProfile('');
 
-  const memberMetadataList = memberList.map((member) => {
+  const idSet = new Set(
+    makersGenerationsData.flatMap((gen) =>
+      gen.teams.flatMap((team) =>
+        team.people
+          .filter((person): person is MakersPerson & { type: 'member' } => person.type === 'member')
+          .map((person) => person.id),
+      ),
+    ),
+  );
+
+  const filteredMemberList = memberList.filter((member) => idSet.has(member.id));
+
+  const memberMetadataList = filteredMemberList.map((member) => {
     const sortedCareers = member.careers.filter((career) => career.isCurrent);
     sortedCareers.sort((a, b) => new Date(a.startDate).getTime() - new Date(b.startDate).getTime());
     const currentCompany = sortedCareers.length > 0 ? sortedCareers.at(-1)?.companyName ?? null : null;


### PR DESCRIPTION
### 🤫 쉿, 나한테만 말해줘요. 이슈넘버


### 🧐 어떤 것을 변경했어요~?

기존에 메이커스 멤버의 정보를 빌드 시점에 가져와서 메이커스 소개 페이지를 SSG하고 있었어요. 그런데 이 과정에서 의도치 않게 모든 멤버의 목록을 가져와 페이지의 용량을 증가시키는 문제가 있어 이를 해결했어요.

### 🤔 그렇다면, 어떻게 구현했어요~?

prop에 멤버 정보를 넘기기 전에, 메이커스 멤버들의 정보만 필터링한 후 전달해요.

### ❤️‍🔥 당신이 생각하는 PR포인트, 내겐 매력포인트.

### 📸 스크린샷, 없으면 이것 참,, 섭섭한데요?
