### PR TITLE
feat: 멘토링 리스트 마크업

### DIFF
--- a/components/members/main/MemberList/index.tsx
+++ b/components/members/main/MemberList/index.tsx
@@ -437,7 +437,6 @@ const StyledContainer = styled.div`
   flex-direction: column;
   align-items: center;
   justify-content: center;
-  margin-top: 103px;
   padding-bottom: 100px;
   overflow-y: scroll;
 

--- a/components/mentoring/MentoringCard/index.tsx
+++ b/components/mentoring/MentoringCard/index.tsx
@@ -29,6 +29,7 @@ const Container = styled.div`
   padding-top: 35px;
   padding-left: 45px;
   width: 424px;
+  min-width: 424px;
   height: 224px;
 `;
 

--- a/components/mentoring/MentoringList/index.tsx
+++ b/components/mentoring/MentoringList/index.tsx
@@ -1,0 +1,84 @@
+import styled from '@emotion/styled';
+import { debounce } from 'lodash-es';
+import { ReactNode, useEffect, useState } from 'react';
+
+import Carousel from '@/components/common/Carousel';
+import Responsive from '@/components/common/Responsive';
+import MentoringCard from '@/components/mentoring/MentoringCard';
+import { MENTORING_CARD_DUMMY_DATA } from '@/components/mentoring/temp';
+import { colors } from '@/styles/colors';
+import { textStyles } from '@/styles/typography';
+
+export default function MentoringList() {
+  const [carouselLimit, setCarouselLimit] = useState<2 | 3>(2);
+
+  const carouselItemList = MENTORING_CARD_DUMMY_DATA.map(({ mentor, keywords, title }) => (
+    <MentoringCard
+      mentor={{ name: mentor.name, career: mentor.career }}
+      keywords={keywords}
+      title={title}
+      key={mentor.id}
+    />
+  ));
+
+  const checkScreenSize = () => {
+    if (window.innerWidth >= SCREEN_SIZE.DESKTOP_LARGE) {
+      setCarouselLimit(3);
+    } else {
+      setCarouselLimit(2);
+    }
+  };
+
+  const handleResize = debounce(() => {
+    checkScreenSize();
+  }, 1000);
+
+  useEffect(() => {
+    checkScreenSize();
+    window.addEventListener('resize', handleResize);
+    return () => window.removeEventListener('resize', handleResize);
+  }, [handleResize]);
+
+  return (
+    <Container>
+      <Title>✨ NEW! 아래의 멘토들이 멘티를 기다리고 있어요</Title>
+      <Responsive only='desktop'>
+        <Carousel
+          itemList={carouselItemList}
+          limit={carouselLimit}
+          renderItemContainer={(children: ReactNode) => <MentoringCardContainer>{children}</MentoringCardContainer>}
+        />
+      </Responsive>
+    </Container>
+  );
+}
+
+const SCREEN_SIZE = {
+  DESKTOP_LARGE: 1542,
+  DESKTOP_SMALL: 1200,
+  TABLET: 768,
+  MOBILE: 375,
+};
+
+const Container = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 40px;
+  align-items: center;
+  justify-content: center;
+  margin-top: 100px;
+`;
+
+const Title = styled.div`
+  width: 1302px;
+  line-height: 100%;
+  color: ${colors.white};
+
+  ${textStyles.SUIT_24_B}
+`;
+
+const MentoringCardContainer = styled.div`
+  display: flex;
+  gap: 15px;
+  width: fit-content;
+`;

