### PR TITLE
fix: 프로필 자유로운 자기소개 > 상세 스타일 버그 fix, 수정/업로드 글자수 제한

### DIFF
--- a/components/members/main/MemberDetail/InterestSection.tsx
+++ b/components/members/main/MemberDetail/InterestSection.tsx
@@ -105,7 +105,7 @@ const InterestSection: FC<InterestSectionProps> = ({
       )}
       {selfIntroduction && (
         <InfoItem label='자유로운 자기소개'>
-          <Description>{selfIntroduction}</Description>
+          <SelfIntroductionDescription>{selfIntroduction}</SelfIntroductionDescription>
         </InfoItem>
       )}
     </StyledInterestSection>
@@ -149,6 +149,14 @@ const Description = styled(Text)`
   @media ${MOBILE_MEDIA_QUERY} {
     margin-top: 12px;
     ${textStyles.SUIT_16_M};
+  }
+`;
+
+const SelfIntroductionDescription = styled(Description)`
+  line-height: 160%;
+
+  @media ${MOBILE_MEDIA_QUERY} {
+    line-height: 140%;
   }
 `;
 

--- a/components/members/upload/forms/CountableTextArea.tsx
+++ b/components/members/upload/forms/CountableTextArea.tsx
@@ -1,4 +1,4 @@
-import { css } from '@emotion/react';
+import { css, SerializedStyles } from '@emotion/react';
 import styled from '@emotion/styled';
 import { ChangeEvent, forwardRef } from 'react';
 
