### PR TITLE
feat: 푸터에 메이커스 소개 추가

### DIFF
--- a/components/common/Footer/index.tsx
+++ b/components/common/Footer/index.tsx
@@ -5,7 +5,7 @@ import { useRouter } from 'next/router';
 import { FC } from 'react';
 
 import useEventLogger from '@/components/eventLogger/hooks/useEventLogger';
-import { FEEDBACK_FORM_URL, playgroundLink } from '@/constants/links';
+import { FEEDBACK_FORM_URL, MAKERS_TEAM_URL, playgroundLink } from '@/constants/links';
 import useScroll from '@/hooks/useScroll';
 import { colors } from '@/styles/colors';
 import { MOBILE_MEDIA_QUERY } from '@/styles/mediaQuery';
@@ -26,6 +26,9 @@ const Footer: FC<FooterProps> = ({}) => {
           만든 사람들
         </FooterLink>
       </Link>
+      <FooterLink href={MAKERS_TEAM_URL} target='_blank'>
+        메이커스 소개
+      </FooterLink>
       <FooterLink href={FEEDBACK_FORM_URL} target='_blank'>
         의견 제안하기
       </FooterLink>

--- a/constants/links.ts
+++ b/constants/links.ts
@@ -2,6 +2,8 @@ export const FEEDBACK_FORM_URL = 'https://forms.gle/FCx5WJ6mDmRuneQi9';
 export const NOTIFY_2ND_GENERATION_URL = 'https://forms.gle/AKf164VXtJPGJRoo8';
 export const MEMBER_REQUEST_FORM_URL = 'https://forms.gle/Hs9tJgMG9bNvT1rS9';
 export const MENTOR_APPLICATION_URL = 'https://forms.gle/iMiCSnqy5oWqAsx47';
+export const MAKERS_TEAM_URL =
+  'https://makers.sopt.org/?utm_source=playground&utm_medium=footer&utm_campaign=recruiting&utm_id=3rd_makers';
 
 export const playgroundLink = {
   memberList: () => `/members`,


### PR DESCRIPTION
### 🤫 쉿, 나한테만 말해줘요. 이슈넘버
- close #908

### 🧐 어떤 것을 변경했어요~?
<!-- 실제로 변경한 사항을 설명해주세요.-->

푸터에 '메이커스 소개'를 추가해요

### 🤔 그렇다면, 어떻게 구현했어요~?
<!-- 실제로 구현한 로직에 대해 설명해주세요.-->

### ❤️‍🔥 당신이 생각하는 PR포인트, 내겐 매력포인트.
<!-- 해당 PR에서 논의가 필요한 사항을 적어주세요. -->

@Tekiter 저는 팀 페이지라고 표현하면 잘 와닿을 것 같아서 링크 url 상수 이름을 `MAKERS_TEAM_URL`이라고 지었는데 혹시 다른 이름이 나을 것 같으면 말해주세요 or 자유롭게 수정 커밋 올려주세요

### 📸 스크린샷, 없으면 이것 참,, 섭섭한데요?

<img width="1440" alt="image" src="https://github.com/sopt-makers/sopt-playground-frontend/assets/73823388/b47177e0-0612-4ae2-9963-dfceaade4d6c">
