### PR TITLE
feat: 마지막 로그인 메시지 추가

### DIFF
--- a/components/auth/states/lastLoginMethodAtom.ts
+++ b/components/auth/states/lastLoginMethodAtom.ts
@@ -1,0 +1,30 @@
+import { atom } from 'recoil';
+
+import { isClientSide } from '@/utils';
+
+type LoginMethods = null | 'facebook' | 'google';
+
+const LAST_REGISTER_KEY = 'pg-lastRegister';
+
+export const lastLoginMethodAtom = atom<LoginMethods>({
+  key: 'lastLoginMethodAtom',
+  default: null,
+  effects: [
+    ({ setSelf, onSet }) => {
+      if (isClientSide()) {
+        const value = localStorage.getItem(LAST_REGISTER_KEY);
+        if (value !== null) {
+          setSelf(value as LoginMethods);
+        }
+      }
+
+      onSet((token, _, isReset) => {
+        if (isReset || token === null) {
+          localStorage.removeItem(LAST_REGISTER_KEY);
+          return;
+        }
+        localStorage.setItem(LAST_REGISTER_KEY, token);
+      });
+    },
+  ],
+});

--- a/pages/auth/callback/facebook/login.tsx
+++ b/pages/auth/callback/facebook/login.tsx
@@ -1,13 +1,16 @@
 import { useRouter } from 'next/router';
 import { FC } from 'react';
+import { useSetRecoilState } from 'recoil';
 
 import OAuthLoginCallback, { ProcessParamFn } from '@/components/auth/callback/OAuthLoginCallback';
 import useFacebookAuth from '@/components/auth/identityProvider/facebook/useFacebookAuth';
