### PR TITLE
chore: 등록순 필터 서버이슈 대응

### DIFF
--- a/api/endpoint_LEGACY/members/index.ts
+++ b/api/endpoint_LEGACY/members/index.ts
@@ -12,7 +12,7 @@ import {
 export const getMemberProfile = async (input: string) => {
   const { data } = await axiosInstance.request<PagedMemberProfile>({
     method: 'GET',
-    url: `api/v1/members/profile${input}&orderBy=2`,
+    url: `api/v1/members/profile${input}`,
   });
 
   return data;

--- a/components/members/main/MemberList/index.tsx
+++ b/components/members/main/MemberList/index.tsx
@@ -67,7 +67,7 @@ const MemberList: FC<MemberListProps> = ({ banner }) => {
   const [sojuCapacity, setSojuCapacity] = useState<string | undefined>(undefined);
   const [team, setTeam] = useState<string | undefined>(undefined);
   const [mbti, setMbti] = useState<string | undefined>(undefined);
-  // const [orderBy, setOrderBy] = useState<string>(ORDER_OPTIONS[0].value);
+  const [orderBy, setOrderBy] = useState<string>(ORDER_OPTIONS[0].value);
 
   const [name, setName] = useState<string>('');
   const [messageModalState, setMessageModalState] = useState<MessageModalState>({ show: false });
@@ -126,9 +126,9 @@ const MemberList: FC<MemberListProps> = ({ banner }) => {
       if (typeof sojuCapacity === 'string' || sojuCapacity === undefined) {
         setSojuCapacity(sojuCapacity);
       }
-      // if (typeof orderBy === 'string') {
-      //   setOrderBy(orderBy);
-      // }
+      if (typeof orderBy === 'string') {
+        setOrderBy(orderBy);
+      }
     }
   }, [router.isReady, router.query, router]);
 
@@ -152,10 +152,10 @@ const MemberList: FC<MemberListProps> = ({ banner }) => {
     addQueryParamsToUrl({ sojuCapacity });
     logClickEvent('filterSojuCapacity', { sojuCapacity });
   };
-  // const handleSelectOrderBy = (orderBy: string) => {
-  //   addQueryParamsToUrl({ orderBy });
-  //   logClickEvent('filterOrderBy', { orderBy });
-  // };
+  const handleSelectOrderBy = (orderBy: string) => {
+    addQueryParamsToUrl({ orderBy });
+    logClickEvent('filterOrderBy', { orderBy });
+  };
   const handleSearch = (searchQuery: string) => {
     addQueryParamsToUrl({ name: searchQuery });
     logSubmitEvent('searchMember', { content: 'searchQuery' });
@@ -250,7 +250,7 @@ const MemberList: FC<MemberListProps> = ({ banner }) => {
               `}
             >
               <Text>{`전체 ${memberProfileData.pages[0].totalMembersCount}명`}</Text>
-              {/* <StyledMobileFilter
+              <StyledMobileFilter
                 placeholder=''
                 options={ORDER_OPTIONS}
                 value={orderBy}
@@ -269,7 +269,7 @@ const MemberList: FC<MemberListProps> = ({ banner }) => {
                     </Text>
                   </div>
                 )}
-              /> */}
+              />
             </div>
           )}
         </Responsive>
@@ -356,7 +356,7 @@ const MemberList: FC<MemberListProps> = ({ banner }) => {
                   `}
                 >
                   <Text typography='SUIT_18_M'>{`전체 ${memberProfileData.pages[0].totalMembersCount}명`}</Text>
-                  {/* <OrderBySelect value={orderBy} onChange={handleSelectOrderBy} options={ORDER_OPTIONS} /> */}
+                  <OrderBySelect value={orderBy} onChange={handleSelectOrderBy} options={ORDER_OPTIONS} />
                 </div>
               )}
             </StyledTopWrapper>

--- a/components/members/main/hooks/useMemberProfileQuery.ts
+++ b/components/members/main/hooks/useMemberProfileQuery.ts
@@ -6,7 +6,7 @@ import { getMemberProfile } from '@/api/endpoint_LEGACY/members';
 import type { PagedMemberProfile } from '@/api/endpoint_LEGACY/members/type';
 
 interface UseMemberProfileQueryVariables {
-  limit?: number;
+  limit: number;
   queryKey?: QueryKey;
 }
 
@@ -21,13 +21,12 @@ export const useMemberProfileQuery = ({ limit, queryKey }: UseMemberProfileQuery
       const data = await getMemberProfile(qs.stringify(searchParams, { addQueryPrefix: true }));
       return data;
     },
-    getNextPageParam: (lastPage: PagedMemberProfile) => {
+    getNextPageParam: (lastPage: PagedMemberProfile, pages) => {
       if (!lastPage.hasNext) {
         return undefined;
       }
-      const lastIndex = lastPage.members.length - 1;
-      const lastMemberId = lastPage.members[lastIndex].id;
-      return lastMemberId;
+      const totalPageNum = pages.length * limit;
+      return totalPageNum;
     },
     onError: (error: { message: string }) => {
       console.error(error.message);


### PR DESCRIPTION
### 🤫 쉿, 나한테만 말해줘요. 이슈넘버
- close #

### 🧐 어떤 것을 변경했어요~?
<!-- 실제로 변경한 사항을 설명해주세요.-->
- 서버에서 cursor로 구현된 부분이 page의 lastMember의 Id를 받는식으로 되어있어서 (id가 incremental이고, 정렬이 있기 이전이라 가능) 이를 서버에서 수정해주었어요.
- 받아온 데이터의 총 갯수를 다음 커서로 보내주도록 개선되었고, 이를 대응하는 PR입니다! (`page.length * limitCount`)
- 따라서 이전에 하드코딩 해두었던 `orderBy=2` 필터를 제거하고, 등록순 필터의 주석을 해제합니다.
- [관련 스레드](https://sopt-makers.slack.com/archives/C04326AHDRT/p1684903947792499)
- 중요한 피처를 다 치고, 해당 페이지의 로직들을 좀 리팩토링 해보려 해요.. (FE 안건에 올렸던 그것!)

### 🤔 그렇다면, 어떻게 구현했어요~?
<!-- 실제로 구현한 로직에 대해 설명해주세요.-->

### ❤️‍🔥 당신이 생각하는 PR포인트, 내겐 매력포인트.
<!-- 해당 PR에서 논의가 필요한 사항을 적어주세요. -->

### 📸 스크린샷, 없으면 이것 참,, 섭섭한데요?
