### PR TITLE
refactor: 프로필 디테일 > InterestSection 다른 섹션과 구조 통일

### DIFF
--- a/components/members/detail/InterestSection/index.stories.tsx
+++ b/components/members/detail/InterestSection/index.stories.tsx
@@ -1,32 +1,9 @@
-import styled from '@emotion/styled';
 import { ComponentMeta, ComponentStory } from '@storybook/react';
-
-import { MOBILE_MEDIA_QUERY } from '@/styles/mediaQuery';
 
 import InterestSection from '.';
 
-const InfoContainer = styled.div`
-  display: flex;
-  flex-direction: column;
-  border-radius: 30px;
-  background: #1c1d1e;
-  padding: 40px;
-  width: 100%;
-  @media ${MOBILE_MEDIA_QUERY} {
-    border-radius: 18px;
-    padding: 30px 20px;
-  }
-`;
-
 export default {
   component: InterestSection,
-  decorators: [
-    (Story) => (
-      <InfoContainer>
-        <Story />
-      </InfoContainer>
-    ),
-  ],
 } as ComponentMeta<typeof InterestSection>;
 
 const Template: ComponentStory<typeof InterestSection> = (args) => <InterestSection {...args} />;

--- a/components/members/detail/InterestSection/index.tsx
+++ b/components/members/detail/InterestSection/index.tsx
@@ -72,7 +72,7 @@ const InterestSection: FC<InterestSectionProps> = ({
   const isBalanceGameAvailable = balanceGame && Object.values(balanceGame).some((value) => value !== null);
 
   return (
-    <Container>
+    <StyledMemberDetailSection>
       {mbti.name && (
         <InfoItem label='MBTI + 제 성격은요...'>
           <MBTI>{mbti.name}</MBTI>
@@ -111,13 +111,13 @@ const InterestSection: FC<InterestSectionProps> = ({
           <SelfIntroductionDescription>{selfIntroduction}</SelfIntroductionDescription>
         </InfoItem>
       )}
-    </Container>
+    </StyledMemberDetailSection>
   );
 };
 
 export default InterestSection;
 
-const Container = styled(MemberDetailSection)`
+const StyledMemberDetailSection = styled(MemberDetailSection)`
   row-gap: 35px;
 `;
 

--- a/components/members/detail/InterestSection/index.tsx
+++ b/components/members/detail/InterestSection/index.tsx
@@ -3,6 +3,7 @@ import React, { FC } from 'react';
 
 import Text from '@/components/common/Text';
 import InfoItem from '@/components/members/detail/InfoItem';
+import MemberDetailSection from '@/components/members/detail/MemberDetailSection';
 import { colors } from '@/styles/colors';
 import { MOBILE_MEDIA_QUERY } from '@/styles/mediaQuery';
 import { textStyles } from '@/styles/typography';
@@ -71,7 +72,7 @@ const InterestSection: FC<InterestSectionProps> = ({
   const isBalanceGameAvailable = balanceGame && Object.values(balanceGame).some((value) => value !== null);
 
   return (
-    <StyledInterestSection>
+    <Container>
       {mbti.name && (
         <InfoItem label='MBTI + 제 성격은요...'>
           <MBTI>{mbti.name}</MBTI>
@@ -110,15 +111,13 @@ const InterestSection: FC<InterestSectionProps> = ({
           <SelfIntroductionDescription>{selfIntroduction}</SelfIntroductionDescription>
         </InfoItem>
       )}
-    </StyledInterestSection>
+    </Container>
   );
 };
 
 export default InterestSection;
 
-const StyledInterestSection = styled.div`
-  display: flex;
-  flex-direction: column;
+const Container = styled(MemberDetailSection)`
   row-gap: 35px;
 `;
 

--- a/components/members/detail/MemberDetail.tsx
+++ b/components/members/detail/MemberDetail.tsx
@@ -196,30 +196,28 @@ const MemberDetail: FC<MemberDetailProps> = ({ memberId }) => {
           profile.userFavor?.isPourSauceLover ||
           profile.userFavor?.isRedBeanFishBreadLover ||
           profile.userFavor?.isRiceTteokLover) && (
-          <MemberDetailSection>
-            <InterestSection
-              sojuCapacity={profile.sojuCapacity}
-              mbti={{
-                name: profile.mbti,
-                description: profile.mbtiDescription,
-              }}
-              balanceGame={
-                profile.userFavor
-                  ? {
-                      isSojuLover: profile.userFavor.isSojuLover,
-                      isHardPeachLover: profile.userFavor.isHardPeachLover,
-                      isMintChocoLover: profile.userFavor.isMintChocoLover,
-                      isPourSauceLover: profile.userFavor.isPourSauceLover,
-                      isRedBeanFishBreadLover: profile.userFavor.isRedBeanFishBreadLover,
-                      isRiceTteokLover: profile.userFavor.isRiceTteokLover,
-                    }
-                  : null
-              }
-              idealType={profile.idealType}
-              interest={profile.interest}
-              selfIntroduction={profile.selfIntroduction}
-            />
-          </MemberDetailSection>
+          <InterestSection
+            sojuCapacity={profile.sojuCapacity}
+            mbti={{
+              name: profile.mbti,
+              description: profile.mbtiDescription,
+            }}
+            balanceGame={
+              profile.userFavor
+                ? {
+                    isSojuLover: profile.userFavor.isSojuLover,
+                    isHardPeachLover: profile.userFavor.isHardPeachLover,
+                    isMintChocoLover: profile.userFavor.isMintChocoLover,
+                    isPourSauceLover: profile.userFavor.isPourSauceLover,
+                    isRedBeanFishBreadLover: profile.userFavor.isRedBeanFishBreadLover,
+                    isRiceTteokLover: profile.userFavor.isRiceTteokLover,
+                  }
+                : null
+            }
+            idealType={profile.idealType}
+            interest={profile.interest}
+            selfIntroduction={profile.selfIntroduction}
+          />
         )}
 
         {profile.careers && profile.careers.length > 0 && (

--- a/components/members/detail/MessageSection/index.tsx
+++ b/components/members/detail/MessageSection/index.tsx
@@ -36,7 +36,7 @@ export default function MessageSection({ name, email, profileImage, memberId }: 
 
   return (
     <>
-      <Container>
+      <StyledMemberDetailSection>
         <div>
           <Title>{name}에게 하고 싶은 질문이 있나요?</Title>
           <Subtitle>“저에게 궁금한게 있다면 편하게 남겨주세요~”</Subtitle>
@@ -44,7 +44,7 @@ export default function MessageSection({ name, email, profileImage, memberId }: 
         <MessageButton onClick={handleClickMessageButton} disabled={isEmptyEmail}>
           쪽지 보내기
         </MessageButton>
-      </Container>
+      </StyledMemberDetailSection>
       {isOpenCoffeeChatModal && (
         <MessageModal receiverId={memberId} name={name} profile={profileImage} onClose={onCloseCoffeeChatModal} />
       )}
@@ -52,7 +52,7 @@ export default function MessageSection({ name, email, profileImage, memberId }: 
   );
 }
 
-const Container = styled(MemberDetailSection)`
+const StyledMemberDetailSection = styled(MemberDetailSection)`
   display: flex;
   flex-direction: row;
   align-items: center;


### PR DESCRIPTION
### 🤫 쉿, 나한테만 말해줘요. 이슈넘버
- close #655 

### 🧐 어떤 것을 변경했어요~?
<!-- 실제로 변경한 사항을 설명해주세요.-->

다른 섹션처럼 MemberDetailSection 스타일 컴포넌트를 베이스로 사용하도록 했어요!
(InfoContainer는 MemberDetailSection의 옛버전입니당)

### 🤔 그렇다면, 어떻게 구현했어요~?
<!-- 실제로 구현한 로직에 대해 설명해주세요.-->

### ❤️‍🔥 당신이 생각하는 PR포인트, 내겐 매력포인트.
<!-- 해당 PR에서 논의가 필요한 사항을 적어주세요. -->

### 📸 스크린샷, 없으면 이것 참,, 섭섭한데요?
