### PR TITLE
feat: 끝말잇기 채팅 > 새 페이지 fetch 시 스크롤을 fetch 전의 위치로 이동

### DIFF
--- a/components/wordchain/WordchainChatting/index.tsx
+++ b/components/wordchain/WordchainChatting/index.tsx
@@ -103,8 +103,6 @@ export default function WordchainChatting({ className }: WordchainChattingProps)
     }
   }, [isVisible, fetchNextPage]);
 
-  useEffect(() => console.log('scrollHeight', scrollHeight), [scrollHeight]);
-
   return (
     <Container className={className}>
       <WordchainList ref={wordchainListRef}>

--- a/components/wordchain/WordchainChatting/index.tsx
+++ b/components/wordchain/WordchainChatting/index.tsx
@@ -21,8 +21,25 @@ interface WordchainChattingProps {
   className?: string;
 }
 export default function WordchainChatting({ className }: WordchainChattingProps) {
+  const [scrollHeight, setScrollHeight] = useState<number | undefined>();
+  const wordchainListRef = useRef<HTMLDivElement>(null);
   const { data: finishedWordchainListPages, fetchNextPage } = useGetFinishedWordchainList({
     limit: LIMIT,
+    queryOptions: {
+      onSuccess: (data) => {
+        setTimeout(() => {
+          if (data.pageParams.length === 1) {
+            wordchainListRef.current && setScrollHeight(wordchainListRef.current.scrollHeight);
+          } else {
+            if (!(wordchainListRef.current && scrollHeight)) {
+              return;
+            }
+            scrollTo(wordchainListRef.current.scrollHeight - scrollHeight);
+            setScrollHeight(wordchainListRef.current.scrollHeight);
+          }
+        }, 0);
+      },
+    },
   });
   const { data: activeWordchain } = useGetActiveWordchain({
     onSuccess: () => {
@@ -51,7 +68,6 @@ export default function WordchainChatting({ className }: WordchainChattingProps)
       }, 2000);
     },
   });
-  const wordchainListRef = useRef<HTMLDivElement>(null);
   const { isVisible, ref: intersectionObserverTargetRef } = useIntersectionObserver({ root: wordchainListRef.current });
   const [{ isError, errorMessage }, setError] = useState({
     isError: false,
@@ -70,9 +86,14 @@ export default function WordchainChatting({ className }: WordchainChattingProps)
     setWord(value);
   };
 
+  const scrollTo = (height: number) => {
+    if (wordchainListRef.current) {
+      wordchainListRef.current.scrollTop = height;
+    }
+  };
   const scrollToBottom = () => {
     if (wordchainListRef.current) {
-      wordchainListRef.current.scrollTop = wordchainListRef.current.scrollHeight;
+      scrollTo(wordchainListRef.current.scrollHeight);
     }
   };
 
@@ -81,6 +102,8 @@ export default function WordchainChatting({ className }: WordchainChattingProps)
       fetchNextPage();
     }
   }, [isVisible, fetchNextPage]);
+
+  useEffect(() => console.log('scrollHeight', scrollHeight), [scrollHeight]);
 
   return (
     <Container className={className}>


### PR DESCRIPTION
### 🤫 쉿, 나한테만 말해줘요. 이슈넘버
- close #839

### 🧐 어떤 것을 변경했어요~?
<!-- 실제로 변경한 사항을 설명해주세요.-->

끝말잇기 채팅 > 새 페이지 fetch 시 스크롤을 fetch 전의 위치로 이동

정확히 어떤 문제였는지는 이슈 참고해주세요!

### 🤔 그렇다면, 어떻게 구현했어요~?
<!-- 실제로 구현한 로직에 대해 설명해주세요.-->

- scroll height를 저장해놓은 뒤 새 페이지가 fetch 되면 기존 scroll height를 통해 옮겨갈 위치를 계산함
- 렌더링이 완료된 후의 정확한 scroll height를 얻기 위해 setTimeout으로 관련 로직의 실행 순서를 미룸

### ❤️‍🔥 당신이 생각하는 PR포인트, 내겐 매력포인트.
<!-- 해당 PR에서 논의가 필요한 사항을 적어주세요. -->

여기까지 구현하고 보니 해당 컴포넌트 복잡성이 높아져서 추후에 리팩토링을 하면 좋을 것 같아 보입니당

### 📸 스크린샷, 없으면 이것 참,, 섭섭한데요?

https://github.com/sopt-makers/sopt-playground-frontend/assets/73823388/bc39b469-d90e-4122-a85c-fe8d2622e642

