### PR TITLE
fix: 다이나믹 라우트 버그 수정

### DIFF
--- a/functions/members/[id].ts
+++ b/functions/members/[id].ts
@@ -1,6 +1,10 @@
 // /members/[id] 주소로 직접 접근 시 /members/[id].html 로 보내기
 export const onRequest: PagesFunction = async (context) => {
-  const { next } = context;
+  const { next, params } = context;
 
-  return next('/members/[id]');
+  if (/\d+/.test(`${params.id}`)) {
+    return next('/members/[id]');
+  }
+
+  return next();
 };

--- a/functions/projects/[id].ts
+++ b/functions/projects/[id].ts
@@ -1,6 +1,10 @@
 // /projects/[id] 주소로 직접 접근 시 /projects/[id].html 로 보내기
 export const onRequest: PagesFunction = async (context) => {
-  const { next } = context;
+  const { next, params } = context;
 
-  return next('/projects/[id]');
+  if (/\d+/.test(`${params.id}`)) {
+    return next('/projects/[id]');
+  }
+
+  return next();
 };

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,13 +1,21 @@
 {
   "compilerOptions": {
     "target": "ESNext",
-    "lib": ["dom", "dom.iterable", "esnext"],
+    "lib": [
+      "dom",
+      "dom.iterable",
+      "esnext"
+    ],
     "allowJs": true,
     "baseUrl": ".",
     "paths": {
-      "@/*": ["./*"]
+      "@/*": [
+        "./*"
+      ]
     },
-    "types": ["jest"],
+    "types": [
+      "jest"
+    ],
     "skipLibCheck": true,
     "strict": true,
     "forceConsistentCasingInFileNames": true,
@@ -16,11 +24,19 @@
     "module": "esnext",
     "moduleResolution": "node",
     "resolveJsonModule": true,
-    "isolatedModules": false,
+    "isolatedModules": true,
     "incremental": true,
     "jsx": "preserve",
     "jsxImportSource": "@emotion/react"
   },
-  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
-  "exclude": ["node_modules", "functions/**/*", "worker/**/*"]
+  "include": [
+    "next-env.d.ts",
+    "**/*.ts",
+    "**/*.tsx"
+  ],
+  "exclude": [
+    "node_modules",
+    "functions/**/*",
+    "worker/**/*"
+  ]
 }


### PR DESCRIPTION
### 🤫 쉿, 나한테만 말해줘요. 이슈넘버
- close #455

### 🧐 어떤 것을 변경했어요~?

#440 에서 한 작업에 약간의 버그가 있었어요. projects/* 에 대한 경로를 모두 projects/[id].html 로 보내주도록 했는데, projects/upload 경로가 있을 수 있다는 것을 생각하지 못했어요. 따라서 projects/ 뒤에 오는 param 이 숫자 문자열 일때만 projects/[id].html 로 보내주도록 변경했어요. members 에 대해서도 동일해요.

### 🤔 그렇다면, 어떻게 구현했어요~?


### ❤️‍🔥 당신이 생각하는 PR포인트, 내겐 매력포인트.


### 📸 스크린샷, 없으면 이것 참,, 섭섭한데요?
