### PR TITLE
feat: 프로필 업로드 > TMI 섹션에 '나는 어느 쪽?' 항목 추가

### DIFF
--- a/components/members/upload/TmiSection/FavorToggle.tsx
+++ b/components/members/upload/TmiSection/FavorToggle.tsx
@@ -7,7 +7,7 @@ interface FavorToggleProps<T extends string> {
   left: T;
   right: T;
   selected: T | null;
-  onSelect: (selected: T | null) => void;
+  onSelect: (value: T | null) => void;
 }
 
 export default function FavorToggle<T extends string>({ left, right, selected, onSelect }: FavorToggleProps<T>) {

--- a/components/members/upload/TmiSection/FavorToggle.tsx
+++ b/components/members/upload/TmiSection/FavorToggle.tsx
@@ -1,0 +1,52 @@
+import styled from '@emotion/styled';
+
+import { colors } from '@/styles/colors';
+import { textStyles } from '@/styles/typography';
+
+interface FavorToggleProps<T extends string> {
+  left: T;
+  right: T;
+  selected: T | null;
+  onSelect: (selected: T | null) => void;
+}
+
+export default function FavorToggle<T extends string>({ left, right, selected, onSelect }: FavorToggleProps<T>) {
+  const onClick = (target: T) => {
+    onSelect(target === selected ? null : target);
+  };
+
+  return (
+    <Container>
+      <Button onClick={() => onClick(left)} isSelected={left === selected}>
+        {left}
+      </Button>
+      <Versus>vs</Versus>
+      <Button onClick={() => onClick(right)} isSelected={right === selected}>
+        {right}
+      </Button>
+    </Container>
+  );
+}
+
+const Container = styled.div`
+  display: flex;
+  gap: 3px;
+  align-items: center;
+`;
+
+const Button = styled.button<{ isSelected: boolean }>`
+  border-radius: 13px;
+  background-color: ${({ isSelected }) => (isSelected ? colors.purple100 : colors.black60)};
+  cursor: pointer;
+  padding: 14px 0;
+  width: 122px;
+  color: ${({ isSelected }) => (isSelected ? colors.white : colors.gray80)};
+
+  ${textStyles.SUIT_16_SB}
+`;
+
+const Versus = styled.div`
+  color: ${colors.white};
+
+  ${textStyles.SUIT_16_SB};
+`;

--- a/components/members/upload/TmiSection/FavorToggle.tsx
+++ b/components/members/upload/TmiSection/FavorToggle.tsx
@@ -11,17 +11,17 @@ interface FavorToggleProps<T extends string> {
 }
 
 export default function FavorToggle<T extends string>({ left, right, selected, onSelect }: FavorToggleProps<T>) {
-  const onClick = (target: T) => {
+  const handleClick = (target: T) => {
     onSelect(target === selected ? null : target);
   };
 
   return (
     <Container>
-      <Button onClick={() => onClick(left)} isSelected={left === selected}>
+      <Button onClick={() => handleClick(left)} isSelected={left === selected}>
         {left}
       </Button>
       <Versus>vs</Versus>
-      <Button onClick={() => onClick(right)} isSelected={right === selected}>
+      <Button onClick={() => handleClick(right)} isSelected={right === selected}>
         {right}
       </Button>
     </Container>

--- a/components/members/upload/TmiSection/index.tsx
+++ b/components/members/upload/TmiSection/index.tsx
@@ -5,8 +5,17 @@ import TextArea from '@/components/common/TextArea';
 import MemberFormHeader from '@/components/members/upload/forms/FormHeader';
 import MemberFormItem from '@/components/members/upload/forms/FormItem';
 import { MemberFormSection } from '@/components/members/upload/forms/FormSection';
+import FavorToggle from '@/components/members/upload/TmiSection/FavorToggle';
 import MbtiSelector from '@/components/members/upload/TmiSection/MbtiSelector';
-import { Mbti } from '@/components/members/upload/TmiSection/types';
+import {
+  FavorAlcohol,
+  FavorFishBread,
+  FavorMintChocolate,
+  FavorPeach,
+  FavorSweetAndSourPork,
+  FavorTteokbokki,
+  Mbti,
+} from '@/components/members/upload/TmiSection/types';
 import { MemberUploadForm } from '@/components/members/upload/types';
 
 export default function TmiSection() {
@@ -45,6 +54,62 @@ export default function TmiSection() {
           <StyledTextArea placeholder='ex) 저는 극강의 EEE에요.' />
         </MbtiWrapper>
       </StyledMemberFormItem>
+      <StyledMemberFormItem title='나는 어느 쪽?'>
+        <FavorWrapper>
+          <Controller
+            control={control}
+            name='favor.sweetAndSourPork'
+            render={({ field }) => (
+              <FavorToggle<FavorSweetAndSourPork>
+                left='부먹'
+                right='찍먹'
+                selected={field.value}
+                onSelect={field.onChange}
+              />
+            )}
+          />
+          <Controller
+            control={control}
+            name='favor.peach'
+            render={({ field }) => (
+              <FavorToggle<FavorPeach> left='딱복' right='물복' selected={field.value} onSelect={field.onChange} />
+            )}
+          />
+          <Controller
+            control={control}
+            name='favor.mintChocolate'
+            render={({ field }) => (
+              <FavorToggle<FavorMintChocolate>
+                left='민초'
+                right='반민초'
+                selected={field.value}
+                onSelect={field.onChange}
+              />
+            )}
+          />
+          <Controller
+            control={control}
+            name='favor.fishBread'
+            render={({ field }) => (
+              <FavorToggle<FavorFishBread> left='팥붕' right='슈붕' selected={field.value} onSelect={field.onChange} />
+            )}
+          />
+          <Controller
+            control={control}
+            name='favor.alcohol'
+            render={({ field }) => (
+              <FavorToggle<FavorAlcohol> left='소주' right='맥주' selected={field.value} onSelect={field.onChange} />
+            )}
+          />
+          <Controller
+            control={control}
+            name='favor.tteokbokki'
+            render={({ field }) => (
+              <FavorToggle<FavorTteokbokki> left='밀떡' right='쌀떡' selected={field.value} onSelect={field.onChange} />
+            )}
+          />
+        </FavorWrapper>
+      </StyledMemberFormItem>
     </MemberFormSection>
   );
 }
@@ -65,4 +130,13 @@ const StyledTextArea = styled(TextArea)`
   padding: 14px 20px;
   width: 632px;
   height: 76px;
+`;
+
+const FavorWrapper = styled.div`
+  display: flex;
+  flex-wrap: wrap;
+  column-gap: 35px;
+  margin-top: 20px;
+  width: 593px;
+  row-gap: 14px;
 `;

--- a/components/members/upload/TmiSection/types.ts
+++ b/components/members/upload/TmiSection/types.ts
@@ -10,3 +10,10 @@ export type Mbti = [
 ];
 
 export type MbtiIndex = typeof MBTI_INDEX_LIST[number];
+
+export type FavorSweetAndSourPork = '부먹' | '찍먹';
+export type FavorMintChocolate = '민초' | '반민초';
+export type FavorAlcohol = '소주' | '맥주';
+export type FavorPeach = '딱복' | '물복';
+export type FavorFishBread = '팥붕' | '슈붕';
+export type FavorTteokbokki = '밀떡' | '쌀떡';

--- a/components/members/upload/types.ts
+++ b/components/members/upload/types.ts
@@ -1,4 +1,6 @@
-import { Mbti } from '@/components/members/upload/TmiSection/types';
+import { FavorPeach, FavorTteokbokki, Mbti } from '@/components/members/upload/TmiSection/types';
+
+import { FavorAlcohol, FavorFishBread, FavorMintChocolate, FavorSweetAndSourPork } from './TmiSection/types';
 
 export interface MemberUploadForm {
   profileImage: string;
@@ -17,6 +19,14 @@ export interface MemberUploadForm {
   careers: Career[];
   mbti: Mbti | null;
   mbtiDescription: string;
+  favor: {
+    sweetAndSourPork: FavorSweetAndSourPork | null;
+    mintChocolate: FavorMintChocolate | null;
+    alcohol: FavorAlcohol | null;
+    peach: FavorPeach | null;
+    fishBread: FavorFishBread | null;
+    tteokbokki: FavorTteokbokki | null;
+  };
 }
 
 interface SoptActivity {


### PR DESCRIPTION
### 🤫 쉿, 나한테만 말해줘요. 이슈넘버
- #508

### 🧐 어떤 것을 변경했어요~?
<!-- 실제로 변경한 사항을 설명해주세요.-->

TMI 섹션에 '나는 어느 쪽?' 항목 추가

### 🤔 그렇다면, 어떻게 구현했어요~?
<!-- 실제로 구현한 로직에 대해 설명해주세요.-->

### ❤️‍🔥 당신이 생각하는 PR포인트, 내겐 매력포인트.
<!-- 해당 PR에서 논의가 필요한 사항을 적어주세요. -->

MBTI 항목에 비해 의존성 없이 잘 만든 것 같은데 요 비슷한 방식으로 MBTI 항목 리팩토링 하면 좋을 것 같습니다 ㅎㅎ

### 📸 스크린샷, 없으면 이것 참,, 섭섭한데요?

TMI 섹션에 항목 하나씩 채워가는 중이고 페이지 컴포넌트에는 아직 안 올렸습니다 

스토리북 `members/upload/TmiSection` 고고링