### PR TITLE
fix: 내 프로필일 경우에만 업로드 넛지 영역 보이도록 수정

### DIFF
--- a/api/endpoint/members/getMemberOfMe.ts
+++ b/api/endpoint/members/getMemberOfMe.ts
@@ -1,0 +1,39 @@
+import { useQuery } from '@tanstack/react-query';
+import { z } from 'zod';
+
+import { createEndpoint } from '@/api/typedAxios';
+
+/**
+ * @desc 자신의 토큰으로 조회
+ */
+export const getMemberOfMe = createEndpoint({
+  request: {
+    method: 'GET',
+    url: 'api/v1/members/me',
+  },
+  serverResponseScheme: z.object({
+    id: z.number(),
+    name: z.string(),
+    generation: z.number(),
+    hasProfile: z.boolean(),
+    profileImage: z.string().nullable(),
+  }),
+});
+
+/**
+ * @desc 멤버 프로필 조회
+ */
+export const useGetMemberOfMe = () => {
+  return useQuery(
+    ['getMemberOfMe'],
+    async () => {
+      const data = await getMemberOfMe.request();
+      return data;
+    },
+    {
+      onError: (error: { message: string }) => {
+        console.error(error.message);
+      },
+    },
+  );
+};

--- a/api/endpoint_LEGACY/hooks/members.ts
+++ b/api/endpoint_LEGACY/hooks/members.ts
@@ -2,29 +2,9 @@ import { useMutation, useQuery, UseQueryOptions } from '@tanstack/react-query';
 import { AxiosError } from 'axios';
 
 import { getMembersSearchByName } from '@/api/endpoint/members/getMembersSearchByName';
-import {
-  getMemberOfMe,
+import { getMemberProfileById, postMemberCoffeeChat } from '@/api/endpoint_LEGACY/members';
   getMemberProfileById,
-  getMemberProfileOfMe,
-  postMemberCoffeeChat,
-} from '@/api/endpoint_LEGACY/members';
 import { PostMemberCoffeeChatVariables, ProfileDetail } from '@/api/endpoint_LEGACY/members/type';
