### PR TITLE
feat: 프로젝트 카드 호버시 디자인 수정

### DIFF
--- a/components/projects/main/ProjectCard.tsx
+++ b/components/projects/main/ProjectCard.tsx
@@ -6,7 +6,7 @@ import { ProjectDetail } from '@/api/endpoint_LEGACY/projects/type';
 import ResizedImage from '@/components/common/ResizedImage';
 import Text from '@/components/common/Text';
 import useEventLogger from '@/components/eventLogger/hooks/useEventLogger';
-import { categoryLabel, getLinkInfo } from '@/components/projects/upload/constants';
+import { categoryLabel } from '@/components/projects/upload/constants';
 import { playgroundLink } from '@/constants/links';
 import { colors } from '@/styles/colors';
 import { MOBILE_MEDIA_QUERY } from '@/styles/mediaQuery';
@@ -21,55 +21,41 @@ const ProjectCard: FC<ProjectDetail> = ({
   summary,
   thumbnailImage,
   logoImage,
-  links,
 }) => {
   const { logClickEvent } = useEventLogger();
 
-  // FIXME: 서버측에서 링크 업로드 하지 않았을 경우 빈 배열이 아닌 속성에 null 이 담긴 link 배열이 내려와 임시 대응 (https://github.com/sopt-makers/internal-server/issues/32)
-  const filteredLinks = links.filter(({ linkId, linkTitle, linkUrl }) => linkId && linkTitle && linkUrl);
-
   return (
-    <Link passHref href={playgroundLink.projectDetail(id)} legacyBehavior>
-      <StyledCard onClick={() => logClickEvent('projectCard', { id, name })}>
-        <StyledServiceTypeWrapper>
-          {serviceType.map((serviceType, index) => (
-            <StyledServiceType key={index}>{serviceType}</StyledServiceType>
-          ))}
-        </StyledServiceTypeWrapper>
-        <StyledImageSection>
-          {thumbnailImage ? (
-            <StyledThumbnail className='card-image' src={thumbnailImage} width={380} alt='thumbnail-image' />
-          ) : (
-            <StyledLogo className='card-image' src={logoImage} width={380} alt='logo-image' />
-          )}
-          <ServiceLinkWrapper className='card-hover'>
-            {filteredLinks.map(({ linkId, linkTitle, linkUrl }) => (
-              <StyledServiceLink key={linkId} href={linkUrl} onClick={(e) => e.stopPropagation()}>
-                <StyledLinkIcon alt='link-icon' src={getLinkInfo(linkTitle)?.icon} />
-                <Text typography='SUIT_12_SB'>{getLinkInfo(linkTitle)?.label}</Text>
-              </StyledServiceLink>
-            ))}
-          </ServiceLinkWrapper>
-        </StyledImageSection>
-        <StyledContent>
-          <StyledTitleWrapper>
-            <Text typography='SUIT_18_B'>{name}</Text>
-            <Text typography='SUIT_12_SB' color={colors.gray100}>
-              {generation ? `${generation}기 ${categoryLabel[category]}` : categoryLabel[category]}
-            </Text>
-          </StyledTitleWrapper>
-          <Text typography='SUIT_14_M' color={colors.gray60}>
-            {summary}
+    <StyledCard href={playgroundLink.projectDetail(id)} onClick={() => logClickEvent('projectCard', { id, name })}>
+      <StyledServiceTypeWrapper>
+        {serviceType.map((serviceType, index) => (
+          <StyledServiceType key={index}>{serviceType}</StyledServiceType>
+        ))}
+      </StyledServiceTypeWrapper>
+      <StyledImageSection>
+        {thumbnailImage ? (
+          <StyledThumbnail className='card-image' src={thumbnailImage} width={380} alt='thumbnail-image' />
+        ) : (
+          <StyledLogo className='card-image' src={logoImage} width={380} alt='logo-image' />
+        )}
+      </StyledImageSection>
+      <StyledContent>
+        <StyledTitleWrapper>
+          <Text typography='SUIT_18_B'>{name}</Text>
+          <Text typography='SUIT_12_SB' color={colors.gray100}>
+            {generation ? `${generation}기 ${categoryLabel[category]}` : categoryLabel[category]}
           </Text>
-        </StyledContent>
-      </StyledCard>
-    </Link>
+        </StyledTitleWrapper>
+        <Text typography='SUIT_14_M' color={colors.gray60}>
+          {summary}
+        </Text>
+      </StyledContent>
+    </StyledCard>
   );
 };
 
 export default ProjectCard;
 
-const StyledCard = styled.a`
+const StyledCard = styled(Link)`
   display: flex;
   position: relative;
   flex-direction: column;
@@ -81,15 +67,10 @@ const StyledCard = styled.a`
   height: 292px;
 
   :hover {
-    & .card-hover {
-      transition: visibility 0.3s linear, opacity 0.3s linear;
-      visibility: visible;
-      opacity: 1;
-    }
-
     & .card-image {
-      transition: opacity 0.2s;
-      opacity: 0.8;
+      transition: opacity 0.2s, scale 0.2s;
+      opacity: 0.75;
+      scale: 1.1;
     }
   }
 
@@ -129,38 +110,15 @@ const StyledServiceType = styled.div`
 
 const StyledImageSection = styled.section`
   display: flex;
-  position: relative;
   flex-direction: column;
   align-items: center;
+  border-radius: 6px;
   width: 100%;
   height: 208px;
-`;
-
-const ServiceLinkWrapper = styled.div`
-  display: flex;
-  position: absolute;
-  bottom: 60px;
-  gap: 16px;
-  visibility: hidden;
-  opacity: 0;
-`;
-
-const StyledLinkIcon = styled.img`
-  border-radius: 10px;
-  background-color: ${colors.black100};
-  width: 54px;
-  height: 54px;
-`;
-
-const StyledServiceLink = styled.a`
-  display: flex;
-  flex-direction: column;
-  gap: 10px;
-  align-items: center;
+  overflow: hidden;
 `;
 
 const StyledThumbnail = styled(ResizedImage)`
-  border-radius: 6px;
   background: linear-gradient(180deg, rgb(35 35 50 / 0%) 0%, rgb(35 35 35 / 80%) 100%);
   width: 100%;
   height: 100%;


### PR DESCRIPTION
### 🤫 쉿, 나한테만 말해줘요. 이슈넘버
- close #890 

### 🧐 어떤 것을 변경했어요~?
<!-- 실제로 변경한 사항을 설명해주세요.-->
- 변경된 디자인에 맞게 프로젝트 카드 호버뷰를 수정했어요.
- 호버 시 보이던 링크들을 제거하고 이미지가 scale up 되도록 변경했어요.

### 🤔 그렇다면, 어떻게 구현했어요~?
<!-- 실제로 구현한 로직에 대해 설명해주세요.-->

### ❤️‍🔥 당신이 생각하는 PR포인트, 내겐 매력포인트.
<!-- 해당 PR에서 논의가 필요한 사항을 적어주세요. -->

### 📸 스크린샷, 없으면 이것 참,, 섭섭한데요?

https://github.com/sopt-makers/sopt-playground-frontend/assets/26808056/fd58ea6c-4220-40be-98da-054992017c36

