### PR TITLE
feat: 마지막 단어를 보낸 유저가 본인이면 새 게임 시작 못하도록

### DIFF
--- a/components/wordchain/WordchainChatting/Wordchain/index.tsx
+++ b/components/wordchain/WordchainChatting/Wordchain/index.tsx
@@ -1,6 +1,7 @@
 import styled from '@emotion/styled';
 import TrophyIcon from 'public/icons/icon-trophy.svg';
 
+import { useGetMemberOfMe } from '@/api/endpoint/members/getMemberOfMe';
 import { useGetCurrentWinnerName } from '@/api/endpoint/wordchain/getWordchain';
 import { useNewGameMutation } from '@/api/endpoint/wordchain/newGame';
 import { Confirm } from '@/components/common/Modal/Confirm';
@@ -43,6 +44,7 @@ export default function Wordchain({ initial, order, wordList, isProgress, winner
   const { logSubmitEvent } = useEventLogger();
   const { data: currentWinnerName } = useGetCurrentWinnerName();
   const { mutate } = useNewGameMutation();
+  const { data: me } = useGetMemberOfMe();
 
   const onClickGiveUp = async () => {
     const confirm = await Confirm({
@@ -72,7 +74,8 @@ export default function Wordchain({ initial, order, wordList, isProgress, winner
         ))}
       </WordChatMessageList>
       {isProgress ? (
-        wordList.length > 0 && (
+        wordList.length > 0 &&
+        wordList[wordList.length - 1].user.id !== me?.id && (
           <GiveUpButton onClick={onClickGiveUp}> 😅 이어나갈 단어가 떠오르지 않는다면?</GiveUpButton>
         )
       ) : winnerName?.length ? (


### PR DESCRIPTION
### 🤫 쉿, 나한테만 말해줘요. 이슈넘버
- close #875

### 🧐 어떤 것을 변경했어요~?
<!-- 실제로 변경한 사항을 설명해주세요.-->
마지막 단어를 보낸 유저가 본인이면 새 게임 시작 버튼이 보이지 않도록 했습니다

### 🤔 그렇다면, 어떻게 구현했어요~?
<!-- 실제로 구현한 로직에 대해 설명해주세요.-->

유저 id 체크

### ❤️‍🔥 당신이 생각하는 PR포인트, 내겐 매력포인트.
<!-- 해당 PR에서 논의가 필요한 사항을 적어주세요. -->


### 📸 스크린샷, 없으면 이것 참,, 섭섭한데요?

<img width="1427" alt="image" src="https://github.com/sopt-makers/sopt-playground-frontend/assets/73823388/96fcbcc9-84b7-48d6-b92c-c3f69a5c90bd">
