### PR TITLE
refactor: GenerationForm 리팩토링

### DIFF
--- a/components/projects/form/ProjectForm.tsx
+++ b/components/projects/form/ProjectForm.tsx
@@ -61,27 +61,26 @@ const ProjectForm: FC<ProjectFormProps> = ({
           />
         </FormEntry>
         <FormEntry title='기수' required>
-            <Controller
-                control={control}
-                name='generation'
-                render={({ field }) => (
-                    <GenerationField {...field} isError={!!errors.generation} errorMessage={errors.generation?.message} />
-                )}
-            />
-      </FormEntry>
-      <FormEntry title='기수' required>
-        <Controller
-          control={control}
-          name='generation'
-          render={({ field }) => <GenerationField {...field} errorMessage={errors.generation?.message} />}
-        />
-      </FormEntry>
-      <SubmitContainer>
-        <Button type='submit' variant='primary'>
-          {submitButtonContent}
-        </Button>
-      </SubmitContainer>
-    </StyledForm>
+          <Controller
+            control={control}
+            name='generation'
+            render={({ field }) => <GenerationField {...field} errorMessage={errors.generation?.message} />}
+          />
+        </FormEntry>
+        <FormEntry title='기수' required>
+          <Controller
+            control={control}
+            name='generation'
+            render={({ field }) => <GenerationField {...field} errorMessage={errors.generation?.message} />}
+          />
+        </FormEntry>
+        <SubmitContainer>
+          <Button type='submit' variant='primary'>
+            {submitButtonContent}
+          </Button>
+        </SubmitContainer>
+      </StyledForm>
+    </StyledFormContainer>
   );
 };
 

--- a/components/projects/form/ProjectForm.tsx
+++ b/components/projects/form/ProjectForm.tsx
@@ -5,6 +5,7 @@ import { Controller, useForm } from 'react-hook-form';
 
 import Button from '@/components/common/Button';
 import Input from '@/components/common/Input';
+import GenerationField from '@/components/projects/form/fields/GenerationField';
 import PeriodField from '@/components/projects/form/fields/PeriodField';
 import FormEntry from '@/components/projects/form/presenter/FormEntry';
 import { defaultUploadValues, ProjectFormType, uploadSchema } from '@/components/projects/form/schema';
@@ -59,13 +60,22 @@ const ProjectForm: FC<ProjectFormProps> = ({
             )}
           />
         </FormEntry>
+        <FormEntry title='기수' required>
+            <Controller
+                control={control}
+                name='generation'
+                render={({ field }) => (
+                    <GenerationField {...field} isError={!!errors.generation} errorMessage={errors.generation?.message} />
+                )}
+            />
+      </FormEntry>
         <SubmitContainer>
           <Button type='submit' variant='primary'>
             {submitButtonContent}
           </Button>
         </SubmitContainer>
       </StyledForm>
-    </StyledFormContainer>
+    </StyledFormContainer
   );
 };
 

--- a/components/projects/form/ProjectForm.tsx
+++ b/components/projects/form/ProjectForm.tsx
@@ -69,13 +69,19 @@ const ProjectForm: FC<ProjectFormProps> = ({
                 )}
             />
       </FormEntry>
-        <SubmitContainer>
-          <Button type='submit' variant='primary'>
-            {submitButtonContent}
-          </Button>
-        </SubmitContainer>
-      </StyledForm>
-    </StyledFormContainer
+      <FormEntry title='기수' required>
+        <Controller
+          control={control}
+          name='generation'
+          render={({ field }) => <GenerationField {...field} errorMessage={errors.generation?.message} />}
+        />
+      </FormEntry>
+      <SubmitContainer>
+        <Button type='submit' variant='primary'>
+          {submitButtonContent}
+        </Button>
+      </SubmitContainer>
+    </StyledForm>
   );
 };
 

