### PR TITLE
refactor: 끝말잇기 채팅 로딩 관련 로직 정리

### DIFF
--- a/src/api/endpoint/wordchain/getWordchain.ts
+++ b/src/api/endpoint/wordchain/getWordchain.ts
@@ -72,7 +72,7 @@ export const useGetFinishedWordchainList = ({
   >;
 }) =>
   useInfiniteQuery<FinishedWordchainListPage, unknown, FinishedWordchainListPage>(
-    ['getWordchain', limit],
+    [wordChainQueryKey.getWordchain, limit],
     async ({ pageParam: cursor = 0 }) => {
       const response = await getWordchain.request({ limit, cursor });
       const wordchainList =

--- a/src/components/wordchain/WordchainChatting/index.tsx
+++ b/src/components/wordchain/WordchainChatting/index.tsx
@@ -1,7 +1,7 @@
 import styled from '@emotion/styled';
 import { useQueryClient } from '@tanstack/react-query';
 import PaperAirplaneIcon from 'public/icons/icon-paper-airplane.svg';
-import { FormEvent, useEffect, useLayoutEffect, useRef, useState } from 'react';
+import { FormEvent, useEffect, useRef, useState } from 'react';
 
 import {
   useGetActiveWordchain,
@@ -9,6 +9,7 @@ import {
   wordChainQueryKey,
 } from '@/api/endpoint/wordchain/getWordchain';
 import { usePostWord } from '@/api/endpoint/wordchain/postWord';
+import Loading from '@/components/common/Loading';
 import Responsive from '@/components/common/Responsive';
 import useEventLogger from '@/components/eventLogger/hooks/useEventLogger';
 import Wordchain from '@/components/wordchain/WordchainChatting/Wordchain';
@@ -79,7 +80,7 @@ export default function WordchainChatting({ className }: WordchainChattingProps)
     isError: false,
     errorMessage: '',
   });
-  // const [isLoading, setIsLoading] = useState(true);
+  const [isLoading, setIsLoading] = useState(true);
 
   const handleSubmit = (e: FormEvent<HTMLFormElement>) => {
     e.preventDefault();
@@ -119,13 +120,13 @@ export default function WordchainChatting({ className }: WordchainChattingProps)
     }
   }, [isVisible, fetchNextPage]);
 
-  useLayoutEffect(() => {
-    setTimeout(() => {
+  useEffect(() => {
+    if (activeWordchain && finishedWordchainListPages && isLoading) {
       scrollToBottom();
-      // setIsLoading(false);
-    }, 500);
+      setIsLoading(false);
+    }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [activeWordchain]);
+  }, [activeWordchain, finishedWordchainListPages, isLoading]);
 
   return (
     <Container className={className}>
@@ -171,6 +172,9 @@ export default function WordchainChatting({ className }: WordchainChattingProps)
         </ErrorMessage>
         <Triangle isVisible={isError} />
       </Form>
+      <LoadingWrapper isVisible={isLoading}>
+        <Loading />
+      </LoadingWrapper>
     </Container>
   );
 }