+import { lastLoginMethodAtom } from '@/components/auth/states/lastLoginMethodAtom';
 import useLastUnauthorized from '@/components/auth/util/useLastUnauthorized';
 
 const FacebookLoginCallbackPage: FC = () => {
   const router = useRouter();
   const facebookAuth = useFacebookAuth();
+  const setLastLoginMethod = useSetRecoilState(lastLoginMethodAtom);
   const lastUnauthorized = useLastUnauthorized();
 
   const processParam: ProcessParamFn = async (url) => {
@@ -25,6 +28,7 @@ const FacebookLoginCallbackPage: FC = () => {
   };
 
   const handleSuccess = () => {
+    setLastLoginMethod('facebook');
     router.replace(lastUnauthorized.popPath() ?? '/');
   };
 

--- a/pages/auth/callback/facebook/register.tsx
+++ b/pages/auth/callback/facebook/register.tsx
@@ -1,15 +1,17 @@
 import { useRouter } from 'next/router';
 import { FC } from 'react';
-import { useRecoilValue } from 'recoil';
+import { useRecoilValue, useSetRecoilState } from 'recoil';
 
 import OAuthLoginCallback, { ProcessParamFn } from '@/components/auth/callback/OAuthLoginCallback';
 import useFacebookAuth from '@/components/auth/identityProvider/facebook/useFacebookAuth';
+import { lastLoginMethodAtom } from '@/components/auth/states/lastLoginMethodAtom';
 import { registerTokenAtom } from '@/components/auth/states/registerTokenAtom';
 import useLastUnauthorized from '@/components/auth/util/useLastUnauthorized';
 
 const FacebookRegisterCallbackPage: FC = () => {
   const router = useRouter();
   const registerToken = useRecoilValue(registerTokenAtom);
+  const setLastLoginMethod = useSetRecoilState(lastLoginMethodAtom);
   const facebookAuth = useFacebookAuth();
   const lastUnauthorized = useLastUnauthorized();
 
@@ -47,6 +49,7 @@ const FacebookRegisterCallbackPage: FC = () => {
   };
 
   const handleSuccess = () => {
+    setLastLoginMethod('facebook');
     router.replace(lastUnauthorized.popPath() ?? '/');
   };
 

--- a/pages/auth/callback/google/login.tsx
+++ b/pages/auth/callback/google/login.tsx
@@ -1,13 +1,16 @@
 import { useRouter } from 'next/router';
 import { FC } from 'react';
+import { useSetRecoilState } from 'recoil';
 
 import OAuthLoginCallback, { ProcessParamFn } from '@/components/auth/callback/OAuthLoginCallback';
 import useGoogleAuth from '@/components/auth/identityProvider/google/useGoogleAuth';
+import { lastLoginMethodAtom } from '@/components/auth/states/lastLoginMethodAtom';
 import useLastUnauthorized from '@/components/auth/util/useLastUnauthorized';
 
 const GoogleLoginCallbackPage: FC = () => {
   const router = useRouter();
   const googleAuth = useGoogleAuth();
+  const setLastLoginMethod = useSetRecoilState(lastLoginMethodAtom);
   const lastUnauthorized = useLastUnauthorized();
 
   const processParam: ProcessParamFn = async (url) => {
@@ -25,6 +28,7 @@ const GoogleLoginCallbackPage: FC = () => {
   };
 
   const handleSuccess = () => {
+    setLastLoginMethod('google');
     router.replace(lastUnauthorized.popPath() ?? '/');
   };
 

--- a/pages/auth/callback/google/register.tsx
+++ b/pages/auth/callback/google/register.tsx
@@ -1,15 +1,17 @@
 import { useRouter } from 'next/router';
 import { FC } from 'react';
-import { useRecoilValue } from 'recoil';
+import { useRecoilValue, useSetRecoilState } from 'recoil';
 
 import OAuthLoginCallback, { ProcessParamFn } from '@/components/auth/callback/OAuthLoginCallback';
 import useGoogleAuth from '@/components/auth/identityProvider/google/useGoogleAuth';
+import { lastLoginMethodAtom } from '@/components/auth/states/lastLoginMethodAtom';
 import { registerTokenAtom } from '@/components/auth/states/registerTokenAtom';
 import useLastUnauthorized from '@/components/auth/util/useLastUnauthorized';
 
 const GoogleRegisterCallbackPage: FC = () => {
   const router = useRouter();
   const registerToken = useRecoilValue(registerTokenAtom);
+  const setLastLoginMethod = useSetRecoilState(lastLoginMethodAtom);
   const googleAuth = useGoogleAuth();
   const lastUnauthorized = useLastUnauthorized();
 
@@ -47,6 +49,7 @@ const GoogleRegisterCallbackPage: FC = () => {
   };
 
   const handleSuccess = () => {
+    setLastLoginMethod('google');
     router.replace(lastUnauthorized.popPath() ?? '/');
   };
 

--- a/pages/auth/login.tsx
+++ b/pages/auth/login.tsx
@@ -1,12 +1,14 @@
 import styled from '@emotion/styled';
 import { m, Variants } from 'framer-motion';
 import Link from 'next/link';
-import { FC } from 'react';
+import { FC, useEffect, useState } from 'react';
+import { useRecoilValue } from 'recoil';
 
 import FacebookButton from '@/components/auth/identityProvider/facebook/FacebookButton';
 import useFacebookAuth from '@/components/auth/identityProvider/facebook/useFacebookAuth';
 import GoogleAuthButton from '@/components/auth/identityProvider/google/GoogleAuthButton';
 import useGoogleAuth from '@/components/auth/identityProvider/google/useGoogleAuth';
+import { lastLoginMethodAtom } from '@/components/auth/states/lastLoginMethodAtom';
 import { playgroundLink } from '@/constants/links';
 import { colors } from '@/styles/colors';
 import { MOBILE_MEDIA_QUERY } from '@/styles/mediaQuery';
@@ -38,8 +40,24 @@ const tooltipVariants: Variants = {
 };
 
 const LoginPage: FC = () => {
+  const lastLoginMethod = useRecoilValue(lastLoginMethodAtom);
+
   const facebookAuth = useFacebookAuth();
   const googleAuth = useGoogleAuth();
+
+  const [lastLoginMessage, setLastLoginMessage] = useState<null | string>(null);
+
+  useEffect(() => {
+    switch (lastLoginMethod) {
+      case 'google':
+        setLastLoginMessage('Google');
+        break;
+      case 'facebook':
+        setLastLoginMessage('Facebook');
+        break;
+      default:
+    }
+  }, [lastLoginMethod]);
 
   return (
     <StyledLoginPage>
@@ -59,6 +77,22 @@ const LoginPage: FC = () => {
         <RegisterInfo>
           Playground가 처음이신가요? <RegisterLink href={playgroundLink.register()}>회원가입하기</RegisterLink>
         </RegisterInfo>
+
+        <LastLogin
+          suppressHydrationWarning
+          initial='hide'
+          animate={lastLoginMessage ? 'show' : 'hide'}
+          variants={{
+            show: {
+              opacity: 1,
+            },
+            hide: {
+              opacity: 0,
+            },
+          }}
+        >
+          마지막으로 로그인한 계정은 {lastLoginMessage}이에요.
+        </LastLogin>
       </LoginBox>
 
       <MotionMakersContainer initial='init' animate='open' whileHover='hover'>
@@ -149,6 +183,13 @@ const RegisterInfo = styled.div`
 
     ${textStyles.SUIT_12_M}
   }
+`;
+
+const LastLogin = styled(m.div)`
+  margin-top: 25px;
+  color: ${colors.purple100};
+
+  ${textStyles.SUIT_16_SB}
 `;
 
 const RegisterLink = styled(Link)`

--- a/pages/auth/login.tsx
+++ b/pages/auth/login.tsx
@@ -79,7 +79,6 @@ const LoginPage: FC = () => {
         </RegisterInfo>
 
         <LastLogin
-          suppressHydrationWarning
           initial='hide'
           animate={lastLoginMessage ? 'show' : 'hide'}
           variants={{


### PR DESCRIPTION
### 🤫 쉿, 나한테만 말해줘요. 이슈넘버
- close #526 

### 🧐 어떤 것을 변경했어요~?
<!-- 실제로 변경한 사항을 설명해주세요.-->

마지막으로 로그인한 방법을 표시하도록 만들었어요!

<img width="650" alt="image" src="https://user-images.githubusercontent.com/36122585/226833623-e2f71b7a-967c-40f9-bb58-8ed32da81a56.png">


### 🤔 그렇다면, 어떻게 구현했어요~?
<!-- 실제로 구현한 로직에 대해 설명해주세요.-->

로그인이나 회원가입 성공시에 로컬스토리지에 어느 방법으로 했는지를 저장하고, 로그인 화면에서 띄워주도록 만들었어요.


### ❤️‍🔥 당신이 생각하는 PR포인트, 내겐 매력포인트.
<!-- 해당 PR에서 논의가 필요한 사항을 적어주세요. -->

### 📸 스크린샷, 없으면 이것 참,, 섭섭한데요?
