### PR TITLE
refactor: Career 타입 구별된 유니온으로 정확한 타이핑 할 수 있도록 하기

### DIFF
--- a/api/members/type.ts
+++ b/api/members/type.ts
@@ -104,14 +104,23 @@ export type MemberProject = {
   thumbnailImage: string;
 };
 
-type Career = {
-  id: number;
-  companyName: string;
-  title: string;
-  startDate: string;
-  endDate: string | null;
-  isCurrent: boolean;
-};
+type Career =
+  | {
+      id: number;
+      companyName: string;
+      title: string;
+      startDate: string;
+      endDate: null;
+      isCurrent: true;
+    }
+  | {
+      id: number;
+      companyName: string;
+      title: string;
+      startDate: string;
+      endDate: string;
+      isCurrent: false;
+    };
 
 export interface ProfileRequest {
   name: string;

--- a/components/members/detail/types.ts
+++ b/components/members/detail/types.ts
@@ -1,9 +1,17 @@
 export type ProjectCategory = 'APPJAM' | 'SOPKATHON' | 'SOPTERM' | 'STUDY' | 'JOINTSEMINAR' | 'ETC';
 
-export interface Career {
-  companyName: string;
-  title: string;
-  startDate: string;
-  endDate: string | null;
-  isCurrent: boolean;
-}
+export type Career =
+  | {
+      companyName: string;
+      title: string;
+      startDate: string;
+      endDate: null;
+      isCurrent: true;
+    }
+  | {
+      companyName: string;
+      title: string;
+      startDate: string;
+      endDate: string;
+      isCurrent: false;
+    };

--- a/components/members/upload/constants.ts
+++ b/components/members/upload/constants.ts
@@ -2,7 +2,7 @@ import { DefaultValues } from 'react-hook-form';
 
 import { MemberUploadForm } from '@/components/members/upload/types';
 
-export const DEFAULT_CAREER = { title: '', companyName: '', isCurrent: false, startDate: '', endDate: '' };
+export const DEFAULT_CAREER = { title: '', companyName: '', isCurrent: false, startDate: '', endDate: '' } as const;
 export const DEFAULT_ACTIVITY = { generation: '', part: '', team: '' };
 export const DEFAULT_LINK = { title: '', url: '' };
 export const DEFAULT_FAVOR = {

--- a/components/members/upload/types.ts
+++ b/components/members/upload/types.ts
@@ -51,10 +51,18 @@ export interface Birthday {
   day: string;
 }
 
-export interface Career {
-  companyName: string;
-  title: string;
-  startDate: string;
-  endDate: string | null;
-  isCurrent: boolean;
-}
+export type Career =
+  | {
+      companyName: string;
+      title: string;
+      startDate: string;
+      endDate: null;
+      isCurrent: true;
+    }
+  | {
+      companyName: string;
+      title: string;
+      startDate: string;
+      endDate: string;
+      isCurrent: false;
+    };

--- a/pages/members/edit.tsx
+++ b/pages/members/edit.tsx
@@ -151,10 +151,14 @@ export default function MemberEditPage() {
         allowOfficial: myProfile.allowOfficial,
         profileImage: myProfile.profileImage,
         careers: myProfile.careers.length
-          ? myProfile.careers.map((career) => ({
-              ...career,
-              endDate: career.endDate ?? '',
-            }))
+          ? myProfile.careers.map((career) =>
+              career.isCurrent
+                ? {
+                    ...career,
+                    endDate: null,
+                  }
+                : career,
+            )
           : [DEFAULT_CAREER],
         mbti: getMbtiFromApiValue(myProfile.mbti),
         mbtiDescription: myProfile.mbtiDescription,


### PR DESCRIPTION
### 🤫 쉿, 나한테만 말해줘요. 이슈넘버
- close #658 

### 🧐 어떤 것을 변경했어요~?
<!-- 실제로 변경한 사항을 설명해주세요.-->

Career 타입의 endDate 필드가 string | null 이었는데, 이는 boolean 타입의 isCurrent 필드에 의해 정해지는 것이었는데,

isCurrent - true, endDate - null / isCurrent - false, endDate - string

위 2가지 외의 쌍은 존재하면 안됐습니다.

따라서 기존처럼 endDate 필드를 유니온 처리하는 것이 아닌, Career 타입 자체를 구별된 유니온으로 처리하여 타입의 정확도를 높였습니다.

### 🤔 그렇다면, 어떻게 구현했어요~?
<!-- 실제로 구현한 로직에 대해 설명해주세요.-->

### ❤️‍🔥 당신이 생각하는 PR포인트, 내겐 매력포인트.
<!-- 해당 PR에서 논의가 필요한 사항을 적어주세요. -->

### 📸 스크린샷, 없으면 이것 참,, 섭섭한데요?
