### PR TITLE
feat: 멤버리스트 페이지 노운,자잘 이슈 수정

### DIFF
--- a/components/members/main/MemberList/index.tsx
+++ b/components/members/main/MemberList/index.tsx
@@ -541,7 +541,7 @@ const StyledMemberSearch = styled(MemberSearch)`
 
     & > svg {
       top: 14px;
-      left: 18px;
+      right: 18px;
     }
   }
 `;

--- a/components/members/main/MemberList/index.tsx
+++ b/components/members/main/MemberList/index.tsx
@@ -441,9 +441,9 @@ export default MemberList;
 
 const StyledContainer = styled.div`
   display: flex;
+  flex: 1;
   flex-direction: column;
   align-items: center;
-  justify-content: center;
   padding-bottom: 100px;
   min-height: 101vh;
 
@@ -455,6 +455,7 @@ const StyledContainer = styled.div`
 const StyledMain = styled.main`
   display: flex;
   position: relative;
+  flex: 1;
   flex-direction: column;
   align-items: center;
   column-gap: 30px;
@@ -467,6 +468,7 @@ const StyledMain = styled.main`
 
 const StyledRightWrapper = styled.div`
   display: flex;
+  flex: 1;
   flex-direction: column;
   width: 100%;
 `;
@@ -575,6 +577,7 @@ const StyledEmpty = styled.div`
   display: flex;
   flex: 1;
   flex-direction: column;
+  gap: 24px;
   align-items: center;
   justify-content: center;
   width: 100%;

--- a/components/members/main/MemberList/index.tsx
+++ b/components/members/main/MemberList/index.tsx
@@ -82,6 +82,7 @@ const MemberList: FC<MemberListProps> = ({ banner }) => {
   const { addQueryParamsToUrl } = usePageQueryParams({
     skipNull: true,
   });
+  const isEmpty = memberProfileData?.pages[0].members.length === 0;
 
   const profiles = useMemo(
     () =>
@@ -407,12 +408,10 @@ const MemberList: FC<MemberListProps> = ({ banner }) => {
               </React.Fragment>
             ))}
           </StyledCardWrapper>
-          {profiles?.length === 0 && (
+          {isEmpty && (
             <StyledEmpty>
-              <Text typography='SUIT_32_B'>OMG... 검색 결과가 없어요.</Text>
-              <Text mt={24} typography='SUIT_16_M' color={colors.gray80}>
-                검색어를 바르게 입력했는지 확인하거나, 필터를 변경해보세요.
-              </Text>
+              <EmptyTitle>OMG... 검색 결과가 없어요.</EmptyTitle>
+              <EmptyDescription>검색어를 바르게 입력했는지 확인하거나, 필터를 변경해보세요.</EmptyDescription>
             </StyledEmpty>
           )}
         </StyledRightWrapper>
@@ -574,6 +573,7 @@ const StyledCardWrapper = styled.div`
 
 const StyledEmpty = styled.div`
   display: flex;
+  flex: 1;
   flex-direction: column;
   align-items: center;
   justify-content: center;
@@ -582,6 +582,27 @@ const StyledEmpty = styled.div`
 
   & > span {
     display: block;
+  }
+
+  @media ${MOBILE_MEDIA_QUERY} {
+    gap: 12px;
+  }
+`;
+
+const EmptyTitle = styled.span`
+  ${textStyles.SUIT_32_B};
+
+  @media ${MOBILE_MEDIA_QUERY} {
+    ${textStyles.SUIT_24_B};
+  }
+`;
+
+const EmptyDescription = styled.span`
+  color: ${colors.gray80};
+  ${textStyles.SUIT_16_M};
+
+  @media ${MOBILE_MEDIA_QUERY} {
+    ${textStyles.SUIT_14_M}
   }
 `;
 


### PR DESCRIPTION
### 🤫 쉿, 나한테만 말해줘요. 이슈넘버
- close #835 

### 🧐 어떤 것을 변경했어요~?
<!-- 실제로 변경한 사항을 설명해주세요.-->
- 모바일 돋보기 포지셔닝 이슈 (`as-is`: 돋보기 랑 겹쳐서 왼쪽에 존재하고 있었음)
- 검색 결과 시 가운데로 오는 이슈
- Empty view 보이지 않던 이슈

### 🤔 그렇다면, 어떻게 구현했어요~?
<!-- 실제로 구현한 로직에 대해 설명해주세요.-->

### ❤️‍🔥 당신이 생각하는 PR포인트, 내겐 매력포인트.
<!-- 해당 PR에서 논의가 필요한 사항을 적어주세요. -->
- 간단한 작업인데 수정하는덴 시간이 좀 걸렸습니다 😂 유지보수 기간에 해당 페이지 코드를 좀 줄이는게 목표입니다
- 스타일 관련 코드도, 로직도 너무 많이 정리되지 않은 채 섞여있어 파악하기 쉽지 않더라구요

### 📸 스크린샷, 없으면 이것 참,, 섭섭한데요?

https://github.com/sopt-makers/sopt-playground-frontend/assets/26808056/65b2155e-d156-44c7-9f62-c5147b5c3040

