### PR TITLE
chore: 회원가입 완료 페이지 스타일링 수정

### DIFF
--- a/components/auth/register/RegisterFinished.tsx
+++ b/components/auth/register/RegisterFinished.tsx
@@ -4,7 +4,6 @@ import { FC } from 'react';
 
 import SquareLink from '@/components/common/SquareLink';
 import { playgroundLink } from '@/constants/links';
-import { MOBILE_MEDIA_QUERY } from '@/styles/mediaQuery';
 import { textStyles } from '@/styles/typography';
 
 const RegisterFinished: FC = () => {
@@ -29,7 +28,6 @@ const Container = styled.div`
   display: flex;
   flex-direction: column;
   align-items: center;
-  width: 420px;
 `;
 
 const Title = styled.h2`
@@ -46,9 +44,4 @@ const Description = styled.p`
 
 const SendButton = styled(SquareLink)`
   align-self: stretch;
-
-  @media ${MOBILE_MEDIA_QUERY} {
-    align-self: center;
-    width: 350px;
-  }
 `;

--- a/components/auth/register/RegisterFinished.tsx
+++ b/components/auth/register/RegisterFinished.tsx
@@ -4,6 +4,7 @@ import { FC } from 'react';
 
 import SquareLink from '@/components/common/SquareLink';
 import { playgroundLink } from '@/constants/links';
+import { MOBILE_MEDIA_QUERY } from '@/styles/mediaQuery';
 import { textStyles } from '@/styles/typography';
 
 const RegisterFinished: FC = () => {
@@ -45,4 +46,9 @@ const Description = styled.p`
 
 const SendButton = styled(SquareLink)`
   align-self: stretch;
+
+  @media ${MOBILE_MEDIA_QUERY} {
+    align-self: center;
+    width: 350px;
+  }
 `;

--- a/pages/auth/register-finished.tsx
+++ b/pages/auth/register-finished.tsx
@@ -20,5 +20,6 @@ const StyledRegisterSuccessPage = styled.div`
   display: flex;
   flex-direction: column;
   align-items: center;
+  justify-content: center;
   height: 100%;
 `;


### PR DESCRIPTION
### 🤫 쉿, 나한테만 말해줘요. 이슈넘버
- close #903

### 🧐 어떤 것을 변경했어요~?
<!-- 실제로 변경한 사항을 설명해주세요.-->

1. 컨텐츠 중앙 정렬하기
2. 모바일 대응

### 🤔 그렇다면, 어떻게 구현했어요~?
<!-- 실제로 구현한 로직에 대해 설명해주세요.-->

1. justifiy content center
2. width: 420px 제거 -> 데스크탑 UI에는 변화가 없으면서 모바일에서 뷰포트를 넘어가 UI가 깨지는 현상 사라짐

### ❤️‍🔥 당신이 생각하는 PR포인트, 내겐 매력포인트.
<!-- 해당 PR에서 논의가 필요한 사항을 적어주세요. -->

### 📸 스크린샷, 없으면 이것 참,, 섭섭한데요?

<img width="1440" alt="image" src="https://github.com/sopt-makers/sopt-playground-frontend/assets/73823388/129d97d7-f207-4cde-8948-0e3e3472d071">

<img width="1440" alt="image" src="https://github.com/sopt-makers/sopt-playground-frontend/assets/73823388/8d5dde18-43d5-4496-accc-5c58679abf54">