--- a/components/mentoring/MentoringList/index.tsx
+++ b/components/mentoring/MentoringList/index.tsx
@@ -55,7 +55,7 @@ export default function MentoringList() {
 
   return (
     <Container>
-      <Title>✨ NEW! 아래의 멘토들이 멘티를 기다리고 있어요</Title>
+      <Title>{`✨ NEW! \n아래의 멘토들이 \n멘티를 기다리고 있어요`}</Title>
       {listType &&
         (listType === 'scroll' ? (
           <MentoringScrollWrapper>
@@ -109,7 +109,9 @@ const Title = styled.div`
   }
 
   @media ${TABLET_MEDIA_QUERY} {
+    padding: 0 20px;
     width: 100%;
+    white-space: pre-line;
   }
 `;
 
@@ -128,6 +130,10 @@ const MentoringCardContainer = styled.div`
 
 const MentoringScrollWrapper = styled.div`
   width: 636px;
+
+  @media ${TABLET_MEDIA_QUERY} {
+    width: 100%;
+  }
 `;
 
 const MentoringScrollList = styled.div`

--- a/components/mentoring/MentoringList/index.tsx
+++ b/components/mentoring/MentoringList/index.tsx
@@ -1,6 +1,6 @@
 import styled from '@emotion/styled';
 import { debounce } from 'lodash-es';
-import { ReactNode, useEffect, useState } from 'react';
+import { ReactNode, useEffect, useMemo, useState } from 'react';
 
 import Carousel from '@/components/common/Carousel';
 import MentoringCard from '@/components/mentoring/MentoringCard';
@@ -36,12 +36,20 @@ export default function MentoringList() {
     />
   ));
 
-  const handleResize = debounce(() => {
-    const newListType = getListType();
-    if (newListType !== listType) {
-      setListType(newListType);
-    }
-  }, 1000);
+  const memorizedDebounceSetListType = useMemo(
+    () =>
+      debounce(() => {
+        const newListType = getListType();
+        if (newListType !== listType) {
+          setListType(newListType);
+        }
+      }, 1000),
+    // useEffect에서 사용 중인 handleResize로 인한 리렌더링 방지
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [],
+  );
+
+  const handleResize = memorizedDebounceSetListType;
 
   useEffect(() => {
     setListType(getListType());

--- a/components/mentoring/MentoringList/index.tsx
+++ b/components/mentoring/MentoringList/index.tsx
@@ -8,6 +8,7 @@ import MentoringCard from '@/components/mentoring/MentoringCard';
 import { MENTORING_CARD_DUMMY_DATA } from '@/components/mentoring/temp';
 import { colors } from '@/styles/colors';
 import { textStyles } from '@/styles/typography';
+import { getScreenMaxWidthMediaQuery } from '@/utils';
 
 export default function MentoringList() {
   const [carouselLimit, setCarouselLimit] = useState<2 | 3>(2);
@@ -60,6 +61,10 @@ const SCREEN_SIZE = {
   MOBILE: 375,
 };
 
+const DESKTOP_LARGE_MEDIA_QUERY = getScreenMaxWidthMediaQuery(`${SCREEN_SIZE.DESKTOP_LARGE}px`);
+const DESKTOP_SMALL_MEDIA_QUERY = getScreenMaxWidthMediaQuery(`${SCREEN_SIZE.DESKTOP_SMALL}px`);
+const TABLET_MEDIA_QUERY = getScreenMaxWidthMediaQuery(`${SCREEN_SIZE.TABLET}px`);
+
 const Container = styled.div`
   display: flex;
   flex-direction: column;
@@ -71,14 +76,31 @@ const Container = styled.div`
 
 const Title = styled.div`
   width: 1302px;
+  text-align: start;
   line-height: 100%;
   color: ${colors.white};
 
   ${textStyles.SUIT_24_B}
+
+  @media ${DESKTOP_LARGE_MEDIA_QUERY} {
+    width: 969px;
+  }
+
+  @media ${DESKTOP_SMALL_MEDIA_QUERY} {
+    width: 636px;
+  }
+
+  @media ${TABLET_MEDIA_QUERY} {
+    width: 100%;
+  }
 `;
 
 const MentoringCardContainer = styled.div`
   display: flex;
   gap: 15px;
-  width: fit-content;
+  width: 1302px;
+
+  @media ${DESKTOP_LARGE_MEDIA_QUERY} {
+    width: 863px;
+  }
 `;

--- a/components/mentoring/MentoringList/index.tsx
+++ b/components/mentoring/MentoringList/index.tsx
@@ -3,15 +3,26 @@ import { debounce } from 'lodash-es';
 import { ReactNode, useEffect, useState } from 'react';
 
 import Carousel from '@/components/common/Carousel';
-import Responsive from '@/components/common/Responsive';
 import MentoringCard from '@/components/mentoring/MentoringCard';
 import { MENTORING_CARD_DUMMY_DATA } from '@/components/mentoring/temp';
 import { colors } from '@/styles/colors';
 import { textStyles } from '@/styles/typography';
 import { getScreenMaxWidthMediaQuery } from '@/utils';
 
+type ListType = 'carousel-large' | 'carousel-small' | 'normal' | undefined;
+
+const getListType = (): ListType => {
+  if (window.innerWidth >= SCREEN_SIZE.DESKTOP_LARGE) {
+    return 'carousel-large';
+  } else if (window.innerWidth >= SCREEN_SIZE.DESKTOP_SMALL) {
+    return 'carousel-small';
+  } else {
+    return 'normal';
+  }
+};
+
 export default function MentoringList() {
-  const [carouselLimit, setCarouselLimit] = useState<2 | 3>(2);
+  const [listType, setListType] = useState<ListType>();
 
   const carouselItemList = MENTORING_CARD_DUMMY_DATA.map(({ mentor, keywords, title }) => (
     <MentoringCard
@@ -22,20 +33,15 @@ export default function MentoringList() {
     />
   ));
 
-  const checkScreenSize = () => {
-    if (window.innerWidth >= SCREEN_SIZE.DESKTOP_LARGE) {
-      setCarouselLimit(3);
-    } else {
-      setCarouselLimit(2);
-    }
-  };
-
   const handleResize = debounce(() => {
-    checkScreenSize();
+    const newListType = getListType();
+    if (newListType !== listType) {
+      setListType(newListType);
+    }
   }, 1000);
 
   useEffect(() => {
-    checkScreenSize();
+    setListType(getListType());
     window.addEventListener('resize', handleResize);
     return () => window.removeEventListener('resize', handleResize);
   }, [handleResize]);
@@ -43,13 +49,16 @@ export default function MentoringList() {
   return (
     <Container>
       <Title>✨ NEW! 아래의 멘토들이 멘티를 기다리고 있어요</Title>
-      <Responsive only='desktop'>
-        <Carousel
-          itemList={carouselItemList}
-          limit={carouselLimit}
-          renderItemContainer={(children: ReactNode) => <MentoringCardContainer>{children}</MentoringCardContainer>}
-        />
-      </Responsive>
+      {listType &&
+        (listType === 'normal' ? (
+          <></>
+        ) : (
+          <StyledCarousel
+            itemList={carouselItemList}
+            limit={listType === 'carousel-large' ? 3 : 2}
+            renderItemContainer={(children: ReactNode) => <MentoringCardContainer>{children}</MentoringCardContainer>}
+          />
+        ))}
     </Container>
   );
 }
@@ -95,12 +104,15 @@ const Title = styled.div`
   }
 `;
 
+const StyledCarousel = styled(Carousel)`
+  width: 1414px;
+
+  @media ${DESKTOP_LARGE_MEDIA_QUERY} {
+    width: 975px;
+  }
+`;
+
 const MentoringCardContainer = styled.div`
   display: flex;
   gap: 15px;
-  width: 1302px;
-
-  @media ${DESKTOP_LARGE_MEDIA_QUERY} {
-    width: 863px;
-  }
 `;

--- a/components/mentoring/MentoringList/index.tsx
+++ b/components/mentoring/MentoringList/index.tsx
@@ -4,7 +4,6 @@ import { ReactNode, useEffect, useMemo, useState } from 'react';
 
 import Carousel from '@/components/common/Carousel';
 import MentoringCard from '@/components/mentoring/MentoringCard';
-import { MENTORING_CARD_DUMMY_DATA } from '@/components/mentoring/temp';
 import { colors } from '@/styles/colors';
 import { textStyles } from '@/styles/typography';
 import { getScreenMaxWidthMediaQuery } from '@/utils';
@@ -23,6 +22,34 @@ const getListType = (): ListType => {
     return 'scroll';
   }
 };
+
+const MENTORING_CARD_DUMMY_DATA = [
+  {
+    mentor: { id: 8, name: '남주영', career: '나사' },
+    keywords: ['별자리 찾기', '우주의 탄생 과정에 대해 알아보기'],
+    title: '정우와 함께하는 CGP Review',
+  },
+  {
+    mentor: { id: 1, name: '송정우', career: 'AWS' },
+    keywords: ['코드 리뷰', '아무거나 물어보세용', '취업 준비 과정에서 우선 순위 정하기'],
+    title: '하둘셋넷다여일여아열하둘셋넷다여일여아열하둘셋넷다여일여아열',
+  },
+  {
+    mentor: { id: 15, name: '백지연', career: '어둠의 커비단' },
+    keywords: ['코드 리뷰', '취업 준비 과정에서 우선 순위 정하기', '노동요추천-에스파스파이씨'],
+    title: '개발 천재 되는 법',
+  },
+  {
+    mentor: { id: 24, name: '김은수', career: '당근마켓' },
+    keywords: ['개자이피엠'],
+    title: '개발 천재 되는 법',
+  },
+  {
+    mentor: { id: 7, name: '이준호', career: '고수수현' },
+    keywords: ['고수수현', '중수수현', '하수수현'],
+    title: '개발 천재 되는 법',
+  },
+];
 
 export default function MentoringList() {
   const [listType, setListType] = useState<ListType>();

--- a/components/mentoring/MentoringList/index.tsx
+++ b/components/mentoring/MentoringList/index.tsx
@@ -63,6 +63,8 @@ export default function MentoringList() {
     />
   ));
 
+  const initListType = () => setListType(getListType());
+
   const handleResize = useMemo(
     () =>
       debounce(() => {
@@ -75,7 +77,7 @@ export default function MentoringList() {
   );
 
   useEffect(() => {
-    setListType(getListType());
+    initListType();
     window.addEventListener('resize', handleResize);
     return () => window.removeEventListener('resize', handleResize);
   }, [handleResize]);

--- a/components/mentoring/MentoringList/index.tsx
+++ b/components/mentoring/MentoringList/index.tsx
@@ -12,6 +12,9 @@ import { getScreenMaxWidthMediaQuery } from '@/utils';
 type ListType = 'carousel-large' | 'carousel-small' | 'normal' | undefined;
 
 const getListType = (): ListType => {
+  if (typeof window === 'undefined') {
+    return;
+  }
   if (window.innerWidth >= SCREEN_SIZE.DESKTOP_LARGE) {
     return 'carousel-large';
   } else if (window.innerWidth >= SCREEN_SIZE.DESKTOP_SMALL) {

--- a/components/mentoring/MentoringList/index.tsx
+++ b/components/mentoring/MentoringList/index.tsx
@@ -90,6 +90,17 @@ const Container = styled.div`
   align-items: center;
   justify-content: center;
   margin-top: 100px;
+  margin-bottom: 103px;
+
+  @media ${DESKTOP_SMALL_MEDIA_QUERY} {
+    margin-top: 104px;
+    margin-bottom: 48px;
+  }
+
+  @media ${TABLET_MEDIA_QUERY} {
+    margin-top: 24px;
+    margin-bottom: 40px;
+  }
 `;
 
 const Title = styled.div`

--- a/components/mentoring/MentoringList/index.tsx
+++ b/components/mentoring/MentoringList/index.tsx
@@ -9,7 +9,7 @@ import { colors } from '@/styles/colors';
 import { textStyles } from '@/styles/typography';
 import { getScreenMaxWidthMediaQuery } from '@/utils';
 
-type ListType = 'carousel-large' | 'carousel-small' | 'normal' | undefined;
+type ListType = 'carousel-large' | 'carousel-small' | 'scroll' | undefined;
 
 const getListType = (): ListType => {
   if (typeof window === 'undefined') {
@@ -20,14 +20,14 @@ const getListType = (): ListType => {
   } else if (window.innerWidth >= SCREEN_SIZE.DESKTOP_SMALL) {
     return 'carousel-small';
   } else {
-    return 'normal';
+    return 'scroll';
   }
 };
 
 export default function MentoringList() {
   const [listType, setListType] = useState<ListType>();
 
-  const carouselItemList = MENTORING_CARD_DUMMY_DATA.map(({ mentor, keywords, title }) => (
+  const mentoringCardList = MENTORING_CARD_DUMMY_DATA.map(({ mentor, keywords, title }) => (
     <MentoringCard
       mentor={{ name: mentor.name, career: mentor.career }}
       keywords={keywords}
@@ -36,7 +36,7 @@ export default function MentoringList() {
     />
   ));
 
-  const memorizedDebounceSetListType = useMemo(
+  const handleResize = useMemo(
     () =>
       debounce(() => {
         const newListType = getListType();
@@ -44,12 +44,8 @@ export default function MentoringList() {
           setListType(newListType);
         }
       }, 1000),
-    // useEffect에서 사용 중인 handleResize로 인한 리렌더링 방지
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    [],
+    [listType],
   );
-
-  const handleResize = memorizedDebounceSetListType;
 
   useEffect(() => {
     setListType(getListType());
@@ -61,11 +57,13 @@ export default function MentoringList() {
     <Container>
       <Title>✨ NEW! 아래의 멘토들이 멘티를 기다리고 있어요</Title>
       {listType &&
-        (listType === 'normal' ? (
-          <></>
+        (listType === 'scroll' ? (
+          <MentoringScrollWrapper>
+            <MentoringScrollList>{mentoringCardList}</MentoringScrollList>
+          </MentoringScrollWrapper>
         ) : (
           <StyledCarousel
-            itemList={carouselItemList}
+            itemList={mentoringCardList}
             limit={listType === 'carousel-large' ? 3 : 2}
             renderItemContainer={(children: ReactNode) => <MentoringCardContainer>{children}</MentoringCardContainer>}
           />
@@ -126,4 +124,18 @@ const StyledCarousel = styled(Carousel)`
 const MentoringCardContainer = styled.div`
   display: flex;
   gap: 15px;
+`;
+
+const MentoringScrollWrapper = styled.div`
+  width: 636px;
+`;
+
+const MentoringScrollList = styled.div`
+  display: flex;
+  gap: 8px;
+  overflow-x: auto;
+
+  &::-webkit-scrollbar {
+    display: none;
+  }
 `;

--- a/pages/members/index.tsx
+++ b/pages/members/index.tsx
@@ -9,7 +9,7 @@ import OnBoardingBanner from '@/components/members/main/MemberList/OnBoardingBan
 import { MOBILE_MEDIA_QUERY } from '@/styles/mediaQuery';
 import { setLayout } from '@/utils/layout';
 
-const UserPage: FC = () => {
+const MemberPage: FC = () => {
   const { data: memberOfMeData } = useGetMemberOfMe();
 
   const hasProfile = !!memberOfMeData?.hasProfile;
@@ -23,9 +23,9 @@ const UserPage: FC = () => {
   );
 };
 
-setLayout(UserPage, 'headerFooter');
+setLayout(MemberPage, 'headerFooter');
 
-export default UserPage;
+export default MemberPage;
 
 const StyledOnBoardingBanner = styled(OnBoardingBanner)`
   margin-bottom: 90px;

--- a/pages/members/index.tsx
+++ b/pages/members/index.tsx
@@ -6,6 +6,7 @@ import AuthRequired from '@/components/auth/AuthRequired';
 import ActiveBannerSlot from '@/components/common/Banner/ActiveBannerSlot';
 import MemberList from '@/components/members/main/MemberList';
 import OnBoardingBanner from '@/components/members/main/MemberList/OnBoardingBanner';
+import MentoringList from '@/components/mentoring/MentoringList';
 import { MOBILE_MEDIA_QUERY } from '@/styles/mediaQuery';
 import { setLayout } from '@/utils/layout';
 
@@ -18,6 +19,7 @@ const MemberPage: FC = () => {
   return (
     <AuthRequired>
       <ActiveBannerSlot />
+      <MentoringList />
       <MemberList banner={onboardingBanner} />
     </AuthRequired>
   );

--- a/utils/index.ts
+++ b/utils/index.ts
@@ -28,3 +28,5 @@ export const convertMillisecondsIntoDateValues = (milliseconds: number) => {
   const seconds = Math.floor((milliseconds % (1000 * 60)) / 1000);
   return { days, hours, minutes, seconds };
 };
+
+export const getScreenMaxWidthMediaQuery = (maxWidth: string) => `screen and (max-width: ${maxWidth})`;


### PR DESCRIPTION
### 🤫 쉿, 나한테만 말해줘요. 이슈넘버
- close #

### 🧐 어떤 것을 변경했어요~?
<!-- 실제로 변경한 사항을 설명해주세요.-->

멘토링 리스트 마크업을 했어요

- 각종 브레이크 포인트에 따라 다른 형태를 취하도록 했어요


### 🤔 그렇다면, 어떻게 구현했어요~?
<!-- 실제로 구현한 로직에 대해 설명해주세요.-->



### ❤️‍🔥 당신이 생각하는 PR포인트, 내겐 매력포인트.
<!-- 해당 PR에서 논의가 필요한 사항을 적어주세요. -->

### 📸 스크린샷, 없으면 이것 참,, 섭섭한데요?

디바운스 때문에 조금씩 늦게 반응하지만, 사용자가 화면 크기를 바꾸는 일이 해당 뷰의 메인 동작이 아니니까 한 번 바꿀 때 조금의 딜레이는 괜찮다고 생각했어요


https://github.com/sopt-makers/sopt-playground-frontend/assets/73823388/02e1f2ec-55dd-46fc-8326-9d27cdd4b13d

