### PR TITLE
fix: 쪽지 모달 > 쪽지 보내기 버튼 로딩 스피너 보이지 않는 버그 fix

### DIFF
--- a/components/common/Loading/index.tsx
+++ b/components/common/Loading/index.tsx
@@ -31,27 +31,34 @@ const variants: AnimationProps['variants'] = {
   },
 };
 
+type LoadingColor = 'default' | 'white';
+
 interface LoadingProps {
   type?: 'default' | 'fullPage';
+  color?: LoadingColor;
 }
-const Loading: FC<LoadingProps> = ({ type = 'default' }) => {
+const Loading: FC<LoadingProps> = ({ type = 'default', color = 'default' }) => {
   if (type === 'fullPage') {
     return (
       <FullPageWrapper>
-        <LoadingDefault />
+        <LoadingDefault color={color} />
       </FullPageWrapper>
     );
   }
-  return <LoadingDefault />;
+  return <LoadingDefault color={color} />;
 };
 
 export default Loading;
 
-const LoadingDefault = () => (
+interface LoadingDefaultProps {
+  color: LoadingColor;
+}
+
+const LoadingDefault = ({ color }: LoadingDefaultProps) => (
   <StyledLoading>
-    <LoadingDot variants={variants} animate='loadingOne' />
-    <LoadingDot variants={variants} animate='loadingTwo' />
-    <LoadingDot variants={variants} animate='loadingThree' />
+    <LoadingDot variants={variants} animate='loadingOne' color={color} />
+    <LoadingDot variants={variants} animate='loadingTwo' color={color} />
+    <LoadingDot variants={variants} animate='loadingThree' color={color} />
   </StyledLoading>
 );
 
@@ -69,9 +76,9 @@ const StyledLoading = styled.div`
   align-items: center;
 `;
 
-const LoadingDot = styled(m.span)`
+const LoadingDot = styled(m.span)<{ color: LoadingColor }>`
   border-radius: 100%;
-  background-color: ${colors.purple100};
+  background-color: ${({ color }) => (color === 'default' ? colors.purple100 : colors.white)};
   width: 12px;
   height: 12px;
 `;

--- a/components/members/detail/MessageSection/MessageModal.tsx
+++ b/components/members/detail/MessageSection/MessageModal.tsx
@@ -173,7 +173,7 @@ const MessageModal: FC<MessageModalProps> = ({
         />
         <StyledButton isDisabled={!isValid}>
           {isLoading ? (
-            <Loading />
+            <Loading color='white' />
           ) : (
             <Text typography='SUIT_15_SB' color={isValid ? colors.white : colors.gray80}>
               쪽지 보내기


### PR DESCRIPTION
### 🤫 쉿, 나한테만 말해줘요. 이슈넘버
- close #640 

### 🧐 어떤 것을 변경했어요~?
<!-- 실제로 변경한 사항을 설명해주세요.-->

쪽지 보낼 때 버튼 텍스트가 사라지길래 고치려고 했는데 알고 보니 로딩 스피너가 들어가 있었고 그것이 버튼 색상과 같아서 보이지 않았던 것이었습니다
따라서 로딩 스피너를 흰색으로 바꾸었습니다

### 🤔 그렇다면, 어떻게 구현했어요~?
<!-- 실제로 구현한 로직에 대해 설명해주세요.-->

Loading 컴포넌트에 color prop을 추가했어요

### ❤️‍🔥 당신이 생각하는 PR포인트, 내겐 매력포인트.
<!-- 해당 PR에서 논의가 필요한 사항을 적어주세요. -->

### 📸 스크린샷, 없으면 이것 참,, 섭섭한데요?


https://github.com/sopt-makers/sopt-playground-frontend/assets/73823388/a453d471-f945-461f-9cbf-64e08a88e37e

