### PR TITLE
fix: 솝티클 바로가기 링크 수정

### DIFF
--- a/components/sopticle/UploadSopticle.tsx
+++ b/components/sopticle/UploadSopticle.tsx
@@ -58,7 +58,7 @@ const UploadSopticle: FC<UploadSopticleProps> = ({ state, errorMessage, onSubmit
         title='SOPT 공식 홈페이지에 솝티클 보러가기'
         content='앗! 업로드가 아니라 솝티클을 읽고 싶으신가요?
 솝트 회원들이 직접 작성한 솝티클은 공홈에서 확인할 수 있어요.'
-        href='https://sopt.org/article'
+        href='https://www.sopt.org/sopticle'
       />
     </Container>
   );

--- a/playground-common/package.json
+++ b/playground-common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sopt-makers/playground-common",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "license": "MIT",
   "source": "src/index.ts",
   "main": "dist/index.js",


### PR DESCRIPTION
### 🤫 쉿, 나한테만 말해줘요. 이슈넘버

### 🧐 어떤 것을 변경했어요~?
<!-- 실제로 변경한 사항을 설명해주세요.-->

솝티클 탭에서 솝티클 바로가기 링크를 누르면 잘못된 경로라고 나오는 문제를 해결했어요.
겸사겸사 playground-common 의 패키지 버전도 올렸어요.

### 🤔 그렇다면, 어떻게 구현했어요~?
<!-- 실제로 구현한 로직에 대해 설명해주세요.-->

### ❤️‍🔥 당신이 생각하는 PR포인트, 내겐 매력포인트.
<!-- 해당 PR에서 논의가 필요한 사항을 적어주세요. -->

### 📸 스크린샷, 없으면 이것 참,, 섭섭한데요?
