### PR TITLE
fix: 업로드 페이지에서 수정 로직 분리 덜 된 작업 추가

### DIFF
--- a/components/members/upload/BasicFormSection.tsx
+++ b/components/members/upload/BasicFormSection.tsx
@@ -1,14 +1,12 @@
 import styled from '@emotion/styled';
 import { Controller, useFormContext } from 'react-hook-form';
 
-import { useGetMemberProfileOfMe } from '@/api/hooks';
 import ImageUploader from '@/components/common/ImageUploader';
 import Input from '@/components/common/Input';
 import FormHeader from '@/components/members/upload/forms/FormHeader';
 import FormItem from '@/components/members/upload/forms/FormItem';
 import { MemberFormSection as FormSection } from '@/components/members/upload/forms/FormSection';
 import { MemberUploadForm } from '@/components/members/upload/types';
-import useStringRouterQuery from '@/hooks/useStringRouterQuery';
 import IconCamera from '@/public/icons/icon-camera.svg';
 import { colors } from '@/styles/colors';
 import { MOBILE_MEDIA_QUERY } from '@/styles/mediaQuery';
@@ -18,12 +16,8 @@ export default function MemberBasicFormSection() {
     control,
     register,
     formState: { errors },
+    getValues,
   } = useFormContext<MemberUploadForm>();
-
-  const { query } = useStringRouterQuery(['edit'] as const);
-  const { data: myProfile } = useGetMemberProfileOfMe();
-
-  const isEditPage = query?.edit === 'true' ? true : false;
 
   const getBirthdayErrorMessage = () => {
     if (errors.birthday?.year) return errors.birthday?.year.message;
@@ -41,11 +35,7 @@ export default function MemberBasicFormSection() {
             name='profileImage'
             control={control}
             render={({ field }) => (
-              <StyledImageUploader
-                src={(isEditPage && myProfile && myProfile.profileImage) || ''}
-                {...field}
-                emptyIcon={IconCamera}
-              />
+              <StyledImageUploader src={getValues('profileImage')} {...field} emptyIcon={IconCamera} />
             )}
           />
         </FormItem>


### PR DESCRIPTION
### 🧐 어떤 것을 변경했어요~?
<!-- 실제로 변경한 사항을 설명해주세요.-->

이미지 업로더에 프리뷰가 안 뜨던 이슈 해결입니다!

### 🤔 그렇다면, 어떻게 구현했어요~?
<!-- 실제로 구현한 로직에 대해 설명해주세요.-->

isEdit(업로드 페이지에 합쳐져 있던 수정 관련 로직)의 잔재가 남아있던 것이 문제였습니다 ~

### ❤️‍🔥 당신이 생각하는 PR포인트, 내겐 매력포인트.
<!-- 해당 PR에서 논의가 필요한 사항을 적어주세요. -->

### 📸 스크린샷, 없으면 이것 참,, 섭섭한데요?
