### PR TITLE
fix: 푸터에 맞춰 토스트 위치 변경

### DIFF
--- a/components/common/Toast/providers/ToastProvider.tsx
+++ b/components/common/Toast/providers/ToastProvider.tsx
@@ -51,7 +51,7 @@ export default ToastProvider;
 
 const ToastContainer = styled.div<{ animation: string }>`
   position: fixed;
-  bottom: 59px;
+  bottom: 80px;
   left: 36px;
   transform: translateY(300%);
   z-index: 100;


### PR DESCRIPTION
### 🤫 쉿, 나한테만 말해줘요. 이슈넘버
- close #652 

### 🧐 어떤 것을 변경했어요~?
<!-- 실제로 변경한 사항을 설명해주세요.-->

푸터가 없을 때 만들어진 토스트라 푸터와 너무 붙어있어서 bottom 값을 조정했습니다!

### 🤔 그렇다면, 어떻게 구현했어요~?
<!-- 실제로 구현한 로직에 대해 설명해주세요.-->

### ❤️‍🔥 당신이 생각하는 PR포인트, 내겐 매력포인트.
<!-- 해당 PR에서 논의가 필요한 사항을 적어주세요. -->

간단한 스타일 변경이라 그냥 바로 머지할게용

### 📸 스크린샷, 없으면 이것 참,, 섭섭한데요?

https://user-images.githubusercontent.com/73823388/233240898-dd238b82-ceed-4d80-8e2c-42a4be83626f.mov