@@ -316,6 +320,15 @@ const Triangle = styled.div<{ isVisible: boolean }>`
   border-left: 8px solid transparent;
   width: 0;
   height: 0;
+`;
+
+const LoadingWrapper = styled(ContainerBase)<{ isVisible: boolean }>`
+  display: ${({ isVisible }) => (isVisible ? 'flex' : 'none')};
+  position: absolute;
+  top: 0;
+  left: 0;
+  align-items: center;
+  justify-content: center;
 `;
 
 const WaringIconSvg = (

--- a/src/components/wordchain/WordchainChatting/index.tsx
+++ b/src/components/wordchain/WordchainChatting/index.tsx
@@ -1,7 +1,7 @@
 import styled from '@emotion/styled';
 import { useQueryClient } from '@tanstack/react-query';
 import PaperAirplaneIcon from 'public/icons/icon-paper-airplane.svg';
-import { FormEvent, useEffect, useRef, useState } from 'react';
+import { FormEvent, useEffect, useLayoutEffect, useRef, useState } from 'react';
 
 import {
   useGetActiveWordchain,
@@ -9,7 +9,6 @@ import {
   wordChainQueryKey,
 } from '@/api/endpoint/wordchain/getWordchain';
 import { usePostWord } from '@/api/endpoint/wordchain/postWord';
-import Loading from '@/components/common/Loading';
 import Responsive from '@/components/common/Responsive';
 import useEventLogger from '@/components/eventLogger/hooks/useEventLogger';
 import Wordchain from '@/components/wordchain/WordchainChatting/Wordchain';
@@ -80,7 +79,7 @@ export default function WordchainChatting({ className }: WordchainChattingProps)
     isError: false,
     errorMessage: '',
   });
-  const [isLoading, setIsLoading] = useState(true);
+  // const [isLoading, setIsLoading] = useState(true);
 
   const handleSubmit = (e: FormEvent<HTMLFormElement>) => {
     e.preventDefault();
@@ -120,10 +119,10 @@ export default function WordchainChatting({ className }: WordchainChattingProps)
     }
   }, [isVisible, fetchNextPage]);
 
-  useEffect(() => {
+  useLayoutEffect(() => {
     setTimeout(() => {
       scrollToBottom();
-      setIsLoading(false);
+      // setIsLoading(false);
     }, 500);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [activeWordchain]);
@@ -172,9 +171,6 @@ export default function WordchainChatting({ className }: WordchainChattingProps)
         </ErrorMessage>
         <Triangle isVisible={isError} />
       </Form>
-      <LoadingWrapper isVisible={isLoading}>
-        <Loading />
-      </LoadingWrapper>
     </Container>
   );
 }
@@ -320,15 +316,6 @@ const Triangle = styled.div<{ isVisible: boolean }>`
   border-left: 8px solid transparent;
   width: 0;
   height: 0;
-`;
-
-const LoadingWrapper = styled(ContainerBase)<{ isVisible: boolean }>`
-  display: ${({ isVisible }) => (isVisible ? 'flex' : 'none')};
-  position: absolute;
-  top: 0;
-  left: 0;
-  align-items: center;
-  justify-content: center;
 `;
 
 const WaringIconSvg = (


### PR DESCRIPTION
### 🤫 쉿, 나한테만 말해줘요. 이슈넘버
- close #

### 🧐 어떤 것을 변경했어요~?
<!-- 실제로 변경한 사항을 설명해주세요.-->

`useLayoutEffect`를 통해 끝말잇기 채팅창의 로딩 뷰를 없앴습니다

사실 저번에 @Tekiter 가 문제 있는 방식이라고 했어서 안 했던 방식인데
당시에 바빠서 어떤 문제인지 이해를 못하고 넘어갔었어요
요번에 직접 확인해보고 싶어서 개발 서버에 배포해서 보려고 올립니다! (ssg 환경이 영향 있을지 보려고)

확인 완료될 때까지 draft 걸어놓겠습니당

=>
로딩 뷰 없애는 건 다시 생각해보니 SSR을 하지 않는 이상 헛된 꿈이었네요!
건드린 김에 당시에 급하게 구현하느라 (당장 동작은 잘 되지만) 꼬여있던 로직 정리만 했습니다

또한 정리해보니 `useLayoutEffect`는 필요가 없어서 사용하지 않았습니다 

(테스트 중)

### 🤔 그렇다면, 어떻게 구현했어요~?
<!-- 실제로 구현한 로직에 대해 설명해주세요.-->

### ❤️‍🔥 당신이 생각하는 PR포인트, 내겐 매력포인트.
<!-- 해당 PR에서 논의가 필요한 사항을 적어주세요. -->

### 📸 스크린샷, 없으면 이것 참,, 섭섭한데요?
