### PR TITLE
feat: 멘토링 리스트 layout shift 개선

### DIFF
--- a/components/mentoring/MentoringList/index.tsx
+++ b/components/mentoring/MentoringList/index.tsx
@@ -178,11 +178,7 @@ const Container = styled.div`
     display: none;
   }
 
-  @media ${DESKTOP_SMALL_MEDIA_QUERY} {
-    gap: 36px;
-    margin-top: 104px;
-    margin-bottom: 48px;
-
+  @media ${DESKTOP_LARGE_MEDIA_QUERY} {
     .${SCREEN_SIZE.desktopLarge.className} {
       display: none;
     }
@@ -196,10 +192,10 @@ const Container = styled.div`
     }
   }
 
-  @media ${TABLET_MEDIA_QUERY} {
-    gap: 24px;
-    margin-top: 24px;
-    margin-bottom: 40px;
+  @media ${DESKTOP_SMALL_MEDIA_QUERY} {
+    gap: 36px;
+    margin-top: 104px;
+    margin-bottom: 48px;
 
     .${SCREEN_SIZE.desktopLarge.className} {
       display: none;
@@ -212,6 +208,12 @@ const Container = styled.div`
     .${SCREEN_SIZE.tablet.className} {
       display: flex;
     }
+  }
+
+  @media ${TABLET_MEDIA_QUERY} {
+    gap: 24px;
+    margin-top: 24px;
+    margin-bottom: 40px;
   }
 `;
 


### PR DESCRIPTION
### 🤫 쉿, 나한테만 말해줘요. 이슈넘버
- close #738 

### 🧐 어떤 것을 변경했어요~?
<!-- 실제로 변경한 사항을 설명해주세요.-->

멘토링 리스트 layout shift를 개선하기 위해 리스트의 렌더링 방식을 바꾸었어요

### 🤔 그렇다면, 어떻게 구현했어요~?
<!-- 실제로 구현한 로직에 대해 설명해주세요.-->

[문제]

기존 코드는 useEffect를 통해 결정되는 `listType` state가 서버 사이드에서 undefined이기 때문에 리스트가 올 자리에 아무것도 렌더링이 되지 않아 layout shift가 발생했어요
현재 멘토링 리스트가 있는 members 페이지가 메인 페이지로 쓰이고 있고, 심지어 멘토링 리스트가 페이지의 상단에 있기 때문에 이는 우리 서비스에 접속하는 유저의 첫 경험을 해쳐 다소 크리티컬한 문제라 판단이 됐어요

[솔루션]

따라서 이를 해결하기 위해 서버 사이드에서는 각 브레이크 포인트 별 UI를 모두 만들어지게 하고 className을 통해 각 스크린 사이즈 별 css display 속성을 설정해놓았어요
따라서 브라우저에 서버에서 받은 html이 그려질 때에 바로 미디어 쿼리가 적용되어 의도한 UI가 보이게 돼요
하지만 모든 브레이크 포인트 별 컴포넌트가 내내 마운트 되어 있을 필요는 없기 때문에 기존의 방식인 `listType`을 통해 조건부 렌더링 하는 코드도 삭제하지 않았어요

또한 resize 이벤트를 MediaQueryList 이벤트로 바꾸었어요
기존에는 resize 이벤트에 디바운스를 적용해놓았는데 이렇게 display: none; 코드가 추가되고 나서는 디바운스로 인한 딜레이 시간 동안 아무것도 렌더링되지 않아 새로운 원인의 layout shift 문제가 발생했어요
디바운스를 제거하는 것보다는 MediaQueryList 이벤트로 변경하는 게 성능 상 더 나을 것 같아서 그렇게 변경했습니다!

(@Tekiter 이가 만든 Responsive 컴포넌트 방식을 참고했어요! https://github.com/sopt-makers/sopt-playground-frontend/pull/430)


### ❤️‍🔥 당신이 생각하는 PR포인트, 내겐 매력포인트.
<!-- 해당 PR에서 논의가 필요한 사항을 적어주세요. -->




### 📸 스크린샷, 없으면 이것 참,, 섭섭한데요?

[SSR에 리스트가 포함된 모습]

<img width="1440" alt="image" src="https://github.com/sopt-makers/sopt-playground-frontend/assets/73823388/7c799c4d-7943-4bdc-8781-538c32d5663e">

<img width="1440" alt="image" src="https://github.com/sopt-makers/sopt-playground-frontend/assets/73823388/0a83671e-3ba7-4a86-b824-135adcd0aa31">


<br />
<br />


[layout shift 비교]

AS-IS


https://github.com/sopt-makers/sopt-playground-frontend/assets/73823388/7072a4ba-839d-48d6-9c73-a140522a3784



TO-BE


https://github.com/sopt-makers/sopt-playground-frontend/assets/73823388/c3ec3487-894a-42e6-b519-30e78d010806

