### PR TITLE
feat: 끝말잇기 채팅 초기 진입 시 스크롤 초기화 되기 전까지 로딩뷰 띄우기

### DIFF
--- a/components/wordchain/WordchainChatting/index.tsx
+++ b/components/wordchain/WordchainChatting/index.tsx
@@ -1,7 +1,7 @@
 import styled from '@emotion/styled';
 import { useQueryClient } from '@tanstack/react-query';
 import PaperAirplaneIcon from 'public/icons/icon-paper-airplane.svg';
-import { FormEvent, useEffect, useLayoutEffect, useRef, useState } from 'react';
+import { FormEvent, useEffect, useRef, useState } from 'react';
 
 import {
   useGetActiveWordchain,
@@ -9,6 +9,7 @@ import {
   wordChainQueryKey,
 } from '@/api/endpoint/wordchain/getWordchain';
 import { usePostWord } from '@/api/endpoint/wordchain/postWord';
+import Loading from '@/components/common/Loading';
 import useEventLogger from '@/components/eventLogger/hooks/useEventLogger';
 import { SMALL_MEDIA_QUERY } from '@/components/wordchain/mediaQuery';
 import Wordchain from '@/components/wordchain/WordchainChatting/Wordchain';
@@ -77,6 +78,7 @@ export default function WordchainChatting({ className }: WordchainChattingProps)
     isError: false,
     errorMessage: '',
   });
+  const [isLoading, setIsLoading] = useState(true);
 
   const handleSubmit = (e: FormEvent<HTMLFormElement>) => {
     e.preventDefault();
@@ -116,9 +118,10 @@ export default function WordchainChatting({ className }: WordchainChattingProps)
     }
   }, [isVisible, fetchNextPage]);
 
-  useLayoutEffect(() => {
+  useEffect(() => {
     setTimeout(() => {
       scrollToBottom();
+      setIsLoading(false);
     }, 500);
   }, [activeWordchain]);
 
@@ -156,11 +159,15 @@ export default function WordchainChatting({ className }: WordchainChattingProps)
         </ErrorMessage>
         <Triangle isVisible={isError} />
       </Form>
+      <LoadingWrapper isVisible={isLoading}>
+        <Loading />
+      </LoadingWrapper>
     </Container>
   );
 }
 
 const Container = styled.div`
+  position: relative;
   border-radius: 30px;
   background-color: ${colors.black80};
   padding: 40px;
@@ -270,6 +277,20 @@ const Triangle = styled.div<{ isVisible: boolean }>`
   border-left: 8px solid transparent;
   width: 0;
   height: 0;
+`;
+
+const LoadingWrapper = styled.div<{ isVisible: boolean }>`
+  display: ${({ isVisible }) => (isVisible ? 'flex' : 'none')};
+  position: absolute;
+  top: 0;
+  left: 0;
+  align-items: center;
+  justify-content: center;
+  border-radius: 30px;
+  background-color: ${colors.black80};
+  padding: 40px;
+  width: 790px;
+  height: 100%;
 `;
 
 const WaringIconSvg = (


### PR DESCRIPTION
### 🤫 쉿, 나한테만 말해줘요. 이슈넘버
- close #865

### 🧐 어떤 것을 변경했어요~?
<!-- 실제로 변경한 사항을 설명해주세요.-->

초기 진입 시 스크롤이 가장 하단으로 이동되어야 하는데 사용자 눈에 해당 움직임이 그대로 보여 버벅이는 것처럼 보이는 현상이 있었습니다
이를 감추기 위해 스크롤이 초기화 되기 전까지 로딩뷰를 띄웠습니다

### 🤔 그렇다면, 어떻게 구현했어요~?
<!-- 실제로 구현한 로직에 대해 설명해주세요.-->

`isLoading` 상태를 추가하여 로딩뷰를 조건부 렌더링 했습니다
`isLoading`은 최초 진입 시 스크롤을 초기화 한 후에 false가 되도록 했습니다

### ❤️‍🔥 당신이 생각하는 PR포인트, 내겐 매력포인트.
<!-- 해당 PR에서 논의가 필요한 사항을 적어주세요. -->

### 📸 스크린샷, 없으면 이것 참,, 섭섭한데요?

AS-IS

https://github.com/sopt-makers/sopt-playground-frontend/assets/73823388/e212f93e-0290-4c42-bdcc-32b1cc070a6f




TO-BE

https://github.com/sopt-makers/sopt-playground-frontend/assets/73823388/dd43bd7a-5e33-4569-b317-cc665c8c1478

