### PR TITLE
fix: 모바일 헤더 프로필 이미지 수정

### DIFF
--- a/components/common/Header/mobile/MobileSideBar.tsx
+++ b/components/common/Header/mobile/MobileSideBar.tsx
@@ -186,6 +186,11 @@ const ProfileImageSlot = styled.div`
   width: 42px;
   height: 42px;
   overflow: hidden;
+
+  & > img {
+    object-fit: cover;
+    width: 100%;
+  }
 `;
 
 const ProfileNameSlot = styled.div`


### PR DESCRIPTION
### 🤫 쉿, 나한테만 말해줘요. 이슈넘버
- close #477

### 🧐 어떤 것을 변경했어요~?

모임 페이지에서 모바일 헤더 프로필 사진이 이상하게 나오는 오류를 해결했어요.

**AS-IS**
<img width="234" alt="image" src="https://user-images.githubusercontent.com/36122585/224539861-2cc22a93-edc8-427a-8cca-5458620eca6a.png">

**TO-BE**
<img width="236" alt="image" src="https://user-images.githubusercontent.com/36122585/224539879-5f33cede-3b34-463a-afa4-067ced7d6edb.png">


### 🤔 그렇다면, 어떻게 구현했어요~?

### ❤️‍🔥 당신이 생각하는 PR포인트, 내겐 매력포인트.

### 📸 스크린샷, 없으면 이것 참,, 섭섭한데요?
