### PR TITLE
refactor: 프로필 업로드와 디테일 타입 의존성 분리

### DIFF
--- a/components/members/detail/ActivityBadge.tsx
+++ b/components/members/detail/ActivityBadge.tsx
@@ -3,7 +3,7 @@ import { FC, useEffect, useState } from 'react';
 
 import { Activity } from '@/api/members/type';
 import { getProjectById } from '@/api/projects';
-import { categoryLabel } from '@/components/projects/upload/constants';
+import { PROJECT_CATEGORY_LABEL } from '@/components/members/detail/constants';
 import { MOBILE_MEDIA_QUERY } from '@/styles/mediaQuery';
 import { textStyles } from '@/styles/typography';
 
@@ -14,7 +14,7 @@ const ActivityBadge: FC<Activity> = (activity) => {
     const getProjectCategory = async () => {
       if (activity.isProject) {
         const project = await getProjectById(activity.id.toString());
-        setCategory(categoryLabel[project.category]);
+        setCategory(PROJECT_CATEGORY_LABEL[project.category]);
       }
     };
 

--- a/components/members/detail/CareerItem.tsx
+++ b/components/members/detail/CareerItem.tsx
@@ -2,7 +2,7 @@ import styled from '@emotion/styled';
 import dayjs from 'dayjs';
 import { FC } from 'react';
 
-import { Career } from '@/components/members/upload/types';
+import { Career } from '@/components/members/detail/types';
 import { colors } from '@/styles/colors';
 import { MOBILE_MEDIA_QUERY } from '@/styles/mediaQuery';
 import { textStyles } from '@/styles/typography';

--- a/components/members/detail/MemberProjectCard.tsx
+++ b/components/members/detail/MemberProjectCard.tsx
@@ -3,7 +3,7 @@ import Link from 'next/link';
 import { FC } from 'react';
 
 import { MemberProject } from '@/api/members/type';
-import { categoryLabel } from '@/components/projects/upload/constants';
+import { PROJECT_CATEGORY_LABEL } from '@/components/members/detail/constants';
 import { playgroundLink } from '@/constants/links';
 import { colors } from '@/styles/colors';
 import { MOBILE_MEDIA_QUERY } from '@/styles/mediaQuery';
@@ -38,7 +38,7 @@ const MemberProjectCard: FC<MemberProject> = ({
           <StyledTitleWrapper>
             <Title>{name}</Title>
             <Generation>
-              {generation ? `${generation}기 ${categoryLabel[category]}` : categoryLabel[category]}
+              {generation ? `${generation}기 ${PROJECT_CATEGORY_LABEL[category]}` : PROJECT_CATEGORY_LABEL[category]}
             </Generation>
           </StyledTitleWrapper>
           <Summary>{summary}</Summary>

--- a/components/members/detail/constants.ts
+++ b/components/members/detail/constants.ts
@@ -1,0 +1,10 @@
+import { ProjectCategory } from '@/components/members/detail/types';
+
+export const PROJECT_CATEGORY_LABEL: Record<ProjectCategory, string> = {
+  APPJAM: '앱잼',
+  SOPKATHON: '솝커톤',
+  SOPTERM: '솝텀 프로젝트',
+  STUDY: '스터디',
+  JOINTSEMINAR: '합동 세미나',
+  ETC: '기타',
+};

--- a/components/members/detail/types.ts
+++ b/components/members/detail/types.ts
@@ -1,0 +1,9 @@
+export type ProjectCategory = 'APPJAM' | 'SOPKATHON' | 'SOPTERM' | 'STUDY' | 'JOINTSEMINAR' | 'ETC';
+
+export interface Career {
+  companyName: string;
+  title: string;
+  startDate: string;
+  endDate: string | null;
+  isCurrent: boolean;
+}


### PR DESCRIPTION
### 🤫 쉿, 나한테만 말해줘요. 이슈넘버
- close #494

### 🧐 어떤 것을 변경했어요~?
<!-- 실제로 변경한 사항을 설명해주세요.-->
프로필 업로드와 디테일 타입 의존성을 분리했어요

### 🤔 그렇다면, 어떻게 구현했어요~?
<!-- 실제로 구현한 로직에 대해 설명해주세요.-->
디테일 쪽에서 가져다 쓰고 있던 업로드 타입을 디테일 폴더 내부에 재선언 했습니다

### ❤️‍🔥 당신이 생각하는 PR포인트, 내겐 매력포인트.
<!-- 해당 PR에서 논의가 필요한 사항을 적어주세요. -->

아무래도 api 타입 의존성까지 해결해야 저희가 원하는 완벽히 관심사가 분리되어 변경 용이한 구조를 가질 수 있을 것 같네요 ㅠ!!

해당 작업 하면서 types.ts 파일이 복잡해지면 types/index.ts, types/project.ts 이런 식으로 프로젝트 타입과 프로필 디테일 자체의 타입을 분리해 선언하면 좋을 것 같습니당

### 📸 스크린샷, 없으면 이것 참,, 섭섭한데요?