--- a/components/projects/form/fields/GenerationField.stories.tsx
+++ b/components/projects/form/fields/GenerationField.stories.tsx
@@ -1,0 +1,21 @@
+import { ComponentMeta, ComponentStory } from '@storybook/react';
+import { useState } from 'react';
+
+import GenerationField from './GenerationField';
+
+export default {
+  component: GenerationField,
+  decorators: [],
+} as ComponentMeta<typeof GenerationField>;
+
+const Template: ComponentStory<typeof GenerationField> = (args) => <GenerationField {...args} />;
+
+export const Default = Template.bind({});
+Default.args = {};
+Default.storyName = '기본';
+
+export const WithState: ComponentStory<typeof GenerationField> = (args) => {
+  const [value, setValue] = useState<string>('');
+
+  return <GenerationField value={value} onChange={setValue} />;
+};

--- a/components/projects/form/fields/GenerationField.stories.tsx
+++ b/components/projects/form/fields/GenerationField.stories.tsx
@@ -17,5 +17,5 @@ Default.storyName = '기본';
 export const WithState: ComponentStory<typeof GenerationField> = (args) => {
   const [value, setValue] = useState<string | null>(null);
 
-  return <GenerationField value={value} onChange={setValue} />;
+  return <GenerationField {...args} value={value} onChange={setValue} />;
 };

--- a/components/projects/form/fields/GenerationField.stories.tsx
+++ b/components/projects/form/fields/GenerationField.stories.tsx
@@ -15,7 +15,7 @@ Default.args = {};
 Default.storyName = '기본';
 
 export const WithState: ComponentStory<typeof GenerationField> = (args) => {
-  const [value, setValue] = useState<string>('');
+  const [value, setValue] = useState<string | null>(null);
 
   return <GenerationField value={value} onChange={setValue} />;
 };

