### PR TITLE
fix: 프로필 업로드 스키마 > 공홈 공개 여부 nullable로 수정

### DIFF
--- a/src/components/members/upload/schema.ts
+++ b/src/components/members/upload/schema.ts
@@ -73,7 +73,7 @@ export const memberFormSchema = yup.object().shape({
       }),
     )
     .nullable(),
-  allowOfficial: yup.boolean(),
+  allowOfficial: yup.boolean().nullable(),
   careers: yup
     .array()
     .of(


### PR DESCRIPTION
### 🤫 쉿, 나한테만 말해줘요. 이슈넘버
- close #959 

### 🧐 어떤 것을 변경했어요~?
<!-- 실제로 변경한 사항을 설명해주세요.-->

공홈 공개 여부(`allowOfficial`)를 nullable로 변경했습니다
서버에서는 null이 오는데 스키마는 nullable이 아니어서 수정하기가 안되는 버그가 있었습니다

boolean인데도 null이 올 줄 몰랐어용
\+ 아직 api 타입과 컴포넌트 타입의 레이어 분리를 하지 않은 이슈
\+ 서버 api 명세에 nullable이 명시 되지 않은 이슈

### 🤔 그렇다면, 어떻게 구현했어요~?
<!-- 실제로 구현한 로직에 대해 설명해주세요.-->

### ❤️‍🔥 당신이 생각하는 PR포인트, 내겐 매력포인트.
<!-- 해당 PR에서 논의가 필요한 사항을 적어주세요. -->

### 📸 스크린샷, 없으면 이것 참,, 섭섭한데요?