@@ -14,12 +14,13 @@ interface MemberCountableTextAreaProps {
   className?: string;
   placeholder?: string;
   value: string;
+  containerStyle?: SerializedStyles;
 }
 
 export const MemberCountableTextArea = forwardRef<HTMLTextAreaElement, MemberCountableTextAreaProps>(
-  ({ error, maxCount, onChange, className, placeholder, value }, ref) => {
+  ({ error, maxCount, onChange, className, placeholder, value, containerStyle }, ref) => {
     return (
-      <StyledContainer className={className}>
+      <StyledContainer customStyle={containerStyle}>
         <StyledTextArea
           onChange={onChange}
           error={error}
@@ -27,6 +28,7 @@ export const MemberCountableTextArea = forwardRef<HTMLTextAreaElement, MemberCou
           maxLength={maxCount}
           placeholder={placeholder}
           value={value}
+          className={className}
         />
         <StyledCountValue>
           <Text color={colors.gray100} typography='SUIT_12_M'>
@@ -39,9 +41,11 @@ export const MemberCountableTextArea = forwardRef<HTMLTextAreaElement, MemberCou
 );
 export default MemberCountableTextArea;
 
-const StyledContainer = styled.div`
+const StyledContainer = styled.div<{ customStyle?: SerializedStyles }>`
   position: relative;
   width: 100%;
+
+  ${({ customStyle }) => customStyle}
 `;
 
 const StyledTextArea = styled.textarea<MemberCountableTextAreaProps>`
@@ -79,6 +83,9 @@ const StyledTextArea = styled.textarea<MemberCountableTextAreaProps>`
 
 const StyledCountValue = styled.div`
   display: flex;
+  position: absolute;
+  right: 25px;
+  bottom: 15px;
   justify-content: flex-end;
   margin-top: 12px;
 

--- a/components/members/upload/sections/TmiSection/index.tsx
+++ b/components/members/upload/sections/TmiSection/index.tsx
@@ -1,3 +1,4 @@
+import { css } from '@emotion/react';
 import styled from '@emotion/styled';
 import { Controller, useFormContext } from 'react-hook-form';
 
@@ -6,6 +7,7 @@ import Responsive from '@/components/common/Responsive';
 import TextArea from '@/components/common/TextArea';
 import Select from '@/components/members/common/select/Select';
 import { SOJU_CAPACITY_RANGE } from '@/components/members/upload/constants';
+import MemberCountableTextArea from '@/components/members/upload/forms/CountableTextArea';
 import MemberFormHeader from '@/components/members/upload/forms/FormHeader';
 import MemberFormItem from '@/components/members/upload/forms/FormItem';
 import { MemberFormSection } from '@/components/members/upload/forms/FormSection';
@@ -150,9 +152,18 @@ export default function TmiSection() {
         </Responsive>
       </StyledMemberFormItem>
       <StyledMemberFormItem title='자유로운 자기소개'>
-        <StyledIntroductionTextarea
-          {...register('longIntroduction')}
-          placeholder={`• 나는 이런 사람이에요.\n• SOPT에 들어온 계기\n• SOPT에 들어오기 전에 무엇을 해왔는지\n• 프로젝트할 때의 나의 성향\n• SOPT에서 하고 싶은 것 등등`}
+        <Controller
+          name='longIntroduction'
+          control={control}
+          render={({ field }) => (
+            <StyledIntroductionTextarea
+              value={field.value}
+              onChange={field.onChange}
+              maxCount={300}
+              placeholder={`• 나는 이런 사람이에요.\n• SOPT에 들어온 계기\n• SOPT에 들어오기 전에 무엇을 해왔는지\n• 프로젝트할 때의 나의 성향\n• SOPT에서 하고 싶은 것 등등`}
+              containerStyle={introductionTextareaContainerStyle}
+            />
+          )}
         />
       </StyledMemberFormItem>
     </MemberFormSection>
@@ -214,13 +225,24 @@ const StyledInput = styled(Input)`
   }
 `;
 
-const StyledIntroductionTextarea = styled(StyledTextArea)`
-  margin-top: 14px;
-  height: 170px;
+const StyledIntroductionTextarea = styled(MemberCountableTextArea)`
+  border-radius: 13px;
+  padding: 14px 20px;
   line-height: 170%;
   letter-spacing: -0.01em;
 
   @media ${MOBILE_MEDIA_QUERY} {
+    line-height: 150%;
+  }
+`;
+
+const introductionTextareaContainerStyle = css`
+  margin-top: 14px;
+  width: 632px;
+  height: 170px;
+
+  @media ${MOBILE_MEDIA_QUERY} {
+    width: 100%;
     height: 152px;
   }
 `;


### PR DESCRIPTION
### 🤫 쉿, 나한테만 말해줘요. 이슈넘버
- close #555

### 🧐 어떤 것을 변경했어요~?
<!-- 실제로 변경한 사항을 설명해주세요.-->

상세는 line height 추가했고

수정/업로드는 textarea를 CountableTextarea 컴포넌트로 바꿨어요

### 🤔 그렇다면, 어떻게 구현했어요~?
<!-- 실제로 구현한 로직에 대해 설명해주세요.-->

### ❤️‍🔥 당신이 생각하는 PR포인트, 내겐 매력포인트.
<!-- 해당 PR에서 논의가 필요한 사항을 적어주세요. -->

CountableTextarea 컴포넌트 스타일 설정 방법 좋은 방법 같진 않은데 더 고민할 체력이 없어서 일단 이렇게 했습니다 쉬고 싶허요 ... 머지하기 전까지 더 좋은 방법 떠오르면 고치러 올게요

### 📸 스크린샷, 없으면 이것 참,, 섭섭한데요?

before

<img width="949" alt="image" src="https://user-images.githubusercontent.com/73823388/227460805-8b35d045-5438-4dea-83c7-4f9e0067cff4.png">

<img width="1033" alt="image" src="https://user-images.githubusercontent.com/73823388/227460869-34ec2cf3-f00f-4988-8539-67e81fd4b048.png">



after

<img width="877" alt="image" src="https://user-images.githubusercontent.com/73823388/227460586-02d01135-d507-407a-8b3f-04372fe7b336.png">

<img width="1061" alt="image" src="https://user-images.githubusercontent.com/73823388/227460694-454c0602-dddb-45da-a26b-8cf1ceed89b6.png">

