### PR TITLE
feat: 프로필 수정/업로드 버튼에 disable 상태 추가

### DIFF
--- a/components/members/upload/forms/Form.tsx
+++ b/components/members/upload/forms/Form.tsx
@@ -13,9 +13,10 @@ interface MemberFormProps {
   type: FormType;
   children: ReactNode;
   onSubmit: () => void;
+  isValid: boolean;
 }
 
-export default function MemberForm({ type, children, onSubmit }: MemberFormProps) {
+export default function MemberForm({ type, children, onSubmit, isValid }: MemberFormProps) {
   return (
     <StyledContainer>
       <StyledHeader>
@@ -25,16 +26,16 @@ export default function MemberForm({ type, children, onSubmit }: MemberFormProps
       <StyledForm onSubmit={(e) => e.preventDefault()}>
         {children}
         <Responsive only='desktop'>
-          <StyledFooter className='pc-only'>
+          <StyledFooter>
             <div className='button-wrapper'>
-              <button onClick={onSubmit} className='submit'>
+              <DesktopSubmitButton onClick={onSubmit} isDisabled={!isValid} disabled={!isValid}>
                 프로필 {TYPE_MAP[type]}하기
-              </button>
+              </DesktopSubmitButton>
             </div>
           </StyledFooter>
         </Responsive>
         <Responsive only='mobile' asChild>
-          <MobileSubmitButton onClick={onSubmit} className='mobile-only'>
+          <MobileSubmitButton onClick={onSubmit} isDisabled={!isValid} disabled={!isValid}>
             완료
           </MobileSubmitButton>
         </Responsive>
@@ -107,16 +108,6 @@ const StyledForm = styled.form`
   }
 `;
 
-const MobileSubmitButton = styled.button`
-  margin-top: 18px;
-  border-radius: 12px;
-  background-color: ${colors.purple100};
-  padding: 18px 0;
-  color: ${colors.white100};
-  font-size: 16px;
-  font-weight: 600;
-`;
-
 const StyledFooter = styled.div`
   display: flex;
   position: fixed;
@@ -128,26 +119,34 @@ const StyledFooter = styled.div`
   width: 100vw;
   height: 90px;
 
-  .submit {
-    border-radius: 100px;
-    background-color: ${colors.purple100};
-    padding: 18px 50px;
-
-    ${textStyles.SUIT_14_M}
-  }
-
   .button-wrapper {
     display: flex;
     align-items: center;
     justify-content: flex-end;
     width: 790px;
 
-    button {
-      cursor: pointer;
-    }
-
     @media (max-width: 790px) {
       width: 100%;
     }
   }
+`;
+
+const SubmitButton = styled.button<{ isDisabled: boolean }>`
+  background-color: ${({ isDisabled }) => (isDisabled ? colors.black60 : colors.purple100)};
+  color: ${({ isDisabled }) => (isDisabled ? colors.gray80 : colors.white100)};
+`;
+
+const DesktopSubmitButton = styled(SubmitButton)`
+  border-radius: 100px;
+  padding: 18px 50px;
+
+  ${textStyles.SUIT_14_M}
+`;
+
+const MobileSubmitButton = styled(SubmitButton)`
+  margin-top: 18px;
+  border-radius: 12px;
+  padding: 18px 0;
+
+  ${textStyles.SUIT_16_SB}
 `;

--- a/components/members/upload/forms/Form.tsx
+++ b/components/members/upload/forms/Form.tsx
@@ -1,6 +1,7 @@
 import styled from '@emotion/styled';
 import { ReactNode } from 'react';
 
+import Responsive from '@/components/common/Responsive';
 import { colors } from '@/styles/colors';
 import { MOBILE_MEDIA_QUERY } from '@/styles/mediaQuery';
 import { textStyles } from '@/styles/typography';
@@ -23,16 +24,20 @@ export default function MemberForm({ type, children, onSubmit }: MemberFormProps
       </StyledHeader>
       <StyledForm onSubmit={(e) => e.preventDefault()}>
         {children}
-        <MobileSubmitButton onClick={onSubmit} className='mobile-only'>
-          완료
-        </MobileSubmitButton>
-        <StyledFooter className='pc-only'>
-          <div className='button-wrapper'>
-            <button onClick={onSubmit} className='submit'>
-              프로필 {TYPE_MAP[type]}하기
-            </button>
-          </div>
-        </StyledFooter>
+        <Responsive only='desktop'>
+          <StyledFooter className='pc-only'>
+            <div className='button-wrapper'>
+              <button onClick={onSubmit} className='submit'>
+                프로필 {TYPE_MAP[type]}하기
+              </button>
+            </div>
+          </StyledFooter>
+        </Responsive>
+        <Responsive only='mobile' asChild>
+          <MobileSubmitButton onClick={onSubmit} className='mobile-only'>
+            완료
+          </MobileSubmitButton>
+        </Responsive>
       </StyledForm>
     </StyledContainer>
   );

--- a/components/members/upload/forms/Form.tsx
+++ b/components/members/upload/forms/Form.tsx
@@ -26,21 +26,20 @@ export default function MemberForm({ type, children, onSubmit }: MemberFormProps
         <MobileSubmitButton onClick={onSubmit} className='mobile-only'>
           완료
         </MobileSubmitButton>
+        <StyledFooter className='pc-only'>
+          <div className='button-wrapper'>
+            <button onClick={onSubmit} className='submit'>
+              프로필 {TYPE_MAP[type]}하기
+            </button>
+          </div>
+        </StyledFooter>
       </StyledForm>
-      <StyledFooter className='pc-only'>
-        <div className='button-wrapper'>
-          <button onClick={onSubmit} className='submit'>
-            프로필 {TYPE_MAP[type]}하기
-          </button>
-        </div>
-      </StyledFooter>
     </StyledContainer>
   );
 }
 
 const StyledContainer = styled.div`
   display: flex;
-  position: relative;
   flex-direction: column;
   align-items: center;
   padding-bottom: 375px;
@@ -117,6 +116,7 @@ const StyledFooter = styled.div`
   display: flex;
   position: fixed;
   bottom: 0;
+  left: 0;
   align-items: center;
   justify-content: center;
   background-color: ${colors.black80};

--- a/pages/members/edit.tsx
+++ b/pages/members/edit.tsx
@@ -47,7 +47,11 @@ export default function MemberEditPage() {
   const queryClient = useQueryClient();
   const { data: myProfile } = useGetMemberProfileOfMe({ cacheTime: Infinity, staleTime: Infinity });
 
-  const { handleSubmit, reset } = formMethods;
+  const {
+    handleSubmit,
+    reset,
+    formState: { isValid },
+  } = formMethods;
 
   const onSubmit = async (formData: MemberUploadForm) => {
     const {
@@ -209,7 +213,7 @@ export default function MemberEditPage() {
   return (
     <AuthRequired>
       <FormProvider {...formMethods}>
-        <MemberForm type='edit' onSubmit={handleSubmit(onSubmit)}>
+        <MemberForm type='edit' onSubmit={handleSubmit(onSubmit)} isValid={isValid}>
           <BasicFormSection />
           <SoptActivityFormSection />
           <TmiFormSection />

--- a/pages/members/upload.tsx
+++ b/pages/members/upload.tsx
@@ -31,7 +31,10 @@ export default function MemberUploadPage() {
   const router = useRouter();
   const queryClient = useQueryClient();
 
-  const { handleSubmit } = formMethods;
+  const {
+    handleSubmit,
+    formState: { isValid },
+  } = formMethods;
 
   const onSubmit = async (formData: MemberUploadForm) => {
     const {
@@ -109,7 +112,7 @@ export default function MemberUploadPage() {
   return (
     <AuthRequired>
       <FormProvider {...formMethods}>
-        <MemberForm type='upload' onSubmit={handleSubmit(onSubmit)}>
+        <MemberForm type='upload' onSubmit={handleSubmit(onSubmit)} isValid={isValid}>
           <BasicFormSection />
           <SoptActivityFormSection />
           <TmiFormSection />


### PR DESCRIPTION
### 🤫 쉿, 나한테만 말해줘요. 이슈넘버
- close #779

### 🧐 어떤 것을 변경했어요~?
<!-- 실제로 변경한 사항을 설명해주세요.-->
1. 프로필 수정/업로드 버튼에 disable 상태 추가
2. submit 버튼 관련 잔잔바리 리팩토링
  2-1. 레거시인 pc-only/desktop-only 클래스를 걷어내고 Responsive 컴포넌트를 적용했어요
  2-2. @juno7803 가 예전에 제기해주었던 submit 버튼이 form 바깥에 있는 이슈를 해결했어요 

### 🤔 그렇다면, 어떻게 구현했어요~?
<!-- 실제로 구현한 로직에 대해 설명해주세요.-->
1. 프로필 수정/업로드 버튼에 disable 상태 추가
react hook form의 isValid state를 활용했어요
폼 컴포넌트에 RHF의 의존성이 생기지 않도록 isValid는 useFormContext를 활용하지 않고 prop으로 넘겨줬어요


### ❤️‍🔥 당신이 생각하는 PR포인트, 내겐 매력포인트.
<!-- 해당 PR에서 논의가 필요한 사항을 적어주세요. -->

### 📸 스크린샷, 없으면 이것 참,, 섭섭한데요?

<img width="1440" alt="image" src="https://github.com/sopt-makers/sopt-playground-frontend/assets/73823388/f9e4b57d-fa13-46da-bfd1-b4e952eca3b3">
