### PR TITLE
feat: 디버그 패널 버튼 크기 변경

### DIFF
--- a/components/debug/SideToggleButton.tsx
+++ b/components/debug/SideToggleButton.tsx
@@ -2,6 +2,7 @@ import styled from '@emotion/styled';
 import { forwardRef } from 'react';
 
 import { colors } from '@/styles/colors';
+import { textStyles } from '@/styles/typography';
 
 interface SideToggleButtonProps {
   onClick(): void;
@@ -19,16 +20,16 @@ export default SideToggleButton;
 
 const StyledSideToggleButton = styled.button`
   position: fixed;
-  right: 10px;
-  bottom: 10px;
+  right: 2px;
+  bottom: 2px;
   z-index: 100009;
   border-radius: 7px;
   background-color: ${colors.purple60};
   cursor: pointer;
   padding: 5px;
   color: ${colors.gray100};
-  font-size: 18px;
-  font-weight: bold;
+
+  ${textStyles.SUIT_14_B}
 
   &:hover {
     background-color: ${colors.white};

--- a/pages/soulmate/index.tsx
+++ b/pages/soulmate/index.tsx
@@ -1,0 +1,18 @@
+import styled from '@emotion/styled';
+import { FC } from 'react';
+
+import AuthRequired from '@/components/auth/AuthRequired';
+
+interface SoulmatePageProps {}
+
+const SoulmatePage: FC<SoulmatePageProps> = ({}) => {
+  return (
+    <AuthRequired>
+      <Container>Soulmate</Container>
+    </AuthRequired>
+  );
+};
+
+export default SoulmatePage;
+
+const Container = styled.div``;


### PR DESCRIPTION
### 🤫 쉿, 나한테만 말해줘요. 이슈넘버
- close #899 

### 🧐 어떤 것을 변경했어요~?
<!-- 실제로 변경한 사항을 설명해주세요.-->

기존에 프리뷰 환경에서 디버그 패널 버튼이 채널톡과 겹치던 문제가 있었어요.
그런데 그렇다고 버튼을 다른데 옮기자니 위치가 애매해서 겹치치 않도록 버튼 크기를 줄였어요.

### 🤔 그렇다면, 어떻게 구현했어요~?
<!-- 실제로 구현한 로직에 대해 설명해주세요.-->

### ❤️‍🔥 당신이 생각하는 PR포인트, 내겐 매력포인트.
<!-- 해당 PR에서 논의가 필요한 사항을 적어주세요. -->

### 📸 스크린샷, 없으면 이것 참,, 섭섭한데요?
<img width="539" alt="image" src="https://github.com/sopt-makers/sopt-playground-frontend/assets/36122585/50b54f7b-0ac5-4095-8b26-b9b19a585975">
