### PR TITLE
fix: 등록순 필터 주석처리

### DIFF
--- a/api/endpoint_LEGACY/members/index.ts
+++ b/api/endpoint_LEGACY/members/index.ts
@@ -12,7 +12,7 @@ import {
 export const getMemberProfile = async (input: string) => {
   const { data } = await axiosInstance.request<PagedMemberProfile>({
     method: 'GET',
-    url: `api/v1/members/profile${input}`,
+    url: `api/v1/members/profile${input}&orderBy=2`,
   });
 
   return data;

--- a/components/members/main/MemberList/index.tsx
+++ b/components/members/main/MemberList/index.tsx
@@ -67,7 +67,7 @@ const MemberList: FC<MemberListProps> = ({ banner }) => {
   const [sojuCapacity, setSojuCapacity] = useState<string | undefined>(undefined);
   const [team, setTeam] = useState<string | undefined>(undefined);
   const [mbti, setMbti] = useState<string | undefined>(undefined);
-  const [orderBy, setOrderBy] = useState<string>(ORDER_OPTIONS[0].value);
+  // const [orderBy, setOrderBy] = useState<string>(ORDER_OPTIONS[0].value);
 
   const [name, setName] = useState<string>('');
   const [messageModalState, setMessageModalState] = useState<MessageModalState>({ show: false });
@@ -126,9 +126,9 @@ const MemberList: FC<MemberListProps> = ({ banner }) => {
       if (typeof sojuCapacity === 'string' || sojuCapacity === undefined) {
         setSojuCapacity(sojuCapacity);
       }
-      if (typeof orderBy === 'string') {
-        setOrderBy(orderBy);
-      }
+      // if (typeof orderBy === 'string') {
+      //   setOrderBy(orderBy);
+      // }
     }
   }, [router.isReady, router.query, router]);
 
@@ -152,10 +152,10 @@ const MemberList: FC<MemberListProps> = ({ banner }) => {
     addQueryParamsToUrl({ sojuCapacity });
     logClickEvent('filterSojuCapacity', { sojuCapacity });
   };
-  const handleSelectOrderBy = (orderBy: string) => {
-    addQueryParamsToUrl({ orderBy });
-    logClickEvent('filterOrderBy', { orderBy });
-  };
+  // const handleSelectOrderBy = (orderBy: string) => {
+  //   addQueryParamsToUrl({ orderBy });
+  //   logClickEvent('filterOrderBy', { orderBy });
+  // };
   const handleSearch = (searchQuery: string) => {
     addQueryParamsToUrl({ name: searchQuery });
     logSubmitEvent('searchMember', { content: 'searchQuery' });
@@ -250,7 +250,7 @@ const MemberList: FC<MemberListProps> = ({ banner }) => {
               `}
             >
               <Text>{`전체 ${memberProfileData.pages[0].totalMembersCount}명`}</Text>
-              <StyledMobileFilter
+              {/* <StyledMobileFilter
                 placeholder=''
                 options={ORDER_OPTIONS}
                 value={orderBy}
@@ -269,7 +269,7 @@ const MemberList: FC<MemberListProps> = ({ banner }) => {
                     </Text>
                   </div>
                 )}
-              />
+              /> */}
             </div>
           )}
         </Responsive>
@@ -356,7 +356,7 @@ const MemberList: FC<MemberListProps> = ({ banner }) => {
                   `}
                 >
                   <Text typography='SUIT_18_M'>{`전체 ${memberProfileData.pages[0].totalMembersCount}명`}</Text>
-                  <OrderBySelect value={orderBy} onChange={handleSelectOrderBy} options={ORDER_OPTIONS} />
+                  {/* <OrderBySelect value={orderBy} onChange={handleSelectOrderBy} options={ORDER_OPTIONS} /> */}
                 </div>
               )}
             </StyledTopWrapper>


### PR DESCRIPTION
### 🤫 쉿, 나한테만 말해줘요. 이슈넘버
- close #

### 🧐 어떤 것을 변경했어요~?
<!-- 실제로 변경한 사항을 설명해주세요.-->
- 무한스크롤을 할 때 다음 커서를 지정하는 방식이 마지막 사람의 id를 기반으로 동작하도록 했어요. (id를 기반으로 커서를 동작시킨다 그랬었나..? 서버쪽 구현에 맞춰서 id가 incremental인 것을 이용해 hacky하게 구현했었습니다.)
- 그래서 일단 등록순 필터는 제거하고 orderBy=2(예전등록순)으로 고정하여 임시 배포합니다.

### 🤔 그렇다면, 어떻게 구현했어요~?
<!-- 실제로 구현한 로직에 대해 설명해주세요.-->

### ❤️‍🔥 당신이 생각하는 PR포인트, 내겐 매력포인트.
<!-- 해당 PR에서 논의가 필요한 사항을 적어주세요. -->

### 📸 스크린샷, 없으면 이것 참,, 섭섭한데요?
