### PR TITLE
feat: 프로필 상세 > 나는 어느 쪽? 항목 디자인 변경 대응

### DIFF
--- a/components/members/detail/InterestSection/index.tsx
+++ b/components/members/detail/InterestSection/index.tsx
@@ -91,11 +91,11 @@ const InterestSection: FC<InterestSectionProps> = ({
       )}
       {isBalanceGameAvailable && (
         <InfoItem label='나는 어느 쪽?'>
-          <BalanceGame>
+          <BalanceGameWrapper>
             {balanceGameResults?.map((balanceGameResult, index) => (
               <BalanceGameItem key={index}>{balanceGameResult}</BalanceGameItem>
             ))}
-          </BalanceGame>
+          </BalanceGameWrapper>
         </InfoItem>
       )}
       {idealType && (
@@ -161,7 +161,7 @@ const SelfIntroductionDescription = styled(Description)`
   white-space: pre-line;
 `;
 
-const BalanceGame = styled.div`
+const BalanceGameWrapper = styled.div`
   display: flex;
   gap: 8px;
   align-items: center;

--- a/components/members/detail/InterestSection/index.tsx
+++ b/components/members/detail/InterestSection/index.tsx
@@ -163,12 +163,14 @@ const SelfIntroductionDescription = styled(Description)`
 
 const BalanceGameWrapper = styled.div`
   display: flex;
+  flex-wrap: wrap;
   gap: 8px;
   align-items: center;
   margin-top: 16px;
 
   @media ${MOBILE_MEDIA_QUERY} {
     margin-top: 12px;
+    max-width: 236px;
   }
 `;
 

--- a/components/members/detail/InterestSection/index.tsx
+++ b/components/members/detail/InterestSection/index.tsx
@@ -93,10 +93,7 @@ const InterestSection: FC<InterestSectionProps> = ({
         <InfoItem label='나는 어느 쪽?'>
           <BalanceGame>
             {balanceGameResults?.map((balanceGameResult, index) => (
-              <React.Fragment key={index}>
-                {balanceGameResult}
-                {index !== balanceGameResults.length - 1 && <VerticalLine />}
-              </React.Fragment>
+              <BalanceGameItem key={index}>{balanceGameResult}</BalanceGameItem>
             ))}
           </BalanceGame>
         </InfoItem>
@@ -166,26 +163,21 @@ const SelfIntroductionDescription = styled(Description)`
 
 const BalanceGame = styled.div`
   display: flex;
+  gap: 8px;
   align-items: center;
-  column-gap: 20px;
   margin-top: 16px;
-  line-height: 160%;
-  ${textStyles.SUIT_18_M};
 
   @media ${MOBILE_MEDIA_QUERY} {
-    column-gap: 12px;
     margin-top: 12px;
-    line-height: 140%;
-    ${textStyles.SUIT_16_M};
   }
 `;
 
-const VerticalLine = styled.div`
-  background-color: ${colors.gray100};
-  width: 1.5px;
-  height: 14px;
+const BalanceGameItem = styled.div`
+  border-radius: 13px;
+  background-color: ${colors.black40};
+  padding: 6px 14px;
+  line-height: 16px;
+  color: ${colors.white};
 
-  @media ${MOBILE_MEDIA_QUERY} {
-    height: 12px;
-  }
+  ${textStyles.SUIT_14_M};
 `;

--- a/components/members/detail/MemberDetail.tsx
+++ b/components/members/detail/MemberDetail.tsx
@@ -436,9 +436,11 @@ const StyledAddressBadgeWrapper = styled.div`
 
 const AddressBadge = styled.div`
   border-radius: 13px;
-  background: ${colors.black40};
+  background-color: ${colors.black40};
   padding: 6px 14px;
+  line-height: 16px;
   color: ${colors.white};
+
   ${textStyles.SUIT_14_M};
 `;
 


### PR DESCRIPTION
### 🤫 쉿, 나한테만 말해줘요. 이슈넘버
- close #687

### 🧐 어떤 것을 변경했어요~?
<!-- 실제로 변경한 사항을 설명해주세요.-->

- 프로필 상세 > 나는 어느 쪽? 항목 디자인을 기존 디바이더로 텍스트가 나뉜 형태에서 블록 형태로 바꾸었어요.
  - 디자인 요구 사항: 모바일에서는 한 줄에 최대 4개가 기본 값, viewport가 4개 너비보다 작아지면 그에 맞춰 한 줄에 들어가는 개수도 줄어들어야 함. => max-width 설정
- 해당 디자인이 주소 뱃지랑 같은 형태인데 스타일 요소가 다른 것들이 있어서 디자이너와 얘기해서 맞추었어요. (AddressBedge)
 


### 🤔 그렇다면, 어떻게 구현했어요~?
<!-- 실제로 구현한 로직에 대해 설명해주세요.-->

### ❤️‍🔥 당신이 생각하는 PR포인트, 내겐 매력포인트.
<!-- 해당 PR에서 논의가 필요한 사항을 적어주세요. -->

### 📸 스크린샷, 없으면 이것 참,, 섭섭한데요?

https://github.com/sopt-makers/sopt-playground-frontend/assets/73823388/54764619-42ee-4cae-a459-9feb01f02032


