### PR TITLE
chore: 프로젝트 추가/수정 시 이벤트 로깅 추가

### DIFF
--- a/components/eventLogger/events.ts
+++ b/components/eventLogger/events.ts
@@ -70,6 +70,13 @@ export interface SubmitEvents {
     receiverId: number;
     referral: 'mentoringDetail' | 'memberDetail' | 'memberList';
   };
+  projectUpload: {
+    writerId: string;
+  };
+  projectEdit: {
+    projectId: string;
+    editorId: string;
+  };
 }
 
 export interface PageViewEvents {


### PR DESCRIPTION
### 🤫 쉿, 나한테만 말해줘요. 이슈넘버
- close #796 

### 🧐 어떤 것을 변경했어요~?
<!-- 실제로 변경한 사항을 설명해주세요.-->
- 프로젝트 추가 / 수정 시 이벤트 로깅을 추가했어요. ([요청 스레드](https://sopt-makers.slack.com/archives/C04326AHDRT/p1686031852203419))
- 수정 api와 추가 api가 같은 페이지에 존재하기 때문에 이름을 `mutate` => `createProjectMutate`로 변경해서 사용했어요.

### 🤔 그렇다면, 어떻게 구현했어요~?
<!-- 실제로 구현한 로직에 대해 설명해주세요.-->

### ❤️‍🔥 당신이 생각하는 PR포인트, 내겐 매력포인트.
<!-- 해당 PR에서 논의가 필요한 사항을 적어주세요. -->

### 📸 스크린샷, 없으면 이것 참,, 섭섭한데요?
