### PR TITLE
fix: 끝말잇기 채팅 쿼리 이펙트 정리

### DIFF
--- a/api/endpoint/wordchain/getWordchain.ts
+++ b/api/endpoint/wordchain/getWordchain.ts
@@ -60,7 +60,7 @@ export const useGetFinishedWordchainList = ({
   queryOptions,
 }: {
   limit: number;
-  queryOptions: Omit<
+  queryOptions?: Omit<
     UseInfiniteQueryOptions<
       FinishedWordchainListPage,
       unknown,

--- a/components/wordchain/WordchainChatting/index.tsx
+++ b/components/wordchain/WordchainChatting/index.tsx
@@ -23,49 +23,18 @@ interface WordchainChattingProps {
 export default function WordchainChatting({ className }: WordchainChattingProps) {
   const { data: finishedWordchainListPages, fetchNextPage } = useGetFinishedWordchainList({
     limit: LIMIT,
-    queryOptions: {
-      onSuccess: (data) => {
-        if (data.pageParams.length === 1) {
-          setTimeout(() => scrollToBottom(), 0);
-        }
-      },
+  });
+  const { data: activeWordchain } = useGetActiveWordchain({
+    onSuccess: () => {
+      setTimeout(() => scrollToBottom(), 0);
     },
   });
-  const { data: activeWordchain } = useGetActiveWordchain();
   const [word, setWord] = useState('');
   const queryClient = useQueryClient();
   const { mutate: mutatePostWord } = usePostWord({
-    onSuccess: ({ word, user }) => {
+    onSuccess: () => {
       setWord('');
-      // FIXME: wordchain 리스트를 불러오는 쿼리가 변경되어 수정 필요
-      // queryClient.invalidateQueries([wordChainQueryKey.getRecentWordchain]);
-      // queryClient.setQueryData<InfiniteData<UseGetWordchainResponse>>(
-      //   [wordChainQueryKey.getWordchain, LIMIT],
-      //   (old) => {
-      //     return old
-      //       ? {
-      //           ...old,
-      //           pages: [
-      //             {
-      //               ...old.pages[0],
-      //               wordchainList: [
-      //                 ...old.pages[0].wordchainList.slice(0, old.pages[0].wordchainList.length - 1),
-      //                 {
-      //                   ...old.pages[0].wordchainList[old.pages[0].wordchainList.length - 1],
-      //                   wordList: [
-      //                     ...old.pages[0].wordchainList[old.pages[0].wordchainList.length - 1].wordList,
-      //                     { content: word, user },
-      //                   ],
-      //                 },
-      //               ],
-      //             },
-      //             ...old.pages.slice(1),
-      //           ],
-      //         }
-      //       : old;
-      //   },
-      // );
-      scrollToBottom();
+      queryClient.invalidateQueries([wordChainQueryKey.getRecentWordchain]);
     },
     onError: (error) => {
       if (typeof error.response?.data !== 'string') {


### PR DESCRIPTION
### 🤫 쉿, 나한테만 말해줘요. 이슈넘버
- close #

### 🧐 어떤 것을 변경했어요~?
<!-- 실제로 변경한 사항을 설명해주세요.-->

1. 낙관적 업데이트 하지 않기로 함 (애초에 실수로 onSuccess에서 해버려서 효과가 없기도 했지만 ,,)
  이유: 생각해보니 좋아요 기능처럼 낙관적으로 업데이트 할 수 있는 구조가 아님. 끝말잇기 특성 상 예외 케이스가 많은데, 그 검증을 서버에서 하기 때문.
  추후 낙관적 업데이트 대신 로딩 애니메이션을 넣거나, 검증 API를 따로 파기로 함.

2. 변경된 쿼리에 따라 이펙트 정리
  스크롤을 최하단으로 옮겨주는 로직을 적절한 곳으로 이동시켰습니다
### 🤔 그렇다면, 어떻게 구현했어요~?
<!-- 실제로 구현한 로직에 대해 설명해주세요.-->

### ❤️‍🔥 당신이 생각하는 PR포인트, 내겐 매력포인트.
<!-- 해당 PR에서 논의가 필요한 사항을 적어주세요. -->

### 📸 스크린샷, 없으면 이것 참,, 섭섭한데요?