--- a/components/projects/form/fields/GenerationField.tsx
+++ b/components/projects/form/fields/GenerationField.tsx
@@ -17,8 +17,8 @@ interface GenerationFieldProps {
 }
 
 const GenerationField: FC<GenerationFieldProps> = ({ value, onChange, errorMessage }) => {
-  const handleCheckboxChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    onChange(e.target.checked ? null : value);
+  const handleCheckboxChange = () => {
+    onChange(null);
   };
 
   return (

--- a/components/projects/form/fields/GenerationField.tsx
+++ b/components/projects/form/fields/GenerationField.tsx
@@ -1,7 +1,5 @@
 import styled from '@emotion/styled';
 import React, { FC } from 'react';
-import { useState } from 'react';
-import { useEffect } from 'react';
 
 import Checkbox from '@/components/common/Checkbox';
 import ErrorMessage from '@/components/common/Input/ErrorMessage';

--- a/components/projects/form/fields/GenerationField.tsx
+++ b/components/projects/form/fields/GenerationField.tsx
@@ -1,5 +1,7 @@
 import styled from '@emotion/styled';
-import React, { FC, useState } from 'react';
+import React, { FC } from 'react';
+import { useState } from 'react';
+import { useEffect } from 'react';
 
 import Checkbox from '@/components/common/Checkbox';
 import ErrorMessage from '@/components/common/Input/ErrorMessage';
@@ -11,38 +13,20 @@ import { MOBILE_MEDIA_QUERY } from '@/styles/mediaQuery';
 import { textStyles } from '@/styles/typography';
 
 interface GenerationFieldProps {
-  value: string;
-  onChange: (value: string) => void;
-  isError?: boolean;
+  value: string | null;
+  onChange: (value: string | null) => void;
   errorMessage?: string;
 }
 
-const GenerationField: FC<GenerationFieldProps> = ({ value, onChange, isError, errorMessage }) => {
-  const [checked, setChecked] = useState<boolean>(!!value);
-
-  const handleGenerationChange = (generation: string) => {
-    if (generation) {
-      setChecked(false);
-    }
-    onChange(generation);
-  };
-
-  const handleCheckedChange = (checked: boolean) => {
-    if (checked) {
-      onChange('');
-    }
-    setChecked(checked);
+const GenerationField: FC<GenerationFieldProps> = ({ value, onChange, errorMessage }) => {
+  const handleCheckboxChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    onChange(e.target.checked ? null : value);
   };
 
   return (
     <StyledGenerationField>
       <StyledDescription>참여한 팀원들의 기수에 맞춰 작성해주세요</StyledDescription>
-      <StyledSelect
-        width={236}
-        placeholder='선택'
-        value={value}
-        onChange={(e) => handleGenerationChange(e.target.value)}
-      >
+      <StyledSelect width={236} placeholder='선택' value={value ?? ''} onChange={(e) => onChange(e.target.value)}>
         {GENERATIONS.map((item) => (
           <option key={item} value={item}>
             {item}기
@@ -50,12 +34,12 @@ const GenerationField: FC<GenerationFieldProps> = ({ value, onChange, isError, e
         ))}
       </StyledSelect>
       <StyledCheckboxWrapper>
-        <Checkbox checked={checked} onChange={(e) => handleCheckedChange(e.target.checked)} />
+        <Checkbox checked={value === null} onChange={handleCheckboxChange} />
         <Text typography='SUIT_12_M' color={colors.gray100}>
           특정 기수 활동으로 진행하지 않았어요
         </Text>
       </StyledCheckboxWrapper>
-      {isError && <StyledErrorMessage message={errorMessage} />}
+      <StyledErrorMessage message={errorMessage} />
     </StyledGenerationField>
   );
 };

--- a/components/projects/form/fields/GenerationField.tsx
+++ b/components/projects/form/fields/GenerationField.tsx
@@ -5,20 +5,30 @@ import Checkbox from '@/components/common/Checkbox';
 import ErrorMessage from '@/components/common/Input/ErrorMessage';
 import Select from '@/components/common/Select';
 import Text from '@/components/common/Text';
-import { GENERATIONS } from '@/constants/generation';
+import { GENERATIONS, LATEST_GENERATION } from '@/constants/generation';
 import { colors } from '@/styles/colors';
 import { MOBILE_MEDIA_QUERY } from '@/styles/mediaQuery';
 import { textStyles } from '@/styles/typography';
 
 interface GenerationFieldProps {
   value: string | null;
+  defaultValue?: string;
   onChange: (value: string | null) => void;
   errorMessage?: string;
 }
 
-const GenerationField: FC<GenerationFieldProps> = ({ value, onChange, errorMessage }) => {
+const GenerationField: FC<GenerationFieldProps> = ({
+  value,
+  defaultValue = String(LATEST_GENERATION),
+  onChange,
+  errorMessage,
+}) => {
   const handleCheckboxChange = () => {
-    onChange(null);
+    if (value === null) {
+      onChange(defaultValue);
+    } else {
+      onChange(null);
+    }
   };
 
   return (

--- a/components/projects/form/fields/GenerationField.tsx
+++ b/components/projects/form/fields/GenerationField.tsx
@@ -1,0 +1,95 @@
+import styled from '@emotion/styled';
+import React, { FC, useState } from 'react';
+
+import Checkbox from '@/components/common/Checkbox';
+import ErrorMessage from '@/components/common/Input/ErrorMessage';
+import Select from '@/components/common/Select';
+import Text from '@/components/common/Text';
+import { GENERATIONS } from '@/constants/generation';
+import { colors } from '@/styles/colors';
+import { MOBILE_MEDIA_QUERY } from '@/styles/mediaQuery';
+import { textStyles } from '@/styles/typography';
+
+interface GenerationFieldProps {
+  value: string;
+  onChange: (value: string) => void;
+  isError?: boolean;
+  errorMessage?: string;
+}
+
+const GenerationField: FC<GenerationFieldProps> = ({ value, onChange, isError, errorMessage }) => {
+  const [checked, setChecked] = useState<boolean>(!!value);
+
+  const handleGenerationChange = (generation: string) => {
+    if (generation) {
+      setChecked(false);
+    }
+    onChange(generation);
+  };
+
+  const handleCheckedChange = (checked: boolean) => {
+    if (checked) {
+      onChange('');
+    }
+    setChecked(checked);
+  };
+
+  return (
+    <StyledGenerationField>
+      <StyledDescription>참여한 팀원들의 기수에 맞춰 작성해주세요</StyledDescription>
+      <StyledSelect
+        width={236}
+        placeholder='선택'
+        value={value}
+        onChange={(e) => handleGenerationChange(e.target.value)}
+      >
+        {GENERATIONS.map((item) => (
+          <option key={item} value={item}>
+            {item}기
+          </option>
+        ))}
+      </StyledSelect>
+      <StyledCheckboxWrapper>
+        <Checkbox checked={checked} onChange={(e) => handleCheckedChange(e.target.checked)} />
+        <Text typography='SUIT_12_M' color={colors.gray100}>
+          특정 기수 활동으로 진행하지 않았어요
+        </Text>
+      </StyledCheckboxWrapper>
+      {isError && <StyledErrorMessage message={errorMessage} />}
+    </StyledGenerationField>
+  );
+};
+
+export default GenerationField;
+
+const StyledGenerationField = styled.div`
+  display: flex;
+  flex-direction: column;
+`;
+
+const StyledDescription = styled(Text)`
+  margin: 12px 0 18px;
+  color: ${colors.gray100};
+  ${textStyles.SUIT_14_M};
+`;
+
+const StyledSelect = styled(Select)`
+  width: 236px;
+
+  @media ${MOBILE_MEDIA_QUERY} {
+    ${textStyles.SUIT_14_M}
+
+    width: 160px;
+  }
+`;
+
+const StyledCheckboxWrapper = styled.div`
+  display: flex;
+  align-items: center;
+  column-gap: 10px;
+  margin: 13px 0;
+`;
+
+const StyledErrorMessage = styled(ErrorMessage)`
+  margin: 10px 0;
+`;

--- a/components/projects/form/schema.ts
+++ b/components/projects/form/schema.ts
@@ -4,6 +4,7 @@ export const dateStringSchema = z.string().regex(/^\d{4}.(0[1-9]|1[0-2])/g, '날
 
 export const uploadSchema = z.object({
   name: z.string().min(1, '프로젝트 이름을 입력해주세요.'),
+  generation: z.string().min(1, '기수를 입력해주세요.'),
   period: z.object({
     startAt: dateStringSchema,
     endAt: dateStringSchema.nullable(),
@@ -14,6 +15,7 @@ export type ProjectFormType = z.infer<typeof uploadSchema>;
 
 export const defaultUploadValues: ProjectFormType = {
   name: '',
+  generation: '',
   period: {
     startAt: '',
     endAt: '',


### PR DESCRIPTION
### 🤫 쉿, 나한테만 말해줘요. 이슈넘버
- close #

### 🧐 어떤 것을 변경했어요~?
<!-- 실제로 변경한 사항을 설명해주세요.-->
- 기수 폼을 추가했어요!
- 기존엔 `generation`, `checked`를 프로퍼티로 가진 object로 검사했지만, `string` 타입의 `generation` 을 받도록 간단하게 변경했어요.
- `Select` 컴포넌트의 기본 값은 `''` 빈 스트링을 줘야 하기 때문에 (https://developer.mozilla.org/ko/docs/Web/HTML/Element/select) `generation`을 **선택 안함** 상태로 초기화 해주기 위해 string 타입으로 두었고, 서버로 전송할 땐 기존처럼 `number | undefined` 타입으로 변환해서 보낼거에요.

### 🤔 그렇다면, 어떻게 구현했어요~?
<!-- 실제로 구현한 로직에 대해 설명해주세요.-->

### ❤️‍🔥 당신이 생각하는 PR포인트, 내겐 매력포인트.
<!-- 해당 PR에서 논의가 필요한 사항을 적어주세요. -->

### 📸 스크린샷, 없으면 이것 참,, 섭섭한데요?
