### PR TITLE
refactor: 프로젝트 수정 페이지 리팩토링

### DIFF
--- a/components/projects/edit/ProjectEdit.tsx
+++ b/components/projects/edit/ProjectEdit.tsx
@@ -1,5 +1,5 @@
 import styled from '@emotion/styled';
-import { useMutation, useQuery } from '@tanstack/react-query';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { useRouter } from 'next/router';
 import { FC, useEffect } from 'react';
 
@@ -8,8 +8,12 @@ import { getProjectById, putProject } from '@/api/endpoint_LEGACY/projects';
 import AuthRequired from '@/components/auth/AuthRequired';
 import { Alert } from '@/components/common/Modal/Alert';
 import { Confirm } from '@/components/common/Modal/Confirm';
+import useToast from '@/components/common/Toast/useToast';
+import useEventLogger from '@/components/eventLogger/hooks/useEventLogger';
 import ProjectForm from '@/components/projects/form/ProjectForm';
 import { ProjectFormType } from '@/components/projects/form/schema';
+import { getProjectListQueryKey } from '@/components/projects/upload/hooks/useGetProjectListQuery';
+import { getProjectQueryKey } from '@/components/projects/upload/hooks/useGetProjectQuery';
 import { convertProjectToFormType, convertToProjectData } from '@/components/projects/utils';
 import { playgroundLink } from '@/constants/links';
 import { MOBILE_MEDIA_QUERY } from '@/styles/mediaQuery';
