### PR TITLE
fix: 프로필 상세 > line-height 통일

### DIFF
--- a/components/members/detail/InfoItem.tsx
+++ b/components/members/detail/InfoItem.tsx
@@ -32,10 +32,12 @@ const Container = styled.div`
 
   .content {
     margin-top: 16px;
-    line-height: 100%;
+    line-height: 160%;
     font-size: 18px;
+
     @media ${MOBILE_MEDIA_QUERY} {
       margin-top: 12px;
+      line-height: 140%;
       font-size: 16px;
     }
   }

--- a/components/members/main/MemberDetail/InterestSection.tsx
+++ b/components/members/main/MemberDetail/InterestSection.tsx
@@ -120,7 +120,14 @@ const StyledInterestSection = styled.div`
   row-gap: 35px;
 `;
 
-const MBTI = styled(Text)`
+const StyledText = styled(Text)`
+  line-height: 160%;
+  @media ${MOBILE_MEDIA_QUERY} {
+    line-height: 140%;
+  }
+`;
+
+const MBTI = styled(StyledText)`
   display: block;
   margin-top: 16px;
   ${textStyles.SUIT_18_B};
@@ -131,7 +138,7 @@ const MBTI = styled(Text)`
   }
 `;
 
-const MBTIDescription = styled(Text)`
+const MBTIDescription = styled(StyledText)`
   display: block;
   margin-top: 10px;
   ${textStyles.SUIT_18_M};
@@ -142,7 +149,7 @@ const MBTIDescription = styled(Text)`
   }
 `;
 
-const Description = styled(Text)`
+const Description = styled(StyledText)`
   margin-top: 16px;
   ${textStyles.SUIT_18_M};
 
@@ -153,12 +160,7 @@ const Description = styled(Text)`
 `;
 
 const SelfIntroductionDescription = styled(Description)`
-  line-height: 160%;
   white-space: pre-line;
-
-  @media ${MOBILE_MEDIA_QUERY} {
-    line-height: 140%;
-  }
 `;
 
 const BalanceGame = styled.div`
@@ -166,11 +168,13 @@ const BalanceGame = styled.div`
   align-items: center;
   column-gap: 20px;
   margin-top: 16px;
+  line-height: 160%;
   ${textStyles.SUIT_18_M};
 
   @media ${MOBILE_MEDIA_QUERY} {
     column-gap: 12px;
     margin-top: 12px;
+    line-height: 140%;
     ${textStyles.SUIT_16_M};
   }
 `;


### PR DESCRIPTION
### 🤫 쉿, 나한테만 말해줘요. 이슈넘버
- close #586

### 🧐 어떤 것을 변경했어요~?
<!-- 실제로 변경한 사항을 설명해주세요.-->

아래처럼 생긴 프로필 항목의 값들을 모두 여러 줄을 고려한 line-height로 통일했어요


<img width="107" alt="image" src="https://user-images.githubusercontent.com/73823388/227734306-df82b873-3e9c-4450-9ce9-c17eb0c93a1a.png">


현재 대부분의 프로필 항목이 여러 줄이 되도록 길게 입력할 수 있는 상태인데 '자유로운 자기소개' 항목만 여러 줄을 고려한 line-height 값이 적용돼있는 것이 어색하여 디자이너와 상의하여 수정했어요

### 🤔 그렇다면, 어떻게 구현했어요~?
<!-- 실제로 구현한 로직에 대해 설명해주세요.-->

### ❤️‍🔥 당신이 생각하는 PR포인트, 내겐 매력포인트.
<!-- 해당 PR에서 논의가 필요한 사항을 적어주세요. -->

### 📸 스크린샷, 없으면 이것 참,, 섭섭한데요?
