### PR TITLE
fix: 한글 파일명 이미지 깨지는 버그 fix

### DIFF
--- a/api/endpoint_LEGACY/image/index.ts
+++ b/api/endpoint_LEGACY/image/index.ts
@@ -9,7 +9,7 @@ export const getPresignedUrl = async ({
 }): Promise<{ filename: string; signedUrl: string }> => {
   const { data } = await axiosInstance.request<{ filename: string; signedUrl: string }>({
     method: 'GET',
-    url: `api/v1/presigned-url?filename=${filename}${type ? `&type=${type}` : ''}`,
+    url: `api/v1/presigned-url?filename=${encodeURIComponent(filename)}${type ? `&type=${type}` : ''}`,
   });
 
   return data;


### PR DESCRIPTION
### 🤫 쉿, 나한테만 말해줘요. 이슈넘버
- close #701 

### 🧐 어떤 것을 변경했어요~?
<!-- 실제로 변경한 사항을 설명해주세요.-->

한글 파일명일 때 aws에서 인코딩한 문자열과 fe에서 인코딩한 문자열이 달라서 생긴 이슈 => fe에서 인코딩을 해서 보냅니다

### 🤔 그렇다면, 어떻게 구현했어요~?
<!-- 실제로 구현한 로직에 대해 설명해주세요.-->

### ❤️‍🔥 당신이 생각하는 PR포인트, 내겐 매력포인트.
<!-- 해당 PR에서 논의가 필요한 사항을 적어주세요. -->

### 📸 스크린샷, 없으면 이것 참,, 섭섭한데요?
