### PR TITLE
feat: 멘토링 카드 및 캐러셀 구현

### DIFF
--- a/components/common/Carousel/Body.tsx
+++ b/components/common/Carousel/Body.tsx
@@ -1,0 +1,26 @@
+import { usePresence } from 'framer-motion';
+import { ReactNode, useEffect, useRef } from 'react';
+
+interface CarouselBodyProps {
+  currentItemList: ReactNode[];
+  renderContainer: (children: ReactNode) => ReactNode;
+}
+
+export default function CarouselBody({ currentItemList, renderContainer }: CarouselBodyProps) {
+  const [isPresent, safeToRemove] = usePresence();
+  const absoluteRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (absoluteRef.current === null) {
+      return;
+    }
+    if (isPresent) {
+      absoluteRef.current.style.position = 'static';
+    } else {
+      absoluteRef.current.style.position = 'absolute';
+      safeToRemove?.();
+    }
+  }, [isPresent, safeToRemove]);
+
+  return <div ref={absoluteRef}>{renderContainer(currentItemList)}</div>;
+}

--- a/components/common/Carousel/index.stories.tsx
+++ b/components/common/Carousel/index.stories.tsx
@@ -56,7 +56,7 @@ const CardContainer = styled.div`
 
 export const Basic = Template.bind({});
 Basic.args = {
-  totalItemList: MENTORING_DUMMY_DATA.map((dummy, index) => <MentoringCard {...dummy} key={index} />),
+  itemList: MENTORING_DUMMY_DATA.map((dummy, index) => <MentoringCard {...dummy} key={index} />),
   limit: 3,
   renderItemContainer: (children: ReactNode) => <CardContainer>{children}</CardContainer>,
 };

--- a/components/common/Carousel/index.stories.tsx
+++ b/components/common/Carousel/index.stories.tsx
@@ -1,0 +1,62 @@
+import styled from '@emotion/styled';
+import { ComponentMeta, ComponentStory } from '@storybook/react';
+import { ReactNode } from 'react';
+
+import Carousel from '@/components/common/Carousel';
+import MentoringCard from '@/components/mentoring/MentoringCard';
+
+export default {
+  components: Carousel,
+  decorators: [
+    (Story) => (
+      <div style={{ width: '1440px', display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
+        <div style={{ width: '1302px' }}>
+          <Story />
+        </div>
+      </div>
+    ),
+  ],
+} as ComponentMeta<typeof Carousel>;
+
+const Template: ComponentStory<typeof Carousel> = (args) => <Carousel {...args} />;
+
+const MENTORING_DUMMY_DATA = [
+  {
+    mentor: { name: '남주영', career: '나사' },
+    keywords: ['별자리 찾기', '우주의 탄생 과정에 대해 알아보기'],
+    title: '정우와 함께하는 CGP Review',
+  },
+  {
+    mentor: { name: '송정우', career: 'AWS' },
+    keywords: ['코드 리뷰', '아무거나 물어보세용', '취업 준비 과정에서 우선 순위 정하기'],
+    title: '하둘셋넷다여일여아열하둘셋넷다여일여아열하둘셋넷다여일여아열',
+  },
+  {
+    mentor: { name: '박건영', career: '어둠의 커비단' },
+    keywords: ['코드 리뷰', '취업 준비 과정에서 우선 순위 정하기', '노동요추천-에스파스파이씨'],
+    title: '개발 천재 되는 법',
+  },
+  {
+    mentor: { name: '이정연', career: '당근마켓' },
+    keywords: ['개자이피엠'],
+    title: '개발 천재 되는 법',
+  },
+  {
+    mentor: { name: '이준호', career: '고수수현' },
+    keywords: ['고수수현', '중수수현', '하수수현'],
+    title: '개발 천재 되는 법',
+  },
+];
+
+const CardContainer = styled.div`
+  display: flex;
+  gap: 15px;
+  width: 100%;
+`;
+
+export const Basic = Template.bind({});
+Basic.args = {
+  totalItemList: MENTORING_DUMMY_DATA.map((dummy, index) => <MentoringCard {...dummy} key={index} />),
+  limit: 3,
+  renderItemContainer: (children: ReactNode) => <CardContainer>{children}</CardContainer>,
+};

--- a/components/common/Carousel/index.stories.tsx
+++ b/components/common/Carousel/index.stories.tsx
@@ -9,10 +9,8 @@ export default {
   components: Carousel,
   decorators: [
     (Story) => (
-      <div style={{ width: '1440px', display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
-        <div style={{ width: '1302px' }}>
-          <Story />
-        </div>
+      <div style={{ width: '1414px' }}>
+        <Story />
       </div>
     ),
   ],

--- a/components/common/Carousel/index.tsx
+++ b/components/common/Carousel/index.tsx
@@ -38,10 +38,10 @@ export default function Carousel({ itemList, limit, className, renderItemContain
           <CarouselBody currentItemList={currentItemList} renderContainer={renderItemContainer} />
         </m.div>
       </AnimatePresence>
-      <LeftControl onClick={movePrevious}>
+      <LeftControl onClick={movePrevious} isActive={page - 1 >= 1}>
         <LeftArrowIcon />
       </LeftControl>
-      <RightControl onClick={moveNext}>
+      <RightControl onClick={moveNext} isActive={page + 1 <= totalPageSize}>
         <RightArrowIcon />
       </RightControl>
       <Indicators>
@@ -81,9 +81,10 @@ const Container = styled.div`
   width: 100%;
 `;
 
-const Control = styled.button`
+const Control = styled.button<{ isActive: boolean }>`
   border-radius: 50%;
   background-color: ${colors.purpledim100};
+  cursor: ${({ isActive }) => (isActive ? 'pointer' : 'default')};
   width: 40px;
   height: 40px;
 `;

