### PR TITLE
feat: 끝말잇기 진입점 새 게임 시작 case 대응

### DIFF
--- a/api/endpoint/wordchain/getWordchain.ts
+++ b/api/endpoint/wordchain/getWordchain.ts
@@ -94,27 +94,29 @@ const mapFinishedWordchainList = (rooms: z.infer<typeof roomSchema>[]): Wordchai
   }));
 
 export const useGetRecentWordchain = () => {
-  return useQuery(
-    ['getRecentWordchain'],
-    async () => {
-      const data = await getWordchain.request({
-        limit: 0,
-        cursor: 0,
-      });
-      return data;
-    },
-    {
-      select: ({ rooms }) => {
-        const firstGameWords = rooms[0].words;
-        const lastWord = firstGameWords[firstGameWords.length - 1];
-        return {
-          words: firstGameWords.slice(-2),
-          currentWinner: lastWord.user,
-          nextStartWord: lastWord.word.charAt(lastWord.word.length - 1),
-        };
-      },
-    },
-  );
+  return useQuery(['getRecentWordchain'], async () => {
+    const data = await getWordchain.request({
+      limit: 0,
+      cursor: 0,
+    });
+
+    const firstRoom = data.rooms[0];
+    const firstGameWords = firstRoom.words;
+    const lastWord = getLastWord(firstGameWords);
+
+    return {
+      words: firstGameWords.slice(-2),
+      startWord: firstRoom.startWord,
+      currentWinner: lastWord ? lastWord.user : null,
+      nextSyllable: lastWord
+        ? lastWord.word.charAt(lastWord.word.length - 1)
+        : firstRoom.startWord.charAt(firstRoom.startWord.length - 1),
+    };
+  });
+};
+
+const getLastWord = (words: z.infer<typeof roomSchema>['words']) => {
+  return words.length > 0 ? words[words.length - 1] : null;
 };
 
 export const wordChainQueryKey = {

--- a/components/wordchain/WordchainChatting/Wordchain/index.tsx
+++ b/components/wordchain/WordchainChatting/Wordchain/index.tsx
@@ -23,7 +23,7 @@ export default function Wordchain({ wordchain, className }: WordchainProps) {
   const onClickGiveUp = async () => {
     const confirm = await Confirm({
       title: '정말 포기하시겠어요?',
-      content: `지금 포기하면 '${data?.currentWinner.name}'님이 우승자가 돼요.`,
+      content: `지금 포기하면 '${data?.currentWinner?.name ?? ''}'님이 우승자가 돼요.`,
       cancelText: '돌아가기',
       okText: '새로 시작하기',
     });

--- a/components/wordchain/WordchainEntry/WordchainMessage.stories.tsx
+++ b/components/wordchain/WordchainEntry/WordchainMessage.stories.tsx
@@ -12,7 +12,7 @@ const Template: ComponentStory<typeof WordchainMessage> = (args) => <WordchainMe
 
 export const Default = Template.bind({});
 Default.args = {
-  isHelper: false,
+  type: 'word',
   user: {
     id: 1,
     name: '남주영',
@@ -25,6 +25,12 @@ Default.storyName = '기본';
 
 export const Helper = Template.bind({});
 Helper.args = {
-  isHelper: true,
+  type: 'helper',
   word: `'과'로 시작하는 단어는?`,
+};
+
+export const StartWord = Template.bind({});
+StartWord.args = {
+  type: 'startWord',
+  word: '토스',
 };

--- a/components/wordchain/WordchainEntry/WordchainMessage.tsx
+++ b/components/wordchain/WordchainEntry/WordchainMessage.tsx
@@ -13,36 +13,46 @@ type User = {
   profileImage?: string;
 };
 
-type WordchainMessageProps = {
-  word: string;
-} & ({ user: User; isHelper?: false } | { user?: User; isHelper: true });
+type WordchainMessageProps = { word: string } & (
+  | {
+      type: 'word';
+      user: User;
+    }
+  | {
+      type: 'startWord' | 'helper';
+    }
+);
 
-export default function WordchainMessage({ user, word, isHelper = false }: WordchainMessageProps) {
+export default function WordchainMessage(props: WordchainMessageProps) {
   return (
     <Container>
       <MessageBox>
-        <Word>{word}</Word>
-        {!isHelper && user && (
+        <Word>{props.word}</Word>
+        {(props.type === 'word' || props.type === 'startWord') && (
           <>
             <Divider>|</Divider>
-            <Link href={playgroundLink.memberDetail(user.id)}>
-              <Name>{user.name}</Name>
-            </Link>
+            {props.type === 'word' && (
+              <Link href={playgroundLink.memberDetail(props.user.id)}>
+                <Name>{props.user.name}</Name>
+              </Link>
+            )}
+            {props.type === 'startWord' && <Name>제시어</Name>}
           </>
         )}
       </MessageBox>
-      {!isHelper && user ? (
-        <Link href={playgroundLink.memberDetail(user.id)}>
-          {user.profileImage ? (
-            <ProfileImage src={user.profileImage} />
+      {(props.type === 'helper' || props.type === 'startWord') && (
+        <ProfileImage src='/logos/img/logo-makers-circle.png' />
+      )}
+      {props.type === 'word' && (
+        <Link href={playgroundLink.memberDetail(props.user.id)}>
+          {props.user.profileImage ? (
+            <ProfileImage src={props.user.profileImage} />
           ) : (
             <EmptyProfileImage>
               <ProfileIcon />
             </EmptyProfileImage>
           )}
         </Link>
-      ) : (
-        <ProfileImage src='/logos/img/logo-makers-circle.png' />
       )}
     </Container>
   );


### PR DESCRIPTION
### 🤫 쉿, 나한테만 말해줘요. 이슈넘버
- close #

### 🧐 어떤 것을 변경했어요~?
<!-- 실제로 변경한 사항을 설명해주세요.-->
- 끝말잇기 진입점 새 게임 시작 케이스를 대응했어요.

### 🤔 그렇다면, 어떻게 구현했어요~?
<!-- 실제로 구현한 로직에 대해 설명해주세요.-->
- `WordchainMessage` 컴포넌트를 리팩토링 했어요. 기존엔 `helper`, `word` 두가지 케이스여서 boolean으로 빠르게 작업했는데요, `startWord` 케이스가 추가되어 변경에 대응하기 쉽게 유효한 상태만 뽑아서 `type`별로 다르게 형태를 분기했어요.
- 진입점의 경우도 비슷한 방식으로 `status`가 `start` 일 때와 `progress` 일 때를 구분하여 수정했어요.

### ❤️‍🔥 당신이 생각하는 PR포인트, 내겐 매력포인트.
<!-- 해당 PR에서 논의가 필요한 사항을 적어주세요. -->

### 📸 스크린샷, 없으면 이것 참,, 섭섭한데요?
![스크린샷 2023-06-27 오후 9 11 26](https://github.com/sopt-makers/sopt-playground-frontend/assets/26808056/8bc318a0-8a4e-4579-b303-292b7df4c83f)