-
-// 멤버 프로필 조회
-export const useGetMemberOfMe = () => {
-  return useQuery(
-    ['getMemberOfMe'],
-    async () => {
-      const data = await getMemberOfMe();
-      return data;
-    },
-    {
-      onError: (error: { message: string }) => {
-        console.error(error.message);
-      },
-    },
-  );
-};
 
 // 멤버 프로필 조회
 export const useGetMemberProfileById = (

--- a/api/endpoint_LEGACY/hooks/members.ts
+++ b/api/endpoint_LEGACY/hooks/members.ts
@@ -2,8 +2,7 @@ import { useMutation, useQuery, UseQueryOptions } from '@tanstack/react-query';
 import { AxiosError } from 'axios';
 
 import { getMembersSearchByName } from '@/api/endpoint/members/getMembersSearchByName';
-import { getMemberProfileById, postMemberCoffeeChat } from '@/api/endpoint_LEGACY/members';
-  getMemberProfileById,
+import { getMemberProfileById, getMemberProfileOfMe, postMemberCoffeeChat } from '@/api/endpoint_LEGACY/members';
 import { PostMemberCoffeeChatVariables, ProfileDetail } from '@/api/endpoint_LEGACY/members/type';
 
 // 멤버 프로필 조회

--- a/api/endpoint_LEGACY/members/index.ts
+++ b/api/endpoint_LEGACY/members/index.ts
@@ -28,16 +28,6 @@ export const getMemberById = async (id: number) => {
   return data;
 };
 
-// 자신의 토큰으로 조회
-export const getMemberOfMe = async () => {
-  const data = await axiosInstance.request<Member>({
-    method: 'GET',
-    url: `api/v1/members/me`,
-  });
-
-  return data.data;
-};
-
 // 멤버 프로필 조회
 export const getMemberProfileById = async (id: number | undefined) => {
   if (typeof id === 'undefined') throw new Error('Invalid id');

--- a/components/common/Header/index.tsx
+++ b/components/common/Header/index.tsx
@@ -2,7 +2,7 @@ import Link from 'next/link';
 import { useRouter } from 'next/router';
 import { FC } from 'react';
 
-import { useGetMemberOfMe } from '@/api/endpoint_LEGACY/hooks';
+import { useGetMemberOfMe } from '@/api/endpoint/members/getMemberOfMe';
 import useAuth from '@/components/auth/useAuth';
 import DesktopHeader from '@/components/common/Header/desktop/DesktopHeader';
 import MobileHeader from '@/components/common/Header/mobile/MobileHeader';

--- a/components/eventLogger/providers/AmplitudeProvider.tsx
+++ b/components/eventLogger/providers/AmplitudeProvider.tsx
@@ -1,6 +1,6 @@
 import { FC, ReactNode, useEffect, useState } from 'react';
 
-import { useGetMemberOfMe } from '@/api/endpoint_LEGACY/hooks';
+import { useGetMemberOfMe } from '@/api/endpoint/members/getMemberOfMe';
 import { EventLoggerContext } from '@/components/eventLogger/context';
 import { createConsoleLogController } from '@/components/eventLogger/controllers/consoleLog';
 

--- a/components/members/detail/MemberDetail.tsx
+++ b/components/members/detail/MemberDetail.tsx
@@ -9,6 +9,7 @@ import MailIcon from 'public/icons/icon-mail.svg';
 import ProfileIcon from 'public/icons/icon-profile.svg';
 import { FC, useMemo } from 'react';
 
+import { useGetMemberOfMe } from '@/api/endpoint/members/getMemberOfMe';
 import { useGetMemberProfileById } from '@/api/endpoint_LEGACY/hooks';
 import { isProjectCategory } from '@/api/endpoint_LEGACY/projects/type';
 import Loading from '@/components/common/Loading';
@@ -49,6 +50,7 @@ const MemberDetail: FC<MemberDetailProps> = ({ memberId }) => {
   const { logClickEvent, logPageViewEvent } = useEventLogger();
   const router = useRouter();
   const { data: profile, isLoading, error } = useGetMemberProfileById(safeParseInt(memberId) ?? undefined);
+  const { data: me } = useGetMemberOfMe();
 
   const sortedSoptActivities = useMemo(() => {
     if (!profile?.soptActivities) {
@@ -229,14 +231,16 @@ const MemberDetail: FC<MemberDetailProps> = ({ memberId }) => {
           {profile.projects.length === 0 && (
             <>
               <ProjectSub>아직 참여한 프로젝트가 없어요</ProjectSub>
-              <ProjectUploadNudge>
-                <Text typography='SUIT_14_M' style={{ textAlign: 'center', lineHeight: '24px' }}>
-                  참여한 프로젝트를 등록하면 <br />
-                  공식 홈페이지에도 프로젝트가 업로드 돼요!
-                </Text>
-                <ProjectUploadButton href={playgroundLink.projectUpload()}>+ 내 프로젝트 올리기</ProjectUploadButton>
-                <ProjectUploadMaskImg src='/icons/img/project-mask.png' alt='project-mask-image' />
-              </ProjectUploadNudge>
+              {String(me?.id) === memberId && (
+                <ProjectUploadNudge>
+                  <Text typography='SUIT_14_M' style={{ textAlign: 'center', lineHeight: '24px' }}>
+                    참여한 프로젝트를 등록하면 <br />
+                    공식 홈페이지에도 프로젝트가 업로드 돼요!
+                  </Text>
+                  <ProjectUploadButton href={playgroundLink.projectUpload()}>+ 내 프로젝트 올리기</ProjectUploadButton>
+                  <ProjectUploadMaskImg src='/icons/img/project-mask.png' alt='project-mask-image' />
+                </ProjectUploadNudge>
+              )}
             </>
           )}
         </ProjectContainer>

--- a/components/projects/main/ProjectDetail.tsx
+++ b/components/projects/main/ProjectDetail.tsx
@@ -4,7 +4,7 @@ import Link from 'next/link';
 import { useRouter } from 'next/router';
 import { FC, useMemo, useState } from 'react';
 
-import { useGetMemberOfMe } from '@/api/endpoint_LEGACY/hooks';
+import { useGetMemberOfMe } from '@/api/endpoint/members/getMemberOfMe';
 import { deleteProject } from '@/api/endpoint_LEGACY/projects';
 import ConfirmModal from '@/components/common/Modal/Confirm';
 import MemberBlock from '@/components/members/common/MemberBlock';

--- a/pages/members/index.tsx
+++ b/pages/members/index.tsx
@@ -1,7 +1,7 @@
 import styled from '@emotion/styled';
 import { FC } from 'react';
 
-import { useGetMemberOfMe } from '@/api/endpoint_LEGACY/hooks';
+import { useGetMemberOfMe } from '@/api/endpoint/members/getMemberOfMe';
 import AuthRequired from '@/components/auth/AuthRequired';
 import ActiveBannerSlot from '@/components/common/Banner/ActiveBannerSlot';
 import MemberList from '@/components/members/main/MemberList';

--- a/pages/projects/upload/index.tsx
+++ b/pages/projects/upload/index.tsx
@@ -5,7 +5,8 @@ import { useRouter } from 'next/router';
 import { FC, useEffect } from 'react';
 import { FormProvider, useForm } from 'react-hook-form';
 
-import { useGetMemberOfMe, useGetProjectById } from '@/api/endpoint_LEGACY/hooks';
+import { useGetMemberOfMe } from '@/api/endpoint/members/getMemberOfMe';
+import { useGetProjectById } from '@/api/endpoint_LEGACY/hooks';
 import { putProject } from '@/api/endpoint_LEGACY/projects';
 import AuthRequired from '@/components/auth/AuthRequired';
 import Button from '@/components/common/Button';


### PR DESCRIPTION
### 🤫 쉿, 나한테만 말해줘요. 이슈넘버
- close #769 

### 🧐 어떤 것을 변경했어요~?
<!-- 실제로 변경한 사항을 설명해주세요.-->
- 프로젝트 업로드 넛지 영역이 내 프로필에서만 보이도록 수정했어요.
- 하는 김에 `endpoint_LAGECY`도 수정했어요!
- 관련 hook을 같은 파일에 만들었는데, 관련해서 의견 있으시면 말씀해주세요! (기존엔 `endpoint_legacy/hooks`) FE 회의때 얘기해봐도 좋겠습니당

### 🤔 그렇다면, 어떻게 구현했어요~?
<!-- 실제로 구현한 로직에 대해 설명해주세요.-->

### ❤️‍🔥 당신이 생각하는 PR포인트, 내겐 매력포인트.
<!-- 해당 PR에서 논의가 필요한 사항을 적어주세요. -->

### 📸 스크린샷, 없으면 이것 참,, 섭섭한데요?
