### PR TITLE
fix: 캐러셀 > 스크린 리사이징으로 인해 존재하지 않는 페이지 넘버가 된 경우 대응

### DIFF
--- a/components/common/Carousel/useCarousel.ts
+++ b/components/common/Carousel/useCarousel.ts
@@ -1,4 +1,4 @@
-import { ReactNode, useMemo, useState } from 'react';
+import { ReactNode, useEffect, useMemo, useState } from 'react';
 
 import usePagination from '@/hooks/usePagination';
 
@@ -23,18 +23,27 @@ export default function useCarousel({ limit, itemList }: { limit: number; itemLi
     movePreviousPage();
     setDirection('previous');
   };
-  const move = (newPage: number) => {
-    if (page === newPage) {
-      return;
-    }
-    if (paginate(newPage)) {
-      if (page < newPage) {
-        setDirection('next');
-      } else {
-        setDirection('previous');
+  const move = useMemo(
+    () => (newPage: number) => {
+      if (page === newPage) {
+        return;
       }
+      if (paginate(newPage)) {
+        if (page < newPage) {
+          setDirection('next');
+        } else {
+          setDirection('previous');
+        }
+      }
+    },
+    [page, paginate],
+  );
+
+  useEffect(() => {
+    if (totalPageSize < page) {
+      move(totalPageSize);
     }
-  };
+  }, [totalPageSize, page, move]);
 
   return { page, direction, moveNext, movePrevious, currentItemList, totalPageSize, move };
 }


### PR DESCRIPTION
### 🤫 쉿, 나한테만 말해줘요. 이슈넘버
- close #748

### 🧐 어떤 것을 변경했어요~?
<!-- 실제로 변경한 사항을 설명해주세요.-->

리사이징 등의 이유로 limit가 늘어나면 마지막 페이지 근방은 존재하지 않는 페이지가 될 수 있어요 이 경우에 현재의 마지막 페이지로 바꾸어 줍니다


### 🤔 그렇다면, 어떻게 구현했어요~?
<!-- 실제로 구현한 로직에 대해 설명해주세요.-->

### ❤️‍🔥 당신이 생각하는 PR포인트, 내겐 매력포인트.
<!-- 해당 PR에서 논의가 필요한 사항을 적어주세요. -->

### 📸 스크린샷, 없으면 이것 참,, 섭섭한데요?
