### PR TITLE
fix: 프로젝트 진행상황 - 기수 버그 수정, 프로젝트 이미지 추가

### DIFF
--- a/components/projects/form/ProjectForm.tsx
+++ b/components/projects/form/ProjectForm.tsx
@@ -119,7 +119,9 @@ const ProjectForm: FC<ProjectFormProps> = ({
           <Controller
             control={control}
             name='generation'
-            render={({ field }) => <GenerationField {...field} errorMessage={errors.generation?.message} />}
+            render={({ field }) => (
+              <GenerationField {...field} defaultValue='' errorMessage={errors.generation?.message} />
+            )}
           />
         </FormEntry>
         <FormEntry title='어디서 진행했나요?' description='기수는 SOPT 공식 활동을 기준으로 선택해주세요' required>

--- a/components/projects/form/UploadProjectProgress.tsx
+++ b/components/projects/form/UploadProjectProgress.tsx
@@ -14,7 +14,13 @@ const UploadProjectProgress: FC<UploadProjectProgressProps> = ({ formState }) =>
 
   const items: FormProgressItem[] = [
     { title: '프로젝트 이름', active: dirtyFields.name, required: true },
-    { title: '기수', active: dirtyFields.generation, required: true },
+    {
+      title: '기수',
+      active:
+        dirtyFields.generation ||
+        (formState.defaultValues?.generation !== null && formState.defaultValues?.generation !== undefined),
+      required: true,
+    },
     { title: '어디서 진행했나요?', active: dirtyFields.category, required: true },
     {
       title: '팀원',
@@ -27,6 +33,11 @@ const UploadProjectProgress: FC<UploadProjectProgressProps> = ({ formState }) =>
     { title: '프로젝트 설명', active: dirtyFields.detail, required: true },
     { title: '로고 이미지', active: dirtyFields.logoImage, required: true },
     { title: '썸네일 이미지', active: dirtyFields.thumbnailImage, required: true },
+    {
+      title: '프로젝트 이미지',
+      active: dirtyFields.projectImages?.some((image) => Boolean(image) && image.imageUrl !== false),
+      required: true,
+    },
   ];
 
   return <StyledFormProgress title='등록 진행' progressLabel='프로젝트를 등록해주세요.' items={items} />;

--- a/components/projects/form/UploadProjectProgress.tsx
+++ b/components/projects/form/UploadProjectProgress.tsx
@@ -16,9 +16,7 @@ const UploadProjectProgress: FC<UploadProjectProgressProps> = ({ formState }) =>
     { title: '프로젝트 이름', active: dirtyFields.name, required: true },
     {
       title: '기수',
-      active:
-        dirtyFields.generation ||
-        (formState.defaultValues?.generation !== null && formState.defaultValues?.generation !== undefined),
+      active: dirtyFields.generation,
       required: true,
     },
     { title: '어디서 진행했나요?', active: dirtyFields.category, required: true },

--- a/components/projects/form/fields/GenerationField.tsx
+++ b/components/projects/form/fields/GenerationField.tsx
@@ -5,20 +5,19 @@ import Checkbox from '@/components/common/Checkbox';
 import ErrorMessage from '@/components/common/Input/ErrorMessage';
 import Select from '@/components/common/Select';
 import Text from '@/components/common/Text';
-import { GENERATIONS, LATEST_GENERATION } from '@/constants/generation';
+import { GENERATIONS } from '@/constants/generation';
 import { colors } from '@/styles/colors';
 import { MOBILE_MEDIA_QUERY } from '@/styles/mediaQuery';
 import { textStyles } from '@/styles/typography';
 
-const defaultValue = String(LATEST_GENERATION);
-
 interface GenerationFieldProps {
   value: string | null;
+  defaultValue: string;
   onChange: (value: string | null) => void;
   errorMessage?: string;
 }
 
-const GenerationField: FC<GenerationFieldProps> = ({ value, onChange, errorMessage }) => {
+const GenerationField: FC<GenerationFieldProps> = ({ value, defaultValue, onChange, errorMessage }) => {
   const handleCheckboxChange = () => {
     if (value === null) {
       onChange(defaultValue);
@@ -29,7 +28,14 @@ const GenerationField: FC<GenerationFieldProps> = ({ value, onChange, errorMessa
 
   return (
     <StyledGenerationField>
-      <StyledSelect width={236} placeholder='선택' value={value ?? ''} onChange={(e) => onChange(e.target.value)}>
+      <StyledSelect
+        width={236}
+        placeholder='선택'
+        value={value ?? defaultValue}
+        onChange={(e) => onChange(e.target.value)}
+        error={Boolean(errorMessage)}
+      >
+        <option value={defaultValue}>선택</option>
         {GENERATIONS.map((item) => (
           <option key={item} value={item}>
             {item}기

--- a/components/projects/form/schema.ts
+++ b/components/projects/form/schema.ts
@@ -2,7 +2,6 @@ import { DefaultValues } from 'react-hook-form';
 import * as z from 'zod';
 
 import { DEFAULT_MEMBER } from '@/components/projects/form/constants';
-import { LATEST_GENERATION } from '@/constants/generation';
 
 export const dateStringSchema = z.string().regex(/^\d{4}.(0[1-9]|1[0-2])/g, '날짜 형식에 맞게 입력해주세요.');
 
@@ -72,7 +71,7 @@ export type ProjectFormType = z.infer<typeof uploadSchema>;
 
 export const defaultUploadValues: DefaultValues<ProjectFormType> = {
   name: '',
-  generation: String(LATEST_GENERATION),
+  generation: '',
   period: {
     startAt: '',
     endAt: '',


### PR DESCRIPTION
### 🤫 쉿, 나한테만 말해줘요. 이슈넘버
- close #930

### 🧐 어떤 것을 변경했어요~?
<!-- 실제로 변경한 사항을 설명해주세요.-->
- 기수쪽에 `defaultValue` 그대로일 경우 (최신기수인 32기) 진행상황 체크가 되지 않던 버그를 수정했습니당. 근데 그럼 결국 채우지 못할 경우의 수가 없으니 뺄까도 고민했는데, 필수 필드들은 다 체크하는 느낌이니 이렇게 대응했어요.
- 프로젝트 이미지를 누락해서, 이것도 추가했습니다.(사실 원래 플젝 이미지 선택이었는데 필수값으로 몰래 바꿨어요 -> 이미지 많이 올려줄 수록 좋을 것 같아서!) 

#### 이후 내용 정리
- 이전에 건영이와 오히려 32기 기수가 기본 설정으로 되어있는게 편할 것 같다고 의견 나눠서 이렇게 됐었는데, https://github.com/sopt-makers/sopt-playground-frontend/pull/931#issuecomment-1666842047 요기에서 주영이가 문제 제기 해주어서 다시 고민해본 결과 기존대로 돌아가도록 변경
- [bc19b03](https://github.com/sopt-makers/sopt-playground-frontend/pull/931/commits/bc19b0327e6b1cf668a2424d36f22feff973bdc2) 해당 커밋으로 변경!

### 🤔 그렇다면, 어떻게 구현했어요~?
<!-- 실제로 구현한 로직에 대해 설명해주세요.-->

### ❤️‍🔥 당신이 생각하는 PR포인트, 내겐 매력포인트.
<!-- 해당 PR에서 논의가 필요한 사항을 적어주세요. -->

### 📸 스크린샷, 없으면 이것 참,, 섭섭한데요?
