### PR TITLE
fix: 활동정보 모바일 스타일 수정

### DIFF
--- a/components/members/detail/PartItem.tsx
+++ b/components/members/detail/PartItem.tsx
@@ -110,13 +110,13 @@ const BelongArea = styled.div`
 
 const Badges = styled.div`
   display: flex;
+  flex-wrap: wrap;
   grid-area: activities;
   gap: 8px;
   align-self: start;
   margin-top: 2px;
 
   @media ${MOBILE_MEDIA_QUERY} {
-    flex-wrap: wrap;
     margin-top: 12px;
   }
 `;

--- a/components/members/detail/PartItem.tsx
+++ b/components/members/detail/PartItem.tsx
@@ -116,6 +116,7 @@ const Badges = styled.div`
   margin-top: 2px;
 
   @media ${MOBILE_MEDIA_QUERY} {
+    flex-wrap: wrap;
     margin-top: 12px;
   }
 `;


### PR DESCRIPTION
### 🤫 쉿, 나한테만 말해줘요. 이슈넘버
- close #610 

### 🧐 어떤 것을 변경했어요~?
<!-- 실제로 변경한 사항을 설명해주세요.-->

멤버프로필의 SOPT 활동 정보의 활동한 프로젝트가 모바일에서 화면을 넘어가버리는 문제를 수정했어요.

 
### 🤔 그렇다면, 어떻게 구현했어요~?
<!-- 실제로 구현한 로직에 대해 설명해주세요.-->

flex-wrap을 줬어요!



### ❤️‍🔥 당신이 생각하는 PR포인트, 내겐 매력포인트.
<!-- 해당 PR에서 논의가 필요한 사항을 적어주세요. -->

### 📸 스크린샷, 없으면 이것 참,, 섭섭한데요?
<img width="360" alt="image" src="https://user-images.githubusercontent.com/36122585/229365760-7520b260-f116-4df3-bc30-ff73f16cea61.png">
