### PR TITLE
chore: 프로젝트 카테고리 기타 -> 사이드 프로젝트 워딩 변경

### DIFF
--- a/components/members/detail/constants.ts
+++ b/components/members/detail/constants.ts
@@ -6,5 +6,5 @@ export const PROJECT_CATEGORY_LABEL: Record<ProjectCategory, string> = {
   SOPTERM: '솝텀 프로젝트',
   STUDY: '스터디',
   JOINTSEMINAR: '합동 세미나',
-  ETC: '기타',
+  ETC: '사이드 프로젝트',
 };

--- a/components/projects/form/fields/CategoryField.tsx
+++ b/components/projects/form/fields/CategoryField.tsx
@@ -12,7 +12,7 @@ const categoryLabel = {
   SOPTERM: '솝텀 프로젝트',
   STUDY: '스터디',
   JOINTSEMINAR: '합동 세미나',
-  ETC: '기타',
+  ETC: '사이드 프로젝트',
 } as const;
 
 interface CategoryFieldProps {

--- a/components/projects/upload/ProjectCategory.tsx
+++ b/components/projects/upload/ProjectCategory.tsx
@@ -17,7 +17,7 @@ const categoryLabel = {
   SOPTERM: '솝텀 프로젝트',
   STUDY: '스터디',
   JOINTSEMINAR: '합동 세미나',
-  ETC: '기타',
+  ETC: '사이드 프로젝트',
 } as const;
 
 const ProjectCategory: FC = () => {

--- a/components/projects/upload/constants.ts
+++ b/components/projects/upload/constants.ts
@@ -11,7 +11,7 @@ export const categoryLabel: Record<Category, string> = {
   SOPTERM: '솝텀 프로젝트',
   STUDY: '스터디',
   JOINTSEMINAR: '합동 세미나',
-  ETC: '기타',
+  ETC: '사이드 프로젝트',
 };
 
 export const FORM_ITEMS: FormItem[] = [


### PR DESCRIPTION
### 🤫 쉿, 나한테만 말해줘요. 이슈넘버
- close #662 

### 🧐 어떤 것을 변경했어요~?
<!-- 실제로 변경한 사항을 설명해주세요.-->

[작업 배경 슬랙 스레드](https://sopt-makers.slack.com/archives/C04RVNVRLLA/p1682402898459319)

프로덕션에 기타 카테고리로 올라간 프로젝트가 없어서 간단히 상수만 수정했습니다~


### 🤔 그렇다면, 어떻게 구현했어요~?
<!-- 실제로 구현한 로직에 대해 설명해주세요.-->

### ❤️‍🔥 당신이 생각하는 PR포인트, 내겐 매력포인트.
<!-- 해당 PR에서 논의가 필요한 사항을 적어주세요. -->

관련 상수가 여기 저기 흩어져 있는데 싱글 소스로 관리돼야 하는 것 아닌지 고민이 되네용

요번 작업은 직접 굉장히 꼼꼼히 빠진 곳이 없는지 확인했습니다

### 📸 스크린샷, 없으면 이것 참,, 섭섭한데요?
