### PR TITLE
refactor: Amplitude 지연 로딩

### DIFF
--- a/components/eventLogger/providers/AmplitudeProvider.tsx
+++ b/components/eventLogger/providers/AmplitudeProvider.tsx
@@ -1,7 +1,6 @@
-import { FC, ReactNode, useMemo } from 'react';
+import { FC, ReactNode, useEffect, useState } from 'react';
 
 import { EventLoggerContext } from '@/components/eventLogger/context';
-import { createAmplitudeController } from '@/components/eventLogger/controllers/amplitude';
 import { createConsoleLogController } from '@/components/eventLogger/controllers/consoleLog';
 
 interface EventLoggerProviderProps {
@@ -10,11 +9,15 @@ interface EventLoggerProviderProps {
 }
 
 const AmplitudeProvider: FC<EventLoggerProviderProps> = ({ children, apiKey }) => {
-  const controller = useMemo(() => {
+  const [controller, setController] = useState(createConsoleLogController());
+
+  useEffect(() => {
     if (!apiKey) {
-      return createConsoleLogController();
+      return;
     }
-    return createAmplitudeController(apiKey);
+    import('@/components/eventLogger/controllers/amplitude').then(({ createAmplitudeController }) => {
+      setController(() => createAmplitudeController(apiKey));
+    });
   }, [apiKey]);
 
   return <EventLoggerContext.Provider value={controller}>{children}</EventLoggerContext.Provider>;

--- a/components/eventLogger/providers/AmplitudeProvider.tsx
+++ b/components/eventLogger/providers/AmplitudeProvider.tsx
@@ -13,6 +13,7 @@ const AmplitudeProvider: FC<EventLoggerProviderProps> = ({ children, apiKey }) =
 
   useEffect(() => {
     if (!apiKey) {
+      setController(createConsoleLogController());
       return;
     }
     import('@/components/eventLogger/controllers/amplitude').then(({ createAmplitudeController }) => {


### PR DESCRIPTION
### 🤫 쉿, 나한테만 말해줘요. 이슈넘버
- close #458 

### 🧐 어떤 것을 변경했어요~?

초기 JS 번들에 불필요하게 들어있던 Amplitude 를 Lazy Load 되도록 변경했어요. 그 결과, 초기 JS 크기를 21KB 줄일 수 있었어요.

### 🤔 그렇다면, 어떻게 구현했어요~?

AmplitudeProvider 에서 실제 amplitude 모듈을 await import 구문을 사용해서, 클라이언트 타이밍에 로드해요.

### ❤️‍🔥 당신이 생각하는 PR포인트, 내겐 매력포인트.


### 📸 스크린샷, 없으면 이것 참,, 섭섭한데요?
**Before**
<img width="393" alt="image" src="https://user-images.githubusercontent.com/36122585/220252080-f54e33fc-b356-49a9-b058-7b7f6fe77db6.png">
<img width="1078" alt="image" src="https://user-images.githubusercontent.com/36122585/220252350-4a12afa0-02d1-47d3-bbe2-8394e7fc4cde.png">

**After**
<img width="377" alt="image" src="https://user-images.githubusercontent.com/36122585/220252126-da20f222-2bfc-4871-a5bb-f9bed0a430b8.png">

<img width="1016" alt="image" src="https://user-images.githubusercontent.com/36122585/220252382-a5e927b9-76ef-4982-b365-a2ba96091499.png">
