### PR TITLE
fix: 프로필 상세 > 프로젝트 뱃지에 프로젝트 카테고리 모두 표시되도록

### DIFF
--- a/api/members/type.ts
+++ b/api/members/type.ts
@@ -1,4 +1,4 @@
-import { Category } from '@/api/projects/type';
+import { ProjectCategory } from '@/api/projects/type';
 import { ServiceType } from '@/components/projects/upload/types';
 
 export type Profile = {
@@ -62,7 +62,7 @@ export type ProfileDetail = {
       id: number;
       generation: number;
       name: string;
-      category: Category;
+      category: ProjectCategory;
     }[];
   }[];
   links: MemberLink[];
@@ -95,7 +95,7 @@ export type Member = {
 };
 
 export type MemberProject = {
-  category: Category;
+  category: ProjectCategory;
   generation: number;
   id: number;
   serviceType: ServiceType[];

--- a/api/members/type.ts
+++ b/api/members/type.ts
@@ -1,4 +1,5 @@
-import { Category, ServiceType } from '@/components/projects/upload/types';
+import { Category } from '@/api/projects/type';
+import { ServiceType } from '@/components/projects/upload/types';
 
 export type Profile = {
   id: number;
@@ -61,7 +62,7 @@ export type ProfileDetail = {
       id: number;
       generation: number;
       name: string;
-      category: 'APPJAM' | 'SOPKATHON' | null;
+      category: Category;
     }[];
   }[];
   links: MemberLink[];

--- a/api/projects/type.ts
+++ b/api/projects/type.ts
@@ -63,7 +63,7 @@ export type ProjectInput = {
 type MemberRole = 'TEAMLEADER' | 'MAINPM' | 'PM' | 'DESIGN' | 'IOS' | 'ANDROID' | 'WEB' | 'SERVER';
 
 export type ProjectCategory = typeof PROJECT_CATEGORY[number];
-export function isProjectCategory(category: unknown): category is ProjectCategory {
+export function isProjectCategory(category: string): category is ProjectCategory {
   return PROJECT_CATEGORY.includes(category as ProjectCategory);
 }
 

--- a/api/projects/type.ts
+++ b/api/projects/type.ts
@@ -5,7 +5,7 @@ export type ProjectDetail = {
   name: string;
   writerId: number;
   generation: number;
-  category: Category;
+  category: ProjectCategory;
   startAt: string;
   endAt?: string;
   serviceType: ServiceType[];
@@ -35,7 +35,7 @@ export type ProjectDetail = {
 export type ProjectInput = {
   name: string;
   writerId: number;
-  category: Category;
+  category: ProjectCategory;
   startAt: string;
   endAt?: string;
   serviceType: ServiceType[];
@@ -62,9 +62,9 @@ export type ProjectInput = {
 
 type MemberRole = 'TEAMLEADER' | 'MAINPM' | 'PM' | 'DESIGN' | 'IOS' | 'ANDROID' | 'WEB' | 'SERVER';
 
-export type Category = typeof PROJECT_CATEGORY[number];
-export function isCategory(category: unknown): category is Category {
-  return PROJECT_CATEGORY.includes(category as Category);
+export type ProjectCategory = typeof PROJECT_CATEGORY[number];
+export function isProjectCategory(category: unknown): category is ProjectCategory {
+  return PROJECT_CATEGORY.includes(category as ProjectCategory);
 }
 
 const LINK_TITLES = ['website', 'googlePlay', 'appStore', 'github', 'instagram', 'media'] as const;

--- a/api/projects/type.ts
+++ b/api/projects/type.ts
@@ -1,3 +1,5 @@
+import { PROJECT_CATEGORY } from '@/components/projects/upload/constants';
+
 export type ProjectDetail = {
   id: number;
   name: string;
@@ -59,7 +61,11 @@ export type ProjectInput = {
 };
 
 type MemberRole = 'TEAMLEADER' | 'MAINPM' | 'PM' | 'DESIGN' | 'IOS' | 'ANDROID' | 'WEB' | 'SERVER';
-type Category = 'APPJAM' | 'SOPKATHON' | 'SOPTERM' | 'STUDY' | 'JOINTSEMINAR' | 'ETC';
+
+export type Category = typeof PROJECT_CATEGORY[number];
+export function isCategory(category: unknown): category is Category {
+  return PROJECT_CATEGORY.includes(category as Category);
+}
 
 const LINK_TITLES = ['website', 'googlePlay', 'appStore', 'github', 'instagram', 'media'] as const;
 export type LinkTitle = typeof LINK_TITLES[number];

--- a/components/members/detail/MemberDetail.tsx
+++ b/components/members/detail/MemberDetail.tsx
@@ -10,6 +10,7 @@ import ProfileIcon from 'public/icons/icon-profile.svg';
 import { FC, useMemo } from 'react';
 
 import { useGetMemberProfileById } from '@/api/hooks';
+import { isCategory } from '@/api/projects/type';
 import Loading from '@/components/common/Loading';
 import useEventLogger from '@/components/eventLogger/hooks/useEventLogger';
 import CareerSection from '@/components/members/detail/CareerSection';
@@ -21,6 +22,7 @@ import MemberProjectCard from '@/components/members/detail/MemberProjectCard';
 import MessageSection from '@/components/members/detail/MessageSection';
 import PartItem from '@/components/members/detail/PartItem';
 import { DEFAULT_DATE } from '@/components/members/upload/constants';
+import { Category } from '@/components/projects/upload/types';
 import { playgroundLink } from '@/constants/links';
 import { useRunOnce } from '@/hooks/useRunOnce';
 import { colors } from '@/styles/colors';
@@ -165,7 +167,7 @@ const MemberDetail: FC<MemberDetailProps> = ({ memberId }) => {
               part={part}
               activities={projects.map((project) => ({
                 name: project.name,
-                type: convertProjectType(project.category),
+                type: convertProjectType(project.category) ?? '',
                 href: playgroundLink.projectDetail(project.id),
               }))}
               teams={team !== null ? [team] : []}
@@ -226,15 +228,25 @@ const MemberDetail: FC<MemberDetailProps> = ({ memberId }) => {
   );
 };
 
-function convertProjectType(typeCode: 'APPJAM' | 'SOPKATHON' | null) {
-  if (typeCode === 'APPJAM') {
-    return '앱잼';
-  }
-  if (typeCode === 'SOPKATHON') {
-    return '솝커톤';
-  }
+function convertProjectType(typeCode: Category) {
+  if (!isCategory(typeCode)) throw new Error('project category type error');
 
-  return '';
+  switch (typeCode) {
+    case 'APPJAM':
+      return '앱잼';
+    case 'ETC':
+      return '사이드 프로젝트';
+    case 'JOINTSEMINAR':
+      return '합동 세미나';
+    case 'SOPKATHON':
+      return '솝커톤';
+    case 'SOPTERM':
+      return '솝텀 프로젝트';
+    case 'STUDY':
+      return '스터디';
+    default:
+      const _exhaustiveCheck: never = typeCode;
+  }
 }
 
 const Container = styled.div`

--- a/components/members/detail/MemberDetail.tsx
+++ b/components/members/detail/MemberDetail.tsx
@@ -245,7 +245,8 @@ function convertProjectType(typeCode: Category) {
     case 'STUDY':
       return '스터디';
     default:
-      const _exhaustiveCheck: never = typeCode;
+      const exhaustiveCheck: never = typeCode;
+      throw new Error(`project category ${exhaustiveCheck} type error`);
   }
 }
 

--- a/components/members/detail/MemberDetail.tsx
+++ b/components/members/detail/MemberDetail.tsx
@@ -10,7 +10,7 @@ import ProfileIcon from 'public/icons/icon-profile.svg';
 import { FC, useMemo } from 'react';
 
 import { useGetMemberProfileById } from '@/api/hooks';
-import { isCategory } from '@/api/projects/type';
+import { isProjectCategory } from '@/api/projects/type';
 import Loading from '@/components/common/Loading';
 import useEventLogger from '@/components/eventLogger/hooks/useEventLogger';
 import CareerSection from '@/components/members/detail/CareerSection';
@@ -229,7 +229,7 @@ const MemberDetail: FC<MemberDetailProps> = ({ memberId }) => {
 };
 
 function convertProjectType(typeCode: Category) {
-  if (!isCategory(typeCode)) throw new Error('project category type error');
+  if (!isProjectCategory(typeCode)) throw new Error('project category type error');
 
   switch (typeCode) {
     case 'APPJAM':

--- a/components/projects/upload/constants.ts
+++ b/components/projects/upload/constants.ts
@@ -171,3 +171,5 @@ export const PROJECT_DEFAULT_VALUES: DefaultValues<ProjectUploadForm> = {
   summary: '',
   detail: '',
 };
+
+export const PROJECT_CATEGORY = ['APPJAM', 'SOPKATHON', 'SOPTERM', 'STUDY', 'JOINTSEMINAR', 'ETC'] as const;


### PR DESCRIPTION
### 🤫 쉿, 나한테만 말해줘요. 이슈넘버
- close #664 

### 🧐 어떤 것을 변경했어요~?
<!-- 실제로 변경한 사항을 설명해주세요.-->

기존 코드가 솝커톤, 앱잼 외의 카테고리는 표시가 안되도록 돼있어서 모든 카테고리를 반영하도록 수정했습니다!

### 🤔 그렇다면, 어떻게 구현했어요~?
<!-- 실제로 구현한 로직에 대해 설명해주세요.-->

convertProjectType 함수를 수정했어요.

현재 api 타입과 컴포넌트 타입의 의존성으로 인해 타입의 신뢰성이 좀 떨어져서 타입 가드를 만들어서 검사해줬어요 (isCategory)
혹시 카테고리가 추가됐을 때에 빠뜨릴까봐 never 타입으로 exhaustive check도 해줬습니다!

### ❤️‍🔥 당신이 생각하는 PR포인트, 내겐 매력포인트.
<!-- 해당 PR에서 논의가 필요한 사항을 적어주세요. -->

### 📸 스크린샷, 없으면 이것 참,, 섭섭한데요?
