### PR TITLE
Revert "feat: 온보딩 배너 삭제"

### DIFF
--- a/components/members/upload/FormSection/Basic/index.tsx
+++ b/components/members/upload/FormSection/Basic/index.tsx
@@ -70,7 +70,7 @@ export default function MemberBasicFormSection() {
             />
           </StyledBirthdayInputWrapper>
         </FormItem>
-        <FormItem title='연락처' errorMessage={errors.phone?.message}>
+        <FormItem title='연락처' errorMessage={errors.phone?.message} essential>
           <StyledInput {...register('phone')} placeholder='010-XXXX-XXXX' />
         </FormItem>
         <FormItem title='이메일' essential errorMessage={errors.email?.message}>

--- a/components/members/upload/schema.ts
+++ b/components/members/upload/schema.ts
@@ -35,10 +35,12 @@ export const memberFormSchema = yup.object().shape({
       ),
     })
     .nullable(),
-  phone: yup.lazy((value) =>
-    value === ''
-      ? yup.string()
-      : yup.string().nullable().matches(PHONE_REG_EXP, `'-'를 넣어 휴대폰 번호 양식에 맞게 입력해주세요.`),
+  phone: yup.lazy(() =>
+    yup
+      .string()
+      .nullable()
+      .required('연락처를 입력해주세요.')
+      .matches(PHONE_REG_EXP, `'-'를 넣어 휴대폰 번호 양식에 맞게 입력해주세요.`),
   ),
   email: yup.lazy((value) =>
     value === ''

--- a/pages/members/index.tsx
+++ b/pages/members/index.tsx
@@ -1,11 +1,13 @@
 import styled from '@emotion/styled';
 import { FC } from 'react';
 
+import { useGetMemberOfMe } from '@/api/endpoint/members/getMemberOfMe';
 import AuthRequired from '@/components/auth/AuthRequired';
 import ActiveBannerSlot from '@/components/common/Banner/ActiveBannerSlot';
 import Responsive from '@/components/common/Responsive';
 import { MemberPageContentLayout } from '@/components/members/common/MemberPageLayout';
 import MemberList from '@/components/members/main/MemberList';
+import OnBoardingBanner from '@/components/members/main/MemberList/OnBoardingBanner';
 import MentoringList from '@/components/mentoring/MentoringList';
 import WordChainEntry from '@/components/wordchain/WordchainEntry/WordChainEntry';
 import { colors } from '@/styles/colors';
@@ -13,6 +15,11 @@ import { MOBILE_MEDIA_QUERY } from '@/styles/mediaQuery';
 import { setLayout } from '@/utils/layout';
 
 const MemberPage: FC = () => {
+  const { data: memberOfMeData } = useGetMemberOfMe();
+
+  const hasProfile = !!memberOfMeData?.hasProfile;
+  const onboardingBanner = memberOfMeData && !hasProfile && <StyledOnBoardingBanner name={memberOfMeData.name ?? ''} />;
+
   return (
     <AuthRequired>
       <ActiveBannerSlot />
@@ -23,7 +30,7 @@ const MemberPage: FC = () => {
         <HDivider />
       </Responsive>
       <MentoringList />
-      <MemberList banner={<></>} />
+      <MemberList banner={onboardingBanner} />
     </AuthRequired>
   );
 };
@@ -37,6 +44,14 @@ const StyledWordChainEntry = styled(WordChainEntry)`
 
   @media ${MOBILE_MEDIA_QUERY} {
     margin-top: 16px;
+  }
+`;
+
+const StyledOnBoardingBanner = styled(OnBoardingBanner)`
+  margin-bottom: 90px;
+
+  @media ${MOBILE_MEDIA_QUERY} {
+    margin: 45px 0;
   }
 `;
 


### PR DESCRIPTION
This reverts commit a1a2287f0679caa499b1dc054f969b3dacc2a22a.

### 🤫 쉿, 나한테만 말해줘요. 이슈넘버
- close #955

### 🧐 어떤 것을 변경했어요~?
<!-- 실제로 변경한 사항을 설명해주세요.-->

회원가입 하면 바로 프로필 등록이 되도록 변경했기 때문에 프로필을 등록하라는 내용의 온보딩 배너를 삭제했었어요 (https://github.com/sopt-makers/sopt-playground-frontend/pull/921)

그러나 당분간은 모든 회원이 프로필이 있을 거라는 보장이 없기 때문에 다시 추가했어요
참고로 해당 이슈가 해결되더라도 어차피 프로필이 없는 유저에만 보여지기 때문에 바로 삭제 조치 하지 않아도 돼요


### 🤔 그렇다면, 어떻게 구현했어요~?
<!-- 실제로 구현한 로직에 대해 설명해주세요.-->

### ❤️‍🔥 당신이 생각하는 PR포인트, 내겐 매력포인트.
<!-- 해당 PR에서 논의가 필요한 사항을 적어주세요. -->

### 📸 스크린샷, 없으면 이것 참,, 섭섭한데요?
