### PR TITLE
fix: words 없는 경우 대응 및 initial 정보에 api 변경 대응

### DIFF
--- a/api/endpoint/wordchain/getWordchain.ts
+++ b/api/endpoint/wordchain/getWordchain.ts
@@ -56,7 +56,7 @@ export const useGetWordchain = ({
         const finishedWordchainList: WordchainInfo[] = mapFinishedWordchainList(rooms.slice(1)).reverse();
         const currentWordchain: WordchainInfo = {
           id: rooms[0].roomId,
-          initial: { userName: rooms[0].words[0].user.name, word: rooms[0].words[0].word },
+          initial: { userName: rooms[0].startUser.name, word: rooms[0].startWord },
           isProgress: true,
           winnerName: null,
           order: rooms[0].roomId,
@@ -86,10 +86,10 @@ export const useGetWordchain = ({
 const mapFinishedWordchainList = (rooms: z.infer<typeof roomSchema>[]): WordchainInfo[] =>
   rooms.map(({ roomId, words }) => ({
     id: roomId,
-    initial: { userName: words[0].user.name, word: words[0].word },
+    initial: { userName: rooms[0].startUser.name, word: rooms[0].startWord },
     isProgress: false,
     order: roomId,
-    winnerName: words[words.length - 1].user.name,
+    winnerName: words.length ? words[words.length - 1].user.name : '',
     wordList: words.map(({ word, user }) => ({ user, content: word })),
   }));
 

--- a/components/wordchain/WordchainChatting/Wordchain/index.tsx
+++ b/components/wordchain/WordchainChatting/Wordchain/index.tsx
@@ -35,7 +35,9 @@ export default function Wordchain({ wordchain, className }: WordchainProps) {
   return (
     <Container className={className}>
       <InitMessage>
-        ‘{initial.userName}’님이 {order}번째 끝말잇기를 시작했어요!
+        {order === 1
+          ? `${order}번째 끝말잇기가 시작됐어요!`
+          : `‘${initial.userName}’님이 ${order}번째 끝말잇기를 시작했어요!`}
       </InitMessage>
       <StartWordChatMessage word='버디버디' />
       <WordChatMessageList>
@@ -45,13 +47,15 @@ export default function Wordchain({ wordchain, className }: WordchainProps) {
       </WordChatMessageList>
       {isProgress ? (
         <GiveUpButton onClick={onClickGiveUp}> 😅 이어나갈 단어가 떠오르지 않는다면?</GiveUpButton>
-      ) : (
+      ) : winnerName.length ? (
         <WinnerMessage>
           <TrophyIconWrapper>
             <TrophyIcon />
           </TrophyIconWrapper>
           {`25번째 우승자는 ‘${winnerName}'님 입니다!`}
         </WinnerMessage>
+      ) : (
+        <></>
       )}
     </Container>
   );
@@ -95,6 +99,7 @@ const WinnerMessage = styled.div`
   display: flex;
   gap: 12px;
   align-items: center;
+  margin-top: 12px;
   line-height: 100%;
   color: ${colors.purple100};
 


### PR DESCRIPTION
### 🤫 쉿, 나한테만 말해줘요. 이슈넘버
- close #824 

### 🧐 어떤 것을 변경했어요~?
<!-- 실제로 변경한 사항을 설명해주세요.-->

- words 빈 배열일 경우 대응
- initial word 및 유저가 startUser startWord로 바뀐 것 대응
- startUser null 대응

### 🤔 그렇다면, 어떻게 구현했어요~?
<!-- 실제로 구현한 로직에 대해 설명해주세요.-->

### ❤️‍🔥 당신이 생각하는 PR포인트, 내겐 매력포인트.
<!-- 해당 PR에서 논의가 필요한 사항을 적어주세요. -->

### 📸 스크린샷, 없으면 이것 참,, 섭섭한데요?

words 빈 배열인 경우

<img width="657" alt="image" src="https://github.com/sopt-makers/sopt-playground-frontend/assets/73823388/531edab4-9ef8-441d-abf0-8f816254828d">

