### PR TITLE
fix: ProjectEdit 수정사항 반영

### DIFF
--- a/components/projects/edit/ProjectEdit.tsx
+++ b/components/projects/edit/ProjectEdit.tsx
@@ -44,7 +44,7 @@ const ProjectEdit: FC<ProjectEditProps> = ({ projectId }) => {
         {
           onSuccess: () => {
             toast.show({ message: '프로젝트를 성공적으로 수정했어요.' });
-            router.push(playgroundLink.projectList());
+            router.push(playgroundLink.projectDetail(projectId));
             queryClient.invalidateQueries(getProjectQueryKey(projectId));
             queryClient.invalidateQueries(getProjectListQueryKey());
             queryClient.invalidateQueries(['getProjectById', projectId]);

--- a/components/projects/utils.ts
+++ b/components/projects/utils.ts
@@ -57,7 +57,7 @@ export const convertProjectToFormType = (projectData: ProjectDetail): ProjectFor
       isAvailable: projectData.isAvailable,
       isFounding: projectData.isFounding,
     },
-    projectImages: projectData.images.map((image) => ({ imageUrl: image })),
+    projectImages: [...projectData.images.map((image) => ({ imageUrl: image })), { imageUrl: DEFAULT_IMAGE_URL }],
     logoImage: projectData.logoImage,
     thumbnailImage: projectData.thumbnailImage,
     members: projectData.members


### PR DESCRIPTION
### 🤫 쉿, 나한테만 말해줘요. 이슈넘버
- close #

### 🧐 어떤 것을 변경했어요~?
<!-- 실제로 변경한 사항을 설명해주세요.-->
- 프로젝트 수정페이지로 진입할 시 추가적으로 프로젝트 이미지를 더 추가할 수 없던 문제를 수정했어요.
- 프로젝트 수정 시 해당 프로젝트의 상세페이지로 이동시키는게 더 자연스러워 보여서 이를 수정했어요. (기존엔 리스트 페이지)

### 🤔 그렇다면, 어떻게 구현했어요~?
<!-- 실제로 구현한 로직에 대해 설명해주세요.-->

### ❤️‍🔥 당신이 생각하는 PR포인트, 내겐 매력포인트.
<!-- 해당 PR에서 논의가 필요한 사항을 적어주세요. -->

### 📸 스크린샷, 없으면 이것 참,, 섭섭한데요?