--- a/components/common/Carousel/index.tsx
+++ b/components/common/Carousel/index.tsx
@@ -81,7 +81,7 @@ const Container = styled.div`
   width: 100%;
 `;
 
-const Control = styled.div`
+const Control = styled.button`
   border-radius: 50%;
   background-color: ${colors.purpledim100};
   width: 40px;

--- a/components/common/Carousel/index.tsx
+++ b/components/common/Carousel/index.tsx
@@ -3,7 +3,7 @@ import { AnimatePresence, m } from 'framer-motion';
 import { ReactNode } from 'react';
 
 import CarouselBody from '@/components/common/Carousel/Body';
-import useCarousel from '@/components/common/Carousel/useCarousel';
+import useCarousel, { CarouselDirection } from '@/components/common/Carousel/useCarousel';
 import LeftArrowIcon from '@/public/icons/icon-arrow-purple.svg';
 import { colors } from '@/styles/colors';
 
@@ -56,9 +56,9 @@ export default function Carousel({ itemList, limit, className, renderItemContain
 }
 
 const variants = {
-  enter: (direction: number) => {
+  enter: (direction: CarouselDirection) => {
     return {
-      x: direction > 0 ? 1000 : -1000,
+      x: direction === 'next' ? 1000 : -1000,
       opacity: 0,
     };
   },
@@ -67,10 +67,10 @@ const variants = {
     x: 0,
     opacity: 1,
   },
-  exit: (direction: number) => {
+  exit: (direction: CarouselDirection) => {
     return {
       zIndex: 0,
-      x: direction < 0 ? 1000 : -1000,
+      x: direction === 'previous' ? 1000 : -1000,
       opacity: 0,
     };
   },

--- a/components/common/Carousel/index.tsx
+++ b/components/common/Carousel/index.tsx
@@ -44,13 +44,13 @@ export default function Carousel({ itemList, limit, className, renderItemContain
       <RightControl onClick={moveNext}>
         <RightArrowIcon />
       </RightControl>
-      <Indicator>
+      <Indicators>
         {Array(totalPageSize)
           .fill(null)
           .map((_, index) => (
-            <Circle onClick={() => move(index + 1)} isColored={index + 1 === page} key={`${index}`} />
+            <Indicator onClick={() => move(index + 1)} isActive={index + 1 === page} key={`${index}`} />
           ))}
-      </Indicator>
+      </Indicators>
     </Container>
   );
 }
@@ -108,7 +108,7 @@ const RightArrowIcon = styled(LeftArrowIcon)`
   transform: rotate(180deg);
 `;
 
-const Indicator = styled.div`
+const Indicators = styled.div`
   display: flex;
   position: absolute;
   bottom: -32px;
@@ -117,10 +117,10 @@ const Indicator = styled.div`
   transform: translateX(-50%);
 `;
 
-const Circle = styled.div<{ isColored?: boolean }>`
+const Indicator = styled.div<{ isActive?: boolean }>`
   border-radius: 50%;
-  background-color: ${({ isColored }) => (isColored ? colors.purple100 : colors.black40)};
-  cursor: pointer;
+  background-color: ${({ isActive }) => (isActive ? colors.purple100 : colors.black40)};
+  cursor: ${({ isActive }) => (isActive ? 'default' : 'pointer')};
   width: 8px;
   height: 8px;
 `;

--- a/components/common/Carousel/index.tsx
+++ b/components/common/Carousel/index.tsx
@@ -8,21 +8,16 @@ import LeftArrowIcon from '@/public/icons/icon-arrow-purple.svg';
 import { colors } from '@/styles/colors';
 
 interface CarouselProps {
-  totalItemList: ReactNode[];
+  itemList: ReactNode[];
   limit: number;
   className?: string;
   renderItemContainer: (children: ReactNode) => ReactNode;
 }
 
-export default function Carousel({
-  totalItemList,
-  limit,
-  className,
-  renderItemContainer: renderListContainer,
-}: CarouselProps) {
+export default function Carousel({ itemList, limit, className, renderItemContainer }: CarouselProps) {
   const { page, direction, moveNext, movePrevious, currentItemList, totalPageSize } = useCarousel({
     limit,
-    totalItemList,
+    itemList,
   });
 
   return (
@@ -40,7 +35,7 @@ export default function Carousel({
             opacity: { duration: 0.2 },
           }}
         >
-          <CarouselBody currentItemList={currentItemList} renderContainer={renderListContainer} />
+          <CarouselBody currentItemList={currentItemList} renderContainer={renderItemContainer} />
         </m.div>
       </AnimatePresence>
       <LeftControl onClick={movePrevious}>

--- a/components/common/Carousel/index.tsx
+++ b/components/common/Carousel/index.tsx
@@ -23,7 +23,7 @@ export default function Carousel({ itemList, limit, className, renderItemContain
   return (
     <Container className={className}>
       <AnimatePresence initial={false} custom={direction}>
-        <m.div
+        <StyledMotionDiv
           key={page}
           custom={direction}
           variants={variants}
@@ -36,7 +36,7 @@ export default function Carousel({ itemList, limit, className, renderItemContain
           }}
         >
           <CarouselBody currentItemList={currentItemList} renderContainer={renderItemContainer} />
-        </m.div>
+        </StyledMotionDiv>
       </AnimatePresence>
       <LeftControl onClick={movePrevious} isActive={page - 1 >= 1}>
         <LeftArrowIcon />
@@ -77,11 +77,18 @@ const variants = {
 };
 
 const Container = styled.div`
-  position: relative;
+  display: grid;
+  grid:
+    [row1-start] 'left-control list right-control' max-content [row1-end]
+    [row2-start] 'indicators indicators indicators' max-content [row2-end]
+    / min-content auto min-content;
+  column-gap: 16px;
   width: 100%;
+  row-gap: 24px;
 `;
 
 const Control = styled.button<{ isActive: boolean }>`
+  align-self: center;
   border-radius: 50%;
   background-color: ${colors.purpledim100};
   cursor: ${({ isActive }) => (isActive ? 'pointer' : 'default')};
@@ -90,18 +97,12 @@ const Control = styled.button<{ isActive: boolean }>`
 `;
 
 const LeftControl = styled(Control)`
-  position: absolute;
-  top: 50%;
-  left: -56px;
-  transform: translateY(-50%);
+  grid-area: left-control;
   padding: 11px 17px 11px 14px;
 `;
 
 const RightControl = styled(Control)`
-  position: absolute;
-  top: 50%;
-  right: -56px;
-  transform: translateY(-50%);
+  grid-area: right-control;
   padding: 11px 14px 11px 17px;
 `;
 
@@ -111,11 +112,9 @@ const RightArrowIcon = styled(LeftArrowIcon)`
 
 const Indicators = styled.div`
   display: flex;
-  position: absolute;
-  bottom: -32px;
-  left: 50%;
+  grid-area: indicators;
   gap: 12px;
-  transform: translateX(-50%);
+  justify-self: center;
 `;
 
 const Indicator = styled.div<{ isActive?: boolean }>`
@@ -124,4 +123,8 @@ const Indicator = styled.div<{ isActive?: boolean }>`
   cursor: ${({ isActive }) => (isActive ? 'default' : 'pointer')};
   width: 8px;
   height: 8px;
+`;
+
+const StyledMotionDiv = styled(m.div)`
+  grid-area: list;
 `;

--- a/components/common/Carousel/index.tsx
+++ b/components/common/Carousel/index.tsx
@@ -85,6 +85,7 @@ const Container = styled.div`
   column-gap: 16px;
   width: 100%;
   row-gap: 24px;
+  overflow: hidden;
 `;
 
 const Control = styled.button<{ isActive: boolean }>`

--- a/components/common/Carousel/index.tsx
+++ b/components/common/Carousel/index.tsx
@@ -15,7 +15,7 @@ interface CarouselProps {
 }
 
 export default function Carousel({ itemList, limit, className, renderItemContainer }: CarouselProps) {
-  const { page, direction, moveNext, movePrevious, currentItemList, totalPageSize } = useCarousel({
+  const { page, direction, moveNext, movePrevious, currentItemList, totalPageSize, move } = useCarousel({
     limit,
     itemList,
   });
@@ -48,7 +48,7 @@ export default function Carousel({ itemList, limit, className, renderItemContain
         {Array(totalPageSize)
           .fill(null)
           .map((_, index) => (
-            <Circle isColored={index + 1 === page} key={`${index}`} />
+            <Circle onClick={() => move(index + 1)} isColored={index + 1 === page} key={`${index}`} />
           ))}
       </Indicator>
     </Container>
@@ -120,6 +120,7 @@ const Indicator = styled.div`
 const Circle = styled.div<{ isColored?: boolean }>`
   border-radius: 50%;
   background-color: ${({ isColored }) => (isColored ? colors.purple100 : colors.black40)};
+  cursor: pointer;
   width: 8px;
   height: 8px;
 `;

--- a/components/common/Carousel/index.tsx
+++ b/components/common/Carousel/index.tsx
@@ -1,0 +1,130 @@
+import styled from '@emotion/styled';
+import { AnimatePresence, m } from 'framer-motion';
+import { ReactNode } from 'react';
+
+import CarouselBody from '@/components/common/Carousel/Body';
+import useCarousel from '@/components/common/Carousel/useCarousel';
+import LeftArrowIcon from '@/public/icons/icon-arrow-purple.svg';
+import { colors } from '@/styles/colors';
+
+interface CarouselProps {
+  totalItemList: ReactNode[];
+  limit: number;
+  className?: string;
+  renderItemContainer: (children: ReactNode) => ReactNode;
+}
+
+export default function Carousel({
+  totalItemList,
+  limit,
+  className,
+  renderItemContainer: renderListContainer,
+}: CarouselProps) {
+  const { page, direction, moveNext, movePrevious, currentItemList, totalPageSize } = useCarousel({
+    limit,
+    totalItemList,
+  });
+
+  return (
+    <Container className={className}>
+      <AnimatePresence initial={false} custom={direction}>
+        <m.div
+          key={page}
+          custom={direction}
+          variants={variants}
+          initial='enter'
+          animate='center'
+          exit='exit'
+          transition={{
+            x: { type: 'spring', stiffness: 300, damping: 30 },
+            opacity: { duration: 0.2 },
+          }}
+        >
+          <CarouselBody currentItemList={currentItemList} renderContainer={renderListContainer} />
+        </m.div>
+      </AnimatePresence>
+      <LeftControl onClick={movePrevious}>
+        <LeftArrowIcon />
+      </LeftControl>
+      <RightControl onClick={moveNext}>
+        <RightArrowIcon />
+      </RightControl>
+      <Indicator>
+        {Array(totalPageSize)
+          .fill(null)
+          .map((_, index) => (
+            <Circle isColored={index + 1 === page} key={`${index}`} />
+          ))}
+      </Indicator>
+    </Container>
+  );
+}
+
+const variants = {
+  enter: (direction: number) => {
+    return {
+      x: direction > 0 ? 1000 : -1000,
+      opacity: 0,
+    };
+  },
+  center: {
+    zIndex: 1,
+    x: 0,
+    opacity: 1,
+  },
+  exit: (direction: number) => {
+    return {
+      zIndex: 0,
+      x: direction < 0 ? 1000 : -1000,
+      opacity: 0,
+    };
+  },
+};
+
+const Container = styled.div`
+  position: relative;
+  width: 100%;
+`;
+
+const Control = styled.div`
+  border-radius: 50%;
+  background-color: ${colors.purpledim100};
+  width: 40px;
+  height: 40px;
+`;
+
+const LeftControl = styled(Control)`
+  position: absolute;
+  top: 50%;
+  left: -56px;
+  transform: translateY(-50%);
+  padding: 11px 17px 11px 14px;
+`;
+
+const RightControl = styled(Control)`
+  position: absolute;
+  top: 50%;
+  right: -56px;
+  transform: translateY(-50%);
+  padding: 11px 14px 11px 17px;
+`;
+
+const RightArrowIcon = styled(LeftArrowIcon)`
+  transform: rotate(180deg);
+`;
+
+const Indicator = styled.div`
+  display: flex;
+  position: absolute;
+  bottom: -32px;
+  left: 50%;
+  gap: 12px;
+  transform: translateX(-50%);
+`;
+
+const Circle = styled.div<{ isColored?: boolean }>`
+  border-radius: 50%;
+  background-color: ${({ isColored }) => (isColored ? colors.purple100 : colors.black40)};
+  width: 8px;
+  height: 8px;
+`;

--- a/components/common/Carousel/useCarousel.ts
+++ b/components/common/Carousel/useCarousel.ts
@@ -1,0 +1,30 @@
+import { ReactNode, useMemo, useState } from 'react';
+
+import usePagination from '@/hooks/usePagination';
+
+export default function useCarousel({ limit, totalItemList }: { limit: number; totalItemList: ReactNode[] }) {
+  const {
+    page,
+    moveNext: moveNextPage,
+    movePrevious: movePreviousPage,
+    startIndex,
+    totalPageSize,
+  } = usePagination({ limit, length: totalItemList.length });
+  const [direction, setDirection] = useState<-1 | 1>(1);
+
+  const currentItemList = useMemo(
+    () => totalItemList.slice(startIndex, startIndex + limit),
+    [startIndex, totalItemList, limit],
+  );
+
+  const moveNext = () => {
+    moveNextPage();
+    setDirection(1);
+  };
+  const movePrevious = () => {
+    movePreviousPage();
+    setDirection(-1);
+  };
+
+  return { page, direction, moveNext, movePrevious, currentItemList, totalPageSize };
+}

--- a/components/common/Carousel/useCarousel.ts
+++ b/components/common/Carousel/useCarousel.ts
@@ -9,6 +9,7 @@ export default function useCarousel({ limit, itemList }: { limit: number; itemLi
     movePrevious: movePreviousPage,
     startIndex,
     totalPageSize,
+    paginate,
   } = usePagination({ limit, length: itemList.length });
   const [direction, setDirection] = useState<-1 | 1>(1);
 
@@ -22,6 +23,18 @@ export default function useCarousel({ limit, itemList }: { limit: number; itemLi
     movePreviousPage();
     setDirection(-1);
   };
+  const move = (newPage: number) => {
+    if (page === newPage) {
+      return;
+    }
+    if (paginate(newPage)) {
+      if (page < newPage) {
+        setDirection(1);
+      } else {
+        setDirection(-1);
+      }
+    }
+  };
 
-  return { page, direction, moveNext, movePrevious, currentItemList, totalPageSize };
+  return { page, direction, moveNext, movePrevious, currentItemList, totalPageSize, move };
 }

--- a/components/common/Carousel/useCarousel.ts
+++ b/components/common/Carousel/useCarousel.ts
@@ -11,17 +11,17 @@ export default function useCarousel({ limit, itemList }: { limit: number; itemLi
     totalPageSize,
     paginate,
   } = usePagination({ limit, length: itemList.length });
-  const [direction, setDirection] = useState<-1 | 1>(1);
+  const [direction, setDirection] = useState<CarouselDirection>('next');
 
   const currentItemList = useMemo(() => itemList.slice(startIndex, startIndex + limit), [startIndex, itemList, limit]);
 
   const moveNext = () => {
     moveNextPage();
-    setDirection(1);
+    setDirection('next');
   };
   const movePrevious = () => {
     movePreviousPage();
-    setDirection(-1);
+    setDirection('previous');
   };
   const move = (newPage: number) => {
     if (page === newPage) {
@@ -29,12 +29,14 @@ export default function useCarousel({ limit, itemList }: { limit: number; itemLi
     }
     if (paginate(newPage)) {
       if (page < newPage) {
-        setDirection(1);
+        setDirection('next');
       } else {
-        setDirection(-1);
+        setDirection('previous');
       }
     }
   };
 
   return { page, direction, moveNext, movePrevious, currentItemList, totalPageSize, move };
 }
+
+export type CarouselDirection = 'previous' | 'next';

--- a/components/common/Carousel/useCarousel.ts
+++ b/components/common/Carousel/useCarousel.ts
@@ -2,20 +2,17 @@ import { ReactNode, useMemo, useState } from 'react';
 
 import usePagination from '@/hooks/usePagination';
 
-export default function useCarousel({ limit, totalItemList }: { limit: number; totalItemList: ReactNode[] }) {
+export default function useCarousel({ limit, itemList }: { limit: number; itemList: ReactNode[] }) {
   const {
     page,
     moveNext: moveNextPage,
     movePrevious: movePreviousPage,
     startIndex,
     totalPageSize,
-  } = usePagination({ limit, length: totalItemList.length });
+  } = usePagination({ limit, length: itemList.length });
   const [direction, setDirection] = useState<-1 | 1>(1);
 
-  const currentItemList = useMemo(
-    () => totalItemList.slice(startIndex, startIndex + limit),
-    [startIndex, totalItemList, limit],
-  );
+  const currentItemList = useMemo(() => itemList.slice(startIndex, startIndex + limit), [startIndex, itemList, limit]);
 
   const moveNext = () => {
     moveNextPage();

--- a/components/mentoring/MentoringCard/index.stories.tsx
+++ b/components/mentoring/MentoringCard/index.stories.tsx
@@ -22,4 +22,4 @@ LongData.args = {
   keywords: ['코드 리뷰', '아무거나 물어보세용', '취업 준비 과정에서 우선 순위 정하기'],
   title: '하둘셋넷다여일여아열하둘셋넷다여일여아열하둘셋넷다여일여아열',
 };
-LongData.storyName = '최대 길이';
+LongData.storyName = '긴 제목, 키워드';

--- a/components/mentoring/MentoringCard/index.stories.tsx
+++ b/components/mentoring/MentoringCard/index.stories.tsx
@@ -1,0 +1,25 @@
+import { ComponentMeta, ComponentStory } from '@storybook/react';
+
+import MentoringCard from '@/components/mentoring/MentoringCard';
+
+export default {
+  component: MentoringCard,
+} as ComponentMeta<typeof MentoringCard>;
+
+const Template: ComponentStory<typeof MentoringCard> = (args) => <MentoringCard {...args} />;
+
+export const Default = Template.bind({});
+Default.args = {
+  mentor: { name: '남주영', career: '나사' },
+  keywords: ['별자리 찾기', '우주의 탄생 과정에 대해 알아보기'],
+  title: '정우와 함께하는 CGP Review',
+};
+Default.storyName = '기본';
+
+export const LongData = Template.bind({});
+LongData.args = {
+  mentor: { name: '송정우', career: 'AWS' },
+  keywords: ['코드 리뷰', '아무거나 물어보세용', '취업 준비 과정에서 우선 순위 정하기'],
+  title: '하둘셋넷다여일여아열하둘셋넷다여일여아열하둘셋넷다여일여아열',
+};
+LongData.storyName = '최대 길이';

--- a/components/mentoring/MentoringCard/index.tsx
+++ b/components/mentoring/MentoringCard/index.tsx
@@ -55,6 +55,7 @@ const Keyword = styled.span`
 `;
 
 const Title = styled.div`
+  display: ${'-webkit-box'};
   margin-bottom: 24px;
   width: 234px;
   overflow: hidden;
@@ -63,10 +64,6 @@ const Title = styled.div`
   color: ${colors.gray10};
   -webkit-line-clamp: 2;
   -webkit-box-orient: vertical;
-  ${
-    // style lint가 -webkit-box를 box로 자동 변환하여 아래와 같이 조치
-    `display: -webkit-box;`
-  }
 
   ${textStyles.SUIT_18_B};
 `;

--- a/components/mentoring/MentoringCard/index.tsx
+++ b/components/mentoring/MentoringCard/index.tsx
@@ -1,0 +1,79 @@
+import styled from '@emotion/styled';
+
+import { colors } from '@/styles/colors';
+import { textStyles } from '@/styles/typography';
+
+interface MentoringCardProps {
+  mentor: { name: string; career: string };
+  keywords: string[];
+  title: string;
+}
+
+export default function MentoringCard({ mentor, keywords, title }: MentoringCardProps) {
+  return (
+    <Container>
+      <Keywords>
+        {keywords.map((keyword, index) => (
+          <Keyword key={`${index}-${keyword}`}>{keyword}</Keyword>
+        ))}
+      </Keywords>
+      <Title>{title}</Title>
+      <Mentor>{`${mentor.name} · ${mentor.career}`}</Mentor>
+    </Container>
+  );
+}
+
+const Container = styled.div`
+  border-radius: 16px;
+  background-color: ${colors.black90};
+  padding-top: 35px;
+  padding-left: 45px;
+  width: 424px;
+  height: 224px;
+`;
+
+// TODO: 다양한 키워드 케이스(ex 하나의 키워드가 너무 김. 키워드 개수가 많음.)에 대응할 수 있는 스타일링. (현재는 소수의 노운 케이스를 하드 코딩할 예정이라 일단 고려하지 않았으며, 추후에 디자이너와 논의하기로 함.)
+const Keywords = styled.div`
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  align-content: flex-end;
+  margin-bottom: 12px;
+  width: 234px;
+  height: 56px;
+`;
+
+const Keyword = styled.span`
+  border-radius: 6px;
+  background-color: ${colors.black60};
+  padding: 6px;
+  height: fit-content;
+  line-height: 14px;
+  color: ${colors.gray30};
+
+  ${textStyles.SUIT_11_M};
+`;
+
+const Title = styled.div`
+  margin-bottom: 24px;
+  width: 234px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  line-height: 22px;
+  color: ${colors.gray10};
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  ${
+    // style lint가 -webkit-box를 box로 자동 변환하여 아래와 같이 조치
+    `display: -webkit-box;`
+  }
+
+  ${textStyles.SUIT_18_B};
+`;
+
+const Mentor = styled.div`
+  line-height: 120%;
+  color: ${colors.gray60};
+
+  ${textStyles.SUIT_14_M};
+`;

--- a/hooks/usePagination.ts
+++ b/hooks/usePagination.ts
@@ -1,0 +1,16 @@
+import { useState } from 'react';
+
+export default function usePagination({ limit, length }: { limit: number; length: number }) {
+  const [page, setPage] = useState(1);
+
+  const totalPageSize = Math.ceil(length / limit);
+  const startIndex = (page - 1) * limit;
+
+  const paginate = (newPage: number) => {
+    setPage(newPage);
+  };
+  const moveNext = () => page + 1 <= totalPageSize && paginate(page + 1);
+  const movePrevious = () => page - 1 >= 1 && paginate(page - 1);
+
+  return { page, paginate, moveNext, movePrevious, totalPageSize, startIndex };
+}

--- a/hooks/usePagination.ts
+++ b/hooks/usePagination.ts
@@ -7,10 +7,14 @@ export default function usePagination({ limit, length }: { limit: number; length
   const startIndex = (page - 1) * limit;
 
   const paginate = (newPage: number) => {
-    setPage(newPage);
+    if (newPage <= totalPageSize && newPage >= 1) {
+      setPage(newPage);
+      return true;
+    }
+    return false;
   };
-  const moveNext = () => page + 1 <= totalPageSize && paginate(page + 1);
-  const movePrevious = () => page - 1 >= 1 && paginate(page - 1);
+  const moveNext = () => paginate(page + 1);
+  const movePrevious = () => paginate(page - 1);
 
   return { page, paginate, moveNext, movePrevious, totalPageSize, startIndex };
 }

--- a/public/icons/icon-arrow-purple.svg
+++ b/public/icons/icon-arrow-purple.svg
@@ -1,0 +1,3 @@
+<svg width="11" height="20" viewBox="0 0 11 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M10 19L0.999999 10L10 1" stroke="#8040FF" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>


### PR DESCRIPTION
### 🤫 쉿, 나한테만 말해줘요. 이슈넘버
- close #703

### 🧐 어떤 것을 변경했어요~?
<!-- 실제로 변경한 사항을 설명해주세요.-->

1. 멘토링 카드 마크업
2. 캐러셀 구현

### 🤔 그렇다면, 어떻게 구현했어요~?
<!-- 실제로 구현한 로직에 대해 설명해주세요.-->

캐러셀 구현 방식

- usePagination과 useCarousel로 관련 로직을 모듈화 함.
- 애니메이션은 framer-motion의 AnimatePresence를 활용했는데, 다음 페이지로 넘어가는 과정에서 이전 컴포넌트와 현재 컴포넌트가 둘 다 마운트 돼있어 레이아웃이 깨지는 현상이 있었음. 이를 framer-motion의 usePresence를 활용하여 exit 될 때 position: absoulte로 만들어 해결함. (참고로 이 훅을 사용하지 않고 useEffect만을 이용해서 스타일을 변경하는 방법은 의도대로 동작하지 않았음.)


### ❤️‍🔥 당신이 생각하는 PR포인트, 내겐 매력포인트.
<!-- 해당 PR에서 논의가 필요한 사항을 적어주세요. -->

캐러셀 관련하여 고민했던 요소들입니다

- 캐러셀을 직접 구현할 것이냐, UI 라이브러리를 사용할 것이냐

일단은 각종 까다로운 처리를 최적화 해서 해주고 있는 UI 라이브러리를 사용하는 것이 효율적일 것 같아서 찾아봄.
but 요구 사항에 맞추어 커스텀 하기 쉬운 라이브러리를 찾지 못함.
따라서 애니메이션만 현재 잘 활용하고 있는 framer-motion을 통해 구현하고 그 외는 직접 구현하기로 함.

- 캐러셀 컴포넌트를 완전히 headless로 구현할 것이냐, 현재 나온 디자인 의존성 있게 구현할 것이냐

고민을 정말 많이 했지만 일단은 후자로 구현했으며, 필요한 경우 최대한 모듈화 하여 재구성하기 좋도록 구현함.
추후 headless로 개선할 의지 있음.

\+

arrow icon svg 파일을 새로 추가하지 않고 기존 파일을 활용하려고 했는데
`안 그래도 아래와 같은 논의가 있어서 대대적으로 svg 파일 정리를 할 것 같음` +  `크기 변경하기가 까다로움` <- 때문에 일단 새로 추가했습니다 ,,
대신 꼭 2기 안에 정리 작업을 시작할 것을 가슴에 손을 얹고 약속합니다 두전!

<img width="628" alt="image" src="https://github.com/sopt-makers/sopt-playground-frontend/assets/73823388/47e84af8-3021-4ddd-9df9-9be2ee94521b">



### 📸 스크린샷, 없으면 이것 참,, 섭섭한데요?

[스토리북](https://62c412f0bcadc13b841ca857-hcyhwalpfv.chromatic.com/iframe.html?id=components-common-carousel--basic&viewMode=story) 확인 부탁 드립니당