@@ -21,19 +25,35 @@ const ProjectEdit: FC<ProjectEditProps> = ({ projectId }) => {
   const { data: projectData } = useQuery(['getProjectById', projectId], () => getProjectById(projectId));
   const { data: myProfileData } = useGetMemberOfMe();
   const { mutate: putProjectMutation } = useMutation(putProject);
+  const queryClient = useQueryClient();
+  const { logSubmitEvent } = useEventLogger();
   const router = useRouter();
+  const toast = useToast();
 
   const handleSubmit = async (formData: ProjectFormType) => {
     const notify = await Confirm({
       title: '알림',
       content: '프로젝트를 수정하시겠습니까?',
     });
-
     if (notify && myProfileData) {
-      putProjectMutation({
-        id: Number(projectId),
-        data: convertToProjectData(formData, myProfileData.id),
-      });
+      putProjectMutation(
+        {
+          id: Number(projectId),
+          data: convertToProjectData(formData, myProfileData.id),
+        },
+        {
+          onSuccess: () => {
+            toast.show({ message: '프로젝트를 성공적으로 수정했어요.' });
+            router.push(playgroundLink.projectList());
+            queryClient.invalidateQueries(getProjectQueryKey(projectId));
+            queryClient.invalidateQueries(getProjectListQueryKey());
+            logSubmitEvent('projectEdit', {
+              projectId,
+              editorId: String(myProfileData.id),
+            });
+          },
+        },
+      );
     }
   };
 

--- a/components/projects/edit/ProjectEdit.tsx
+++ b/components/projects/edit/ProjectEdit.tsx
@@ -1,17 +1,18 @@
 import styled from '@emotion/styled';
-import { useQuery } from '@tanstack/react-query';
+import { useMutation, useQuery } from '@tanstack/react-query';
 import { useRouter } from 'next/router';
 import { FC, useEffect } from 'react';
 
 import { useGetMemberOfMe } from '@/api/endpoint/members/getMemberOfMe';
-import { getProjectById } from '@/api/endpoint_LEGACY/projects';
+import { getProjectById, putProject } from '@/api/endpoint_LEGACY/projects';
 import AuthRequired from '@/components/auth/AuthRequired';
 import { Alert } from '@/components/common/Modal/Alert';
+import { Confirm } from '@/components/common/Modal/Confirm';
 import ProjectForm from '@/components/projects/form/ProjectForm';
 import { ProjectFormType } from '@/components/projects/form/schema';
+import { convertProjectToFormType, convertToProjectData } from '@/components/projects/utils';
 import { playgroundLink } from '@/constants/links';
 import { MOBILE_MEDIA_QUERY } from '@/styles/mediaQuery';
-import { setLayout } from '@/utils/layout';
 
 interface ProjectEditProps {
   projectId: string;
@@ -19,7 +20,22 @@ interface ProjectEditProps {
 const ProjectEdit: FC<ProjectEditProps> = ({ projectId }) => {
   const { data: projectData } = useQuery(['getProjectById', projectId], () => getProjectById(projectId));
   const { data: myProfileData } = useGetMemberOfMe();
+  const { mutate: putProjectMutation } = useMutation(putProject);
   const router = useRouter();
+
+  const handleSubmit = async (formData: ProjectFormType) => {
+    const notify = await Confirm({
+      title: '알림',
+      content: '프로젝트를 수정하시겠습니까?',
+    });
+
+    if (notify && myProfileData) {
+      putProjectMutation({
+        id: Number(projectId),
+        data: convertToProjectData(formData, myProfileData.id),
+      });
+    }
+  };
 
   useEffect(() => {
     if (myProfileData && projectData && myProfileData?.id !== projectData?.writerId) {
@@ -35,53 +51,23 @@ const ProjectEdit: FC<ProjectEditProps> = ({ projectId }) => {
     return null;
   }
 
-  const defaultValues: ProjectFormType = {
-    name: projectData.name,
-    generation: `${projectData?.generation}`,
-    category: projectData.category,
-    detail: projectData.detail,
-    summary: projectData.summary,
-    serviceType: projectData.serviceType as [string, ...string[]],
-    period: {
-      startAt: projectData.startAt,
-      endAt: projectData.endAt ? projectData.endAt : null,
-    },
-    status: {
-      isAvailable: projectData.isAvailable,
-      isFounding: projectData.isFounding,
-    },
-    projectImages: projectData?.images.map((image) => ({ imageUrl: image })) || [],
-    logoImage: projectData.logoImage,
-    thumbnailImage: projectData.thumbnailImage,
-    members: projectData.members
-      .filter((member) => member.isTeamMember)
-      .map((member) => ({
-        memberId: member.memberId.toString(),
-        memberRole: member.memberRole,
-        memberDescription: member.memberDescription,
-      })),
-    releaseMembers: projectData.members
-      .filter((member) => !member.isTeamMember)
-      .map((member) => ({
-        memberId: member.memberId.toString(),
-        memberRole: member.memberRole,
-        memberDescription: member.memberDescription,
-      })),
-    links: projectData.links,
-  };
+  const defaultValues: ProjectFormType = convertProjectToFormType(projectData);
 
   return (
     <AuthRequired>
       <Container>
-        <ProjectForm hideProgress submitButtonContent='프로젝트 수정하기' defaultValues={defaultValues} />
+        <ProjectForm
+          hideProgress
+          submitButtonContent='프로젝트 수정하기'
+          defaultValues={defaultValues}
+          onSubmit={handleSubmit}
+        />
       </Container>
     </AuthRequired>
   );
 };
 
 export default ProjectEdit;
-
-setLayout(ProjectEdit, 'header');
 
 const Container = styled.div`
   display: flex;

--- a/components/projects/edit/ProjectEdit.tsx
+++ b/components/projects/edit/ProjectEdit.tsx
@@ -1,0 +1,31 @@
+import { useQuery } from '@tanstack/react-query';
+import { useRouter } from 'next/router';
+import { FC, useEffect } from 'react';
+
+import { useGetMemberOfMe } from '@/api/endpoint/members/getMemberOfMe';
+import { getProjectById } from '@/api/endpoint_LEGACY/projects';
+import { Alert } from '@/components/common/Modal/Alert';
+import { playgroundLink } from '@/constants/links';
+
+interface ProjectEditProps {
+  projectId: string;
+}
+const ProjectEdit: FC<ProjectEditProps> = ({ projectId }) => {
+  const { data: projectData } = useQuery(['getProjectById', projectId], () => getProjectById(projectId));
+  const { data: myProfileData } = useGetMemberOfMe();
+  const router = useRouter();
+
+  useEffect(() => {
+    if (myProfileData && projectData && myProfileData?.id !== projectData?.writerId) {
+      Alert({
+        title: '알림',
+        content: '해당 프로젝트를 작성한 유저만 접근 가능한 페이지 입니다.',
+        onClose: () => router.push(playgroundLink.projectList()),
+      });
+    }
+  }, [myProfileData, projectData, router]);
+
+  return <div>{projectId}</div>;
+};
+
+export default ProjectEdit;

--- a/components/projects/edit/ProjectEdit.tsx
+++ b/components/projects/edit/ProjectEdit.tsx
@@ -1,11 +1,17 @@
+import styled from '@emotion/styled';
 import { useQuery } from '@tanstack/react-query';
 import { useRouter } from 'next/router';
 import { FC, useEffect } from 'react';
 
 import { useGetMemberOfMe } from '@/api/endpoint/members/getMemberOfMe';
 import { getProjectById } from '@/api/endpoint_LEGACY/projects';
+import AuthRequired from '@/components/auth/AuthRequired';
 import { Alert } from '@/components/common/Modal/Alert';
+import ProjectForm from '@/components/projects/form/ProjectForm';
+import { ProjectFormType } from '@/components/projects/form/schema';
 import { playgroundLink } from '@/constants/links';
+import { MOBILE_MEDIA_QUERY } from '@/styles/mediaQuery';
+import { setLayout } from '@/utils/layout';
 
 interface ProjectEditProps {
   projectId: string;
@@ -25,7 +31,64 @@ const ProjectEdit: FC<ProjectEditProps> = ({ projectId }) => {
     }
   }, [myProfileData, projectData, router]);
 
-  return <div>{projectId}</div>;
+  if (!projectData) {
+    return null;
+  }
+
+  const defaultValues: ProjectFormType = {
+    name: projectData.name,
+    generation: `${projectData?.generation}`,
+    category: projectData.category,
+    detail: projectData.detail,
+    summary: projectData.summary,
+    serviceType: projectData.serviceType as [string, ...string[]],
+    period: {
+      startAt: projectData.startAt,
+      endAt: projectData.endAt ? projectData.endAt : null,
+    },
+    status: {
+      isAvailable: projectData.isAvailable,
+      isFounding: projectData.isFounding,
+    },
+    projectImages: projectData?.images.map((image) => ({ imageUrl: image })) || [],
+    logoImage: projectData.logoImage,
+    thumbnailImage: projectData.thumbnailImage,
+    members: projectData.members
+      .filter((member) => member.isTeamMember)
+      .map((member) => ({
+        memberId: member.memberId.toString(),
+        memberRole: member.memberRole,
+        memberDescription: member.memberDescription,
+      })),
+    releaseMembers: projectData.members
+      .filter((member) => !member.isTeamMember)
+      .map((member) => ({
+        memberId: member.memberId.toString(),
+        memberRole: member.memberRole,
+        memberDescription: member.memberDescription,
+      })),
+    links: projectData.links,
+  };
+
+  return (
+    <AuthRequired>
+      <Container>
+        <ProjectForm hideProgress submitButtonContent='프로젝트 수정하기' defaultValues={defaultValues} />
+      </Container>
+    </AuthRequired>
+  );
 };
 
 export default ProjectEdit;
+
+setLayout(ProjectEdit, 'header');
+
+const Container = styled.div`
+  display: flex;
+  justify-content: center;
+  margin: 98px 0;
+
+  @media ${MOBILE_MEDIA_QUERY} {
+    margin-top: 12px;
+  }
+`;

--- a/components/projects/edit/ProjectEdit.tsx
+++ b/components/projects/edit/ProjectEdit.tsx
@@ -47,6 +47,7 @@ const ProjectEdit: FC<ProjectEditProps> = ({ projectId }) => {
             router.push(playgroundLink.projectList());
             queryClient.invalidateQueries(getProjectQueryKey(projectId));
             queryClient.invalidateQueries(getProjectListQueryKey());
+            queryClient.invalidateQueries(['getProjectById', projectId]);
             logSubmitEvent('projectEdit', {
               projectId,
               editorId: String(myProfileData.id),

--- a/components/projects/form/ProjectForm.tsx
+++ b/components/projects/form/ProjectForm.tsx
@@ -84,6 +84,7 @@ const ProjectForm: FC<ProjectFormProps> = ({
   const { category } = useWatch({
     control,
   });
+
   const { errors } = useFormState({
     control,
   });
@@ -440,7 +441,10 @@ const StyledAddButton = styled.button`
 `;
 
 const StyledInput = styled(Input)`
+  width: 340px;
+
   @media ${MOBILE_MEDIA_QUERY} {
+    width: 100%;
     ${textStyles.SUIT_14_M};
   }
 `;

--- a/components/projects/form/fields/MemberField.tsx
+++ b/components/projects/form/fields/MemberField.tsx
@@ -3,6 +3,7 @@ import { isEmpty } from 'lodash-es';
 import { FC, useMemo, useState } from 'react';
 
 import { getMembersSearchByName } from '@/api/endpoint/members/getMembersSearchByName';
+import { getMemberById } from '@/api/endpoint_LEGACY/members';
 import Input from '@/components/common/Input';
 import ErrorMessage from '@/components/common/Input/ErrorMessage';
 import Select from '@/components/common/Select';
@@ -51,6 +52,18 @@ const MemberField: FC<MemberFieldProps> = ({ className, value, errorMessage, onC
     }));
   };
 
+  const fetchMemberById = async (id: string) => {
+    const member = await getMemberById(Number(id));
+    const defaultMember = {
+      id: String(member.id),
+      name: member.name,
+      generation: member.generation,
+      profileImage: member.profileImage,
+    };
+    setSelcetedMember(defaultMember);
+    return defaultMember;
+  };
+
   const onSelectMember = (member: Member) => {
     onChange({
       ...value,
@@ -89,13 +102,8 @@ const MemberField: FC<MemberFieldProps> = ({ className, value, errorMessage, onC
           <MemberSearchContext.Provider
             value={{
               searchMember,
-              // TODO: 수정 작업 시 실제 API로 변경
-              getMemberById: async () => {
-                return new Promise((resolve, reject) => {
-                  resolve({ id: '3', generation: 30, name: '이준호', profileImage: '' });
-                  reject(undefined);
-                });
-              },
+              memberId: value.memberId,
+              getMemberById: fetchMemberById,
             }}
           >
             <StyledFormWrapper>

--- a/components/projects/form/fields/member/MemberSearch.tsx
+++ b/components/projects/form/fields/member/MemberSearch.tsx
@@ -29,12 +29,13 @@ interface MemberSearchProps {
 const MemberSearch: FC<MemberSearchProps> = ({
   className,
   placeholder,
-  selectedMember,
+  selectedMember: selectedMemberProp,
   isError,
   onSelect,
   onClear,
 }) => {
-  const { name, onValueChange, onValueClear, searchedMemberList } = useMemberSearch();
+  const { name, onValueChange, onValueClear, searchedMemberList, defaultValue } = useMemberSearch();
+  const selectedMember = selectedMemberProp || defaultValue;
 
   const handleSelect = (member: Member) => {
     onSelect(member);

--- a/components/projects/form/fields/member/MemberSearchContext.tsx
+++ b/components/projects/form/fields/member/MemberSearchContext.tsx
@@ -10,8 +10,8 @@ export type Member = {
 };
 
 interface MemberSearchContextType {
+  memberId?: string;
   searchMember: (name: string) => Promise<Member[]>;
-  // for edit
   getMemberById: (id: string) => Promise<Member | undefined>;
 }
 
@@ -26,7 +26,7 @@ export const MemberSearchContext = createContext(
 export function useMemberSearch() {
   const [name, setName] = useState<string>('');
   const [searchQuery, setSearchQuery] = useState<string>('');
-  const { searchMember, getMemberById } = useContext(MemberSearchContext);
+  const { memberId, searchMember, getMemberById } = useContext(MemberSearchContext);
 
   const { data: searchedMemberData } = useQuery(
     ['searchMember', searchQuery],
@@ -35,7 +35,19 @@ export function useMemberSearch() {
       return data;
     },
     {
-      enabled: !!searchQuery,
+      enabled: Boolean(searchQuery),
+    },
+  );
+
+  const { data: defaultValue } = useQuery(
+    ['getMemberById', memberId],
+    async () => {
+      if (!memberId) return;
+      const data = await getMemberById(memberId);
+      return data;
+    },
+    {
+      enabled: Boolean(memberId),
     },
   );
 
@@ -56,6 +68,6 @@ export function useMemberSearch() {
     onValueChange,
     onValueClear,
     searchedMemberList: searchedMemberData,
-    getMemberById,
+    defaultValue,
   };
 }

--- a/components/projects/upload/hooks/useGetProjectListQuery.ts
+++ b/components/projects/upload/hooks/useGetProjectListQuery.ts
@@ -2,11 +2,11 @@ import { useQuery } from '@tanstack/react-query';
 
 import { getProjects } from '@/api/endpoint_LEGACY/projects';
 
-export const getProjectListQueryKey = 'getProjectListQuery';
+export const getProjectListQueryKey = () => ['getProjectListQuery'];
 
 const useGetProjectListQuery = () => {
   return useQuery(
-    [getProjectListQueryKey],
+    getProjectListQueryKey(),
     async () => {
       const data = await getProjects();
       return data;

--- a/components/projects/upload/hooks/useGetProjectQuery.ts
+++ b/components/projects/upload/hooks/useGetProjectQuery.ts
@@ -3,6 +3,7 @@ import { uniqBy as _uniqBy } from 'lodash-es';
 
 import { getProjectById } from '@/api/endpoint_LEGACY/projects';
 
+export const getProjectQueryKey = (id: string) => ['getProjectQuery', id];
 interface GetProjectQueryVariables {
   id: string;
 }
@@ -10,7 +11,7 @@ interface GetProjectQueryVariables {
 const useGetProjectQuery = (variables: GetProjectQueryVariables) => {
   const { id } = variables;
   return useQuery(
-    ['getProjectQuery', id],
+    getProjectQueryKey(id),
     async () => {
       const data = await getProjectById(id);
 

--- a/components/projects/utils.ts
+++ b/components/projects/utils.ts
@@ -1,0 +1,79 @@
+import type {
+  MemberRole,
+  ProjectCategory,
+  ProjectDetail,
+  ProjectInput,
+  ServiceType,
+} from '@/api/endpoint_LEGACY/projects/type';
+import { DEFAULT_IMAGE_URL } from '@/components/projects/form/constants';
+import { ProjectFormType } from '@/components/projects/form/schema';
+import { convertPeriodFormat, convertPeriodFormatReverse } from '@/components/projects/upload/utils';
+
+export const convertToProjectData = (formData: ProjectFormType, writerId: number): ProjectInput => ({
+  name: formData.name,
+  generation: formData.generation ? Number(formData.generation) : undefined,
+  category: formData.category as ProjectCategory,
+  detail: formData.detail,
+  summary: formData.summary,
+  serviceType: formData.serviceType as ServiceType[],
+  startAt: convertPeriodFormat(formData.period.startAt),
+  ...(formData.period.endAt ? { endAt: convertPeriodFormat(formData.period.endAt) } : {}),
+  isAvailable: formData.status.isAvailable,
+  isFounding: formData.status.isFounding,
+  images: formData.projectImages.map(({ imageUrl }) => imageUrl).filter((image) => image !== DEFAULT_IMAGE_URL),
+  logoImage: formData.logoImage,
+  thumbnailImage: formData.thumbnailImage,
+  members: [
+    ...formData.members.map((member) => ({
+      ...member,
+      memberId: Number(member.memberId),
+      memberRole: member.memberRole as MemberRole,
+      isTeamMember: true,
+    })),
+    ...formData.releaseMembers.map((releasedMember) => ({
+      ...releasedMember,
+      memberId: Number(releasedMember.memberId),
+      memberRole: releasedMember.memberRole as MemberRole,
+      isTeamMember: false,
+    })),
+  ],
+  links: formData.links,
+  writerId,
+});
+
+export const convertProjectToFormType = (projectData: ProjectDetail): ProjectFormType => {
+  return {
+    name: projectData.name,
+    generation: `${projectData?.generation}`,
+    category: projectData.category,
+    detail: projectData.detail,
+    summary: projectData.summary,
+    serviceType: projectData.serviceType as [string, ...string[]],
+    period: {
+      startAt: convertPeriodFormatReverse(projectData.startAt),
+      endAt: projectData.endAt ? convertPeriodFormatReverse(projectData.endAt) : null,
+    },
+    status: {
+      isAvailable: projectData.isAvailable,
+      isFounding: projectData.isFounding,
+    },
+    projectImages: projectData.images.map((image) => ({ imageUrl: image })),
+    logoImage: projectData.logoImage,
+    thumbnailImage: projectData.thumbnailImage,
+    members: projectData.members
+      .filter((member) => member.isTeamMember)
+      .map((member) => convertMemberToMemberFormType(member)),
+    releaseMembers: projectData.members
+      .filter((member) => !member.isTeamMember)
+      .map((member) => convertMemberToMemberFormType(member)),
+    links: projectData.links,
+  };
+};
+
+const convertMemberToMemberFormType = (member: ProjectDetail['members'][number]) => {
+  return {
+    memberId: `${member.memberId}`,
+    memberRole: member.memberRole,
+    memberDescription: member.memberDescription,
+  };
+};

--- a/constants/links.ts
+++ b/constants/links.ts
@@ -11,7 +11,7 @@ export const playgroundLink = {
   projectList: () => `/projects`,
   projectDetail: (id: string | number) => `/projects/${id}`,
   projectUpload: () => `/projects/upload`,
-  projectEdit: (id: string | number) => `/projects/upload?id=${id}&edit=true`,
+  projectEdit: (id: string | number) => `/projects/edit/${id}`,
   groupList: () => '/group',
   login: () => `/auth/login`,
   register: () => `/auth/verify`,

--- a/pages/projects/edit/[id].tsx
+++ b/pages/projects/edit/[id].tsx
@@ -27,6 +27,6 @@ const ProjectEditPage: FC = () => {
   return null;
 };
 
-setLayout(ProjectEditPage, 'headerFooter');
+setLayout(ProjectEditPage, 'header');
 
 export default ProjectEditPage;

--- a/pages/projects/edit/[id].tsx
+++ b/pages/projects/edit/[id].tsx
@@ -1,0 +1,32 @@
+import { FC } from 'react';
+
+import AuthRequired from '@/components/auth/AuthRequired';
+import ProjectEdit from '@/components/projects/edit/ProjectEdit';
+import useStringRouterQuery from '@/hooks/useStringRouterQuery';
+import { setLayout } from '@/utils/layout';
+
+const ProjectEditPage: FC = () => {
+  const { status, query } = useStringRouterQuery(['id'] as const);
+
+  if (status === 'loading') {
+    return null;
+  }
+
+  if (status === 'error') {
+    return null;
+  }
+
+  if (status === 'success') {
+    return (
+      <AuthRequired>
+        <ProjectEdit projectId={query.id} />
+      </AuthRequired>
+    );
+  }
+
+  return null;
+};
+
+setLayout(ProjectEditPage, 'headerFooter');
+
+export default ProjectEditPage;

--- a/pages/projects/upload/v2/index.tsx
+++ b/pages/projects/upload/v2/index.tsx
@@ -3,17 +3,15 @@ import { useQueryClient } from '@tanstack/react-query';
 import { useRouter } from 'next/router';
 
 import { useGetMemberOfMe } from '@/api/endpoint/members/getMemberOfMe';
-import type { MemberRole, ProjectCategory, ServiceType } from '@/api/endpoint_LEGACY/projects/type';
 import AuthRequired from '@/components/auth/AuthRequired';
 import { Confirm } from '@/components/common/Modal/Confirm';
 import useToast from '@/components/common/Toast/useToast';
 import useEventLogger from '@/components/eventLogger/hooks/useEventLogger';
-import { DEFAULT_IMAGE_URL } from '@/components/projects/form/constants';
 import ProjectForm from '@/components/projects/form/ProjectForm';
 import { ProjectFormType } from '@/components/projects/form/schema';
 import useCreateProjectMutation from '@/components/projects/upload/hooks/useCreateProjectMutation';
 import { getProjectListQueryKey } from '@/components/projects/upload/hooks/useGetProjectListQuery';
-import { convertPeriodFormat } from '@/components/projects/upload/utils';
+import { convertToProjectData } from '@/components/projects/utils';
 import { playgroundLink } from '@/constants/links';
 import { MOBILE_MEDIA_QUERY } from '@/styles/mediaQuery';
 import { setLayout } from '@/utils/layout';
@@ -32,38 +30,7 @@ const ProjectUploadPage = () => {
       content: '프로젝트를 업로드 하시겠습니까?',
     });
     if (notify && myProfileData) {
-      createProjectMutate(
-        {
-          name: formData.name,
-          generation: formData.generation ? Number(formData.generation) : undefined,
-          category: formData.category as ProjectCategory,
-          detail: formData.detail,
-          summary: formData.summary,
-          serviceType: formData.serviceType as ServiceType[],
-          startAt: convertPeriodFormat(formData.period.startAt),
-          ...(formData.period.endAt ? { endAt: convertPeriodFormat(formData.period.endAt) } : {}),
-          isAvailable: formData.status.isAvailable,
-          isFounding: formData.status.isFounding,
-          images: formData.projectImages.map(({ imageUrl }) => imageUrl).filter((image) => image !== DEFAULT_IMAGE_URL),
-          logoImage: formData.logoImage,
-          thumbnailImage: formData.thumbnailImage,
-          members: [
-            ...formData.members.map((member) => ({
-              ...member,
-              memberId: Number(member.memberId),
-              memberRole: member.memberRole as MemberRole,
-              isTeamMember: true,
-            })),
-            ...formData.releaseMembers.map((releasedMember) => ({
-              ...releasedMember,
-              memberId: Number(releasedMember.memberId),
-              memberRole: releasedMember.memberRole as MemberRole,
-              isTeamMember: false,
-            })),
-          ],
-          links: formData.links,
-          writerId: myProfileData?.id,
-        },
+      createProjectMutate(convertToProjectData(formData, myProfileData.id)),
         {
           onSuccess: () => {
             toast.show({ message: '프로젝트가 성공적으로 업로드 되었습니다.' });
@@ -73,8 +40,7 @@ const ProjectUploadPage = () => {
               writerId: String(myProfileData.id),
             });
           },
-        },
-      );
+        };
     }
   };
 

--- a/pages/projects/upload/v2/index.tsx
+++ b/pages/projects/upload/v2/index.tsx
@@ -33,9 +33,9 @@ const ProjectUploadPage = () => {
       createProjectMutate(convertToProjectData(formData, myProfileData.id)),
         {
           onSuccess: () => {
-            toast.show({ message: '프로젝트가 성공적으로 업로드 되었습니다.' });
+            toast.show({ message: '프로젝트를 성공적으로 업로드 했어요.' });
             router.push(playgroundLink.projectList());
-            queryClient.invalidateQueries([getProjectListQueryKey]);
+            queryClient.invalidateQueries(getProjectListQueryKey());
             logSubmitEvent('projectUpload', {
               writerId: String(myProfileData.id),
             });


### PR DESCRIPTION
### 🤫 쉿, 나한테만 말해줘요. 이슈넘버
- close #871 

### 🧐 어떤 것을 변경했어요~?
<!-- 실제로 변경한 사항을 설명해주세요.-->
- `upload?id=109&edit=true` 형태의 링크에서 `project/edit/:id` 형태로 변경했어요.
- 만약 바로 링크를 타고 들어왔을 때, 로그인한 id와 project의 writerId가 다를 경우 알럿창을 띄우고 projectList 페이지로 리다이렉트 시키는 방어로직을 추가했어요.

### 🤔 그렇다면, 어떻게 구현했어요~?
<!-- 실제로 구현한 로직에 대해 설명해주세요.-->

### ❤️‍🔥 당신이 생각하는 PR포인트, 내겐 매력포인트.
<!-- 해당 PR에서 논의가 필요한 사항을 적어주세요. -->

### 📸 스크린샷, 없으면 이것 참,, 섭섭한데요?
