### PR TITLE
refactor: 파라미터 없는 이벤트 사용 개선

### DIFF
--- a/components/common/Footer/index.tsx
+++ b/components/common/Footer/index.tsx
@@ -22,7 +22,7 @@ const Footer: FC<FooterProps> = ({}) => {
   return (
     <StyledFooter hide={isScrollingDown && !isScrollTop}>
       <Link href={playgroundLink.makers()} passHref legacyBehavior>
-        <FooterLink highlight={pathname === playgroundLink.makers()} onClick={() => logClickEvent('aboutMakers', {})}>
+        <FooterLink highlight={pathname === playgroundLink.makers()} onClick={() => logClickEvent('aboutMakers')}>
           만든 사람들
         </FooterLink>
       </Link>

--- a/components/common/Header/index.tsx
+++ b/components/common/Header/index.tsx
@@ -26,7 +26,7 @@ const Header: FC = () => {
     }
     if (me && href.includes(playgroundLink.memberDetail(`${me.id}`))) {
       return (
-        <Link href={href} onClick={() => logClickEvent('myProfile', {})}>
+        <Link href={href} onClick={() => logClickEvent('myProfile')}>
           {children}
         </Link>
       );

--- a/components/eventLogger/controllers/amplitude.ts
+++ b/components/eventLogger/controllers/amplitude.ts
@@ -9,14 +9,14 @@ export function createAmplitudeController(apiKey: string, userId: string | undef
   });
 
   return {
-    clickEvent(key, params) {
-      instance.track(`Click-${key}`, params);
+    clickEvent(key, ...params) {
+      instance.track(`Click-${key}`, ...params);
     },
-    submitEvent(key, params) {
-      instance.track(`Submit-${key}`, params);
+    submitEvent(key, ...params) {
+      instance.track(`Submit-${key}`, ...params);
     },
-    pageViewEvent(key, params) {
-      instance.track(`Pageview-${key}`, params);
+    pageViewEvent(key, ...params) {
+      instance.track(`Pageview-${key}`, ...params);
     },
   };
 }

--- a/components/eventLogger/controllers/consoleLog.ts
+++ b/components/eventLogger/controllers/consoleLog.ts
@@ -2,14 +2,14 @@ import { EventLoggerController } from '@/components/eventLogger/types';
 
 export function createConsoleLogController(): EventLoggerController {
   return {
-    clickEvent(key, params) {
-      console.log('[EventLogger.clickEvent]', key, params);
+    clickEvent(key, ...params) {
+      console.log('[EventLogger.clickEvent]', key, ...params);
     },
-    submitEvent(key, params) {
-      console.log('[EventLogger.submitEvent]', key, params);
+    submitEvent(key, ...params) {
+      console.log('[EventLogger.submitEvent]', key, ...params);
     },
-    pageViewEvent(key, params) {
-      console.log('[EventLogger.pageviewEvent]', key, params);
+    pageViewEvent(key, ...params) {
+      console.log('[EventLogger.pageviewEvent]', key, ...params);
     },
   };
 }

--- a/components/eventLogger/controllers/storybookAction.ts
+++ b/components/eventLogger/controllers/storybookAction.ts
@@ -4,14 +4,14 @@ import { EventLoggerController } from '@/components/eventLogger/types';
 
 export function createStorybookActionController(): EventLoggerController {
   return {
-    clickEvent(key, params) {
-      action('EventLogger.clickEvent')(key, params);
+    clickEvent(key, ...params) {
+      action('EventLogger.clickEvent')(key, ...params);
     },
-    submitEvent(key, params) {
-      action('EventLogger.submitEvent')(key, params);
+    submitEvent(key, ...params) {
+      action('EventLogger.submitEvent')(key, ...params);
     },
-    pageViewEvent(key, params) {
-      action('EventLogger.pageviewEvent')(key, params);
+    pageViewEvent(key, ...params) {
+      action('EventLogger.pageviewEvent')(key, ...params);
     },
   };
 }

--- a/components/eventLogger/events.ts
+++ b/components/eventLogger/events.ts
@@ -10,30 +10,16 @@ type ProjectCard = {
 export interface ClickEvents {
   memberCard: MemberCard;
   projectCard: ProjectCard;
-  registerLink: {
-    //
-  };
+  registerLink: undefined;
   registerWith: {
     method: 'facebook' | 'google' | 'apple';
   };
-  onboardingBannerProjectUpload: {
-    //
-  };
-  onboardingBannerProfileUpload: {
-    //
-  };
-  myProfile: {
-    //
-  };
-  editProfile: {
-    //
-  };
-  submitProfile: {
-    //
-  };
-  aboutMakers: {
-    //
-  };
+  onboardingBannerProjectUpload: undefined;
+  onboardingBannerProfileUpload: undefined;
+  myProfile: undefined;
+  editProfile: undefined;
+  submitProfile: undefined;
+  aboutMakers: undefined;
   filterGeneration: {
     generation: string;
   };
@@ -52,9 +38,7 @@ export interface ClickEvents {
   filterOrderBy: {
     orderBy: string;
   };
-  mentoringCarouselButton: {
-    //
-  };
+  mentoringCarouselButton: undefined;
   mentoringCard: {
     mentorId: number;
   };
@@ -73,9 +57,7 @@ export interface SubmitEvents {
   searchMember: {
     content: string;
   };
-  editProfile: {
-    //
-  };
+  editProfile: undefined;
   verify: {
     by: 'phone' | 'email';
   };
@@ -87,9 +69,7 @@ export interface SubmitEvents {
 }
 
 export interface PageViewEvents {
-  mamberPageList: {
-    //
-  };
+  mamberPageList: undefined;
   memberCard: MemberCard;
   projectCard: ProjectCard;
   mentoringDetail: {

--- a/components/eventLogger/types.ts
+++ b/components/eventLogger/types.ts
@@ -1,7 +1,9 @@
 import { ClickEvents, PageViewEvents, SubmitEvents } from '@/components/eventLogger/events';
 
 export interface EventLoggerController {
-  clickEvent<K extends keyof ClickEvents>(key: K, params: ClickEvents[K]): void;
-  submitEvent<K extends keyof SubmitEvents>(key: K, params: SubmitEvents[K]): void;
-  pageViewEvent<K extends keyof PageViewEvents>(key: K, params?: PageViewEvents[K]): void;
+  clickEvent<K extends keyof ClickEvents>(key: K, ...params: ParamTuple<ClickEvents[K]>): void;
+  submitEvent<K extends keyof SubmitEvents>(key: K, ...params: ParamTuple<SubmitEvents[K]>): void;
+  pageViewEvent<K extends keyof PageViewEvents>(key: K, ...params: ParamTuple<PageViewEvents[K]>): void;
 }
+
+type ParamTuple<T> = T extends undefined ? [] : [params: T];

--- a/components/members/detail/MemberDetail.tsx
+++ b/components/members/detail/MemberDetail.tsx
@@ -123,7 +123,7 @@ const MemberDetail: FC<MemberDetailProps> = ({ memberId }) => {
             <EditButton
               onClick={() => {
                 router.push(playgroundLink.memberEdit());
-                logClickEvent('editProfile', {});
+                logClickEvent('editProfile');
               }}
             >
               <EditIcon />

--- a/components/members/main/MemberList/OnBoardingBanner.tsx
+++ b/components/members/main/MemberList/OnBoardingBanner.tsx
@@ -39,12 +39,10 @@ const OnBoardingBanner: FC<OnBoardingBannerProps> = ({ className, name }) => {
       </LeftContainer>
       <ButtonContainer>
         <Link href={playgroundLink.projectUpload()} passHref legacyBehavior>
-          <UploadButton onClick={() => logClickEvent('onboardingBannerProjectUpload', {})}>
-            프로젝트 업로드
-          </UploadButton>
+          <UploadButton onClick={() => logClickEvent('onboardingBannerProjectUpload')}>프로젝트 업로드</UploadButton>
         </Link>
         <Link href={playgroundLink.memberUpload()} passHref legacyBehavior>
-          <ProfileButton onClick={() => logClickEvent('onboardingBannerProfileUpload', {})}>프로필 추가</ProfileButton>
+          <ProfileButton onClick={() => logClickEvent('onboardingBannerProfileUpload')}>프로필 추가</ProfileButton>
         </Link>
       </ButtonContainer>
     </IntroducePanel>

--- a/components/members/main/MemberList/index.tsx
+++ b/components/members/main/MemberList/index.tsx
@@ -96,7 +96,7 @@ const MemberList: FC<MemberListProps> = ({ banner }) => {
   );
 
   useRunOnce(() => {
-    logPageViewEvent('mamberPageList', {});
+    logPageViewEvent('mamberPageList');
   }, []);
 
   useEffect(() => {

--- a/components/mentoring/MentoringList/index.tsx
+++ b/components/mentoring/MentoringList/index.tsx
@@ -68,7 +68,7 @@ export default function MentoringList() {
   );
 
   const eventLogger = {
-    moveCarousel: () => logClickEvent('mentoringCarouselButton', {}),
+    moveCarousel: () => logClickEvent('mentoringCarouselButton'),
     clickCarouselCard: (mentorId: number) => logClickEvent('mentoringCard', { mentorId }),
   };
 

--- a/pages/auth/login.tsx
+++ b/pages/auth/login.tsx
@@ -83,7 +83,7 @@ const LoginPage: FC = () => {
         </LinkContainer>
         <RegisterInfo>
           Playground가 처음이신가요?{' '}
-          <RegisterLink href={playgroundLink.register()} onClick={() => logClickEvent('registerLink', {})}>
+          <RegisterLink href={playgroundLink.register()} onClick={() => logClickEvent('registerLink')}>
             회원가입하기
           </RegisterLink>
         </RegisterInfo>

--- a/pages/members/edit.tsx
+++ b/pages/members/edit.tsx
@@ -121,7 +121,7 @@ export default function MemberEditPage() {
 
     router.push(playgroundLink.memberDetail(response.id));
 
-    logSubmitEvent('editProfile', {});
+    logSubmitEvent('editProfile');
   };
 
   useEffect(() => {


### PR DESCRIPTION
### 🤫 쉿, 나한테만 말해줘요. 이슈넘버


### 🧐 어떤 것을 변경했어요~?
<!-- 실제로 변경한 사항을 설명해주세요.-->

기존에 파라미터 없는 이벤트도 `logClickEvent('myProfile', {})` 와 같이 빈 객체를 넣어줘야하는 불편함이 있었는데, 이제 파라미터 타입을 undefined 로 선언하면 빈 객체를 넣지 않아도 되도록 개선했어요!



### 🤔 그렇다면, 어떻게 구현했어요~?
<!-- 실제로 구현한 로직에 대해 설명해주세요.-->

components/eventLogger/types.ts 파일이 핵심인데요, 그저께 새로 알아낸 기법을 활용하여 이벤트 파라미터 타입이 undefined 인경우 함수의 spread된 인자를 빈 튜플로 줘서 인자를 받지 않도록 하고, 아닐 경우 원래의 이벤트 파라미터를 받도록 했어요.

### ❤️‍🔥 당신이 생각하는 PR포인트, 내겐 매력포인트.
<!-- 해당 PR에서 논의가 필요한 사항을 적어주세요. -->

### 📸 스크린샷, 없으면 이것 참,, 섭섭한데요?
