### PR TITLE
fix: 무한 스크롤 버그 수정

### DIFF
--- a/components/members/main/MemberList/index.tsx
+++ b/components/members/main/MemberList/index.tsx
@@ -219,4 +219,6 @@ const StyledMemberRoleDropdown = styled(MemberRoleDropdown)`
   max-width: 505px;
 `;
 
-const Target = styled.div``;
+const Target = styled.div`
+  height: 40px;
+`;


### PR DESCRIPTION
### 🤫 쉿, 나한테만 말해줘요. 이슈넘버


### 🧐 어떤 것을 변경했어요~?

무한 스크롤이 안되는 버그를 긴급 수정했어요.

### 🤔 그렇다면, 어떻게 구현했어요~?

이전 PR의 스크롤을 항상 보이게 하는 코드때문에 화면 내림을 감지하는 div가 화면 밖으로 넘어가버리는 문제가 발생했어요. 이를 해결하기 위해 감지 div의 높이를 키웠어요.

### ❤️‍🔥 당신이 생각하는 PR포인트, 내겐 매력포인트.

### 📸 스크린샷, 없으면 이것 참,, 섭섭한데요?
