### PR TITLE
feat: 역대 우승자 한 칸 만들기

### DIFF
--- a/src/components/wordchain/WordchainWinners/WordChainWinner.stories.tsx
+++ b/src/components/wordchain/WordchainWinners/WordChainWinner.stories.tsx
@@ -1,0 +1,17 @@
+import { Meta } from '@storybook/react';
+
+import WordChainWinner from '@/components/wordchain/WordchainWinners/WordChainWinner';
+
+export default {
+  component: WordChainWinner,
+} as Meta<typeof WordChainWinner>;
+
+export const Default = {
+  args:  {
+    "roomId": 25,
+    "id": 1,
+    "profileImage": "https://item.kakaocdn.net/do/cefb8ed496e0541d2a99293a1fa06233616b58f7bf017e58d417ccb3283deeb3",
+    "name": "서지수"
+  },
+  name: '기본',
+};

--- a/src/components/wordchain/WordchainWinners/WordChainWinner.stories.tsx
+++ b/src/components/wordchain/WordchainWinners/WordChainWinner.stories.tsx
@@ -7,11 +7,11 @@ export default {
 } as Meta<typeof WordChainWinner>;
 
 export const Default = {
-  args:  {
-    "roomId": 25,
-    "id": 1,
-    "profileImage": "https://item.kakaocdn.net/do/22b3b5f6c65114f383f5986c98828993616b58f7bf017e58d417ccb3283deeb3",
-    "name": "서지수"
+  args: {
+    roomId: 25,
+    id: 1,
+    profileImage: 'https://item.kakaocdn.net/do/22b3b5f6c65114f383f5986c98828993616b58f7bf017e58d417ccb3283deeb3',
+    name: '서지수',
   },
   name: '기본',
 };

--- a/src/components/wordchain/WordchainWinners/WordChainWinner.stories.tsx
+++ b/src/components/wordchain/WordchainWinners/WordChainWinner.stories.tsx
@@ -10,7 +10,7 @@ export const Default = {
   args:  {
     "roomId": 25,
     "id": 1,
-    "profileImage": "https://item.kakaocdn.net/do/cefb8ed496e0541d2a99293a1fa06233616b58f7bf017e58d417ccb3283deeb3",
+    "profileImage": "https://item.kakaocdn.net/do/22b3b5f6c65114f383f5986c98828993616b58f7bf017e58d417ccb3283deeb3",
     "name": "서지수"
   },
   name: '기본',

--- a/src/components/wordchain/WordchainWinners/WordChainWinner.tsx
+++ b/src/components/wordchain/WordchainWinners/WordChainWinner.tsx
@@ -1,45 +1,50 @@
+import { css } from '@emotion/react';
 import styled from '@emotion/styled';
 
 import { colors } from '@/styles/colors';
 import { MOBILE_MEDIA_QUERY } from '@/styles/mediaQuery';
 import { textStyles } from '@/styles/typography';
 
-export default function WordChainWinner() {
-  const WORDCHAIN_WINNER_DATA = {
-    winners: [
-      {
-        roomId: 25,
-        winner: {
-          id: 1,
-          profileImage: 'https://item.kakaocdn.net/do/22b3b5f6c65114f383f5986c98828993616b58f7bf017e58d417ccb3283deeb3',
-          name: '서지수',
-        },
-      },
-    ],
-    hasNext: true,
-  };
+interface WordChainWinnerProps {
+  roomId: number;
+  profileImage: string;
+  name: string;
+  isRecent: boolean;
+}
 
-  const rommId = WORDCHAIN_WINNER_DATA.winners[0]?.roomId;
-  const profileImage = WORDCHAIN_WINNER_DATA.winners[0]?.winner?.profileImage;
-  const name = WORDCHAIN_WINNER_DATA.winners[0]?.winner?.name;
-
+export default function WordChainWinner({ roomId, profileImage, name, isRecent }: WordChainWinnerProps) {
   return (
-    <WordChainWinnerContainer>
-      <WinRound>{rommId}번째</WinRound>
+    <WordChainWinnerContainer isRecent={isRecent}>
+      <WinRound>
+        {roomId}번째 <WinnerTag> 우승자 | </WinnerTag>
+      </WinRound>
       <WinnerImageBox>
-        <WinnerImage src={profileImage} alt='우승자 이미지' />
+        {profileImage ? (
+          <WinnerImage src={profileImage} alt='우승자 이미지' />
+        ) : (
+          <DefaultImage src='/icons/icon-member-default.svg' alt='default_member_image' />
+        )}
       </WinnerImageBox>
       <WinnerName>{name}</WinnerName>
     </WordChainWinnerContainer>
   );
 }
 
-const WordChainWinnerContainer = styled.article`
+const WordChainWinnerContainer = styled.article<{ isRecent: boolean }>`
   display: grid;
   grid: [row1-start] 'winRound winnerImageBox winnerName' min-content [row1-end]/ auto;
-  margin-top: 12px;
   border-radius: 10px;
-  background-color: ${colors.black60};
+  ${({ isRecent }) =>
+    isRecent
+      ? css`
+          margin-top: 16px;
+          background-color: ${colors.purple100};
+        `
+      : css`
+          margin-top: 12px;
+          background-color: ${colors.black60};
+        `}
+
   padding: 14px 20px;
   width: 268px;
 
@@ -48,6 +53,7 @@ const WordChainWinnerContainer = styled.article`
     grid:
       [row1-start] 'winnerImageBox winRound' auto [row1-end]
       [row2-start] 'winnerImageBox winnerName' auto [row2-end]/ auto;
+    margin-top: 12px;
     margin-right: 16px;
     background-color: transparent;
     padding: 0;
@@ -57,14 +63,11 @@ const WordChainWinnerContainer = styled.article`
 `;
 
 const WinRound = styled.p`
+  display: flex;
   grid-area: winRound;
-  width: 105px;
+  width: 110px;
   color: ${colors.white};
   ${textStyles.SUIT_16_SB}
-
-  &::after {
-    content: ' 우승자  | ';
-  }
 
   @media ${MOBILE_MEDIA_QUERY} {
     margin-top: 2px;
@@ -79,6 +82,15 @@ const WinRound = styled.p`
   }
 `;
 
+const WinnerTag = styled.p`
+  display: block;
+  margin: 0 5px;
+
+  @media ${MOBILE_MEDIA_QUERY} {
+    display: none;
+  }
+`;
+
 const WinnerImageBox = styled.div`
   display: flex;
   grid-area: winnerImageBox;
@@ -86,6 +98,7 @@ const WinnerImageBox = styled.div`
   justify-content: center;
   margin-right: 6px;
   border-radius: 50%;
+  background-color: ${colors.black40};
   width: 20px;
   height: 20px;
   overflow: hidden;
@@ -98,10 +111,15 @@ const WinnerImageBox = styled.div`
 `;
 
 const WinnerImage = styled.img`
-  transform: translate(50, 50);
   margin: auto;
   width: 100%;
   height: 100%;
+  object-fit: cover;
+`;
+
+const DefaultImage = styled.img`
+  margin: auto;
+  width: 40%;
   object-fit: cover;
 `;
 

--- a/src/components/wordchain/WordchainWinners/WordChainWinner.tsx
+++ b/src/components/wordchain/WordchainWinners/WordChainWinner.tsx
@@ -1,3 +1,8 @@
+import styled from "@emotion/styled"
+
+import { colors } from "@/styles/colors"
+import { MOBILE_MEDIA_QUERY } from "@/styles/mediaQuery"
+import { textStyles } from "@/styles/typography"
 
 export default function WordChainWinner() {
    const WORDCHAIN_WINNER_DATA={
@@ -6,7 +11,7 @@ export default function WordChainWinner() {
         "roomId": 25,
         "winner": {
           "id": 1,
-          "profileImage": "https://item.kakaocdn.net/do/cefb8ed496e0541d2a99293a1fa06233616b58f7bf017e58d417ccb3283deeb3",
+          "profileImage": "https://item.kakaocdn.net/do/22b3b5f6c65114f383f5986c98828993616b58f7bf017e58d417ccb3283deeb3",
           "name": "서지수"
         }
       }
@@ -19,10 +24,96 @@ export default function WordChainWinner() {
   const name=WORDCHAIN_WINNER_DATA.winners[0]?.winner?.name
 
   return (
-    <>
-    <p>{rommId}</p>
-    <img src={profileImage} alt="우승자 이미지"/>
-    <p>{name}</p>
-    </>
+    <WordChainWinnerContainer>
+        <WinRound>{rommId}번째</WinRound>
+        <WinnerImageBox>
+            <WinnerImage src={profileImage} alt="우승자 이미지"/>
+        </WinnerImageBox>
+        <WinnerName>{name}</WinnerName>
+    </WordChainWinnerContainer>
   )
 }
+
+const WordChainWinnerContainer=styled.article`
+    display: grid;
+    grid:    
+        [row1-start] 'winRound winnerImageBox winnerName' min-content [row1-end]/ auto;
+    margin-top:12px;
+    border-radius: 10px;
+    background-color: ${colors.black60};
+    padding: 14px 20px;
+    width: 268px;
+
+    @media ${MOBILE_MEDIA_QUERY} {
+        display: grid;
+        grid:
+            [row1-start] 'winnerImageBox winRound' auto [row1-end]
+            [row2-start] 'winnerImageBox winnerName' auto [row2-end]/ auto;
+        margin-right:16px;
+        background-color: transparent;
+        padding: 0;
+        width: 76px;
+        height: 32px;
+    }
+`
+
+const WinRound=styled.p`
+    grid-area:winRound;
+    width: 105px;
+    color: ${colors.white};
+    ${textStyles.SUIT_16_SB}    
+
+    &::after {
+        content: " 우승자  | ";
+    }
+  
+  @media ${MOBILE_MEDIA_QUERY} {
+    margin-top: 2px;
+    width: 35px;
+    height: 12px;
+    color: ${colors.gray60};
+    ${textStyles.SUIT_10_M}    
+
+    &::after {
+        content: "";
+    }
+  }
+`
+
+const WinnerImageBox=styled.div`
+    display: flex;
+    grid-area:winnerImageBox;
+    align-items: center;
+    justify-content: center;
+    margin-right: 6px;
+    border-radius: 50%;
+    width:20px;
+    height:20px;
+    overflow: hidden;
+
+    @media ${MOBILE_MEDIA_QUERY} {
+        margin-right: 12px;
+        width:32px;
+        height:32px;
+    }
+`
+
+const WinnerImage=styled.img`
+    transform: translate(50, 50);
+    margin: auto;
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+`
+
+const WinnerName=styled.p`
+    grid-area:winnerName;
+    width: 110px;
+    color: ${colors.white};
+    ${textStyles.SUIT_16_SB}   
+
+    @media ${MOBILE_MEDIA_QUERY} {
+        width: 35px;
+        ${textStyles.SUIT_12_M}  
+    }
+`

--- a/src/components/wordchain/WordchainWinners/WordChainWinner.tsx
+++ b/src/components/wordchain/WordchainWinners/WordChainWinner.tsx
@@ -1,119 +1,118 @@
-import styled from "@emotion/styled"
+import styled from '@emotion/styled';
 
-import { colors } from "@/styles/colors"
-import { MOBILE_MEDIA_QUERY } from "@/styles/mediaQuery"
-import { textStyles } from "@/styles/typography"
+import { colors } from '@/styles/colors';
+import { MOBILE_MEDIA_QUERY } from '@/styles/mediaQuery';
+import { textStyles } from '@/styles/typography';
 
 export default function WordChainWinner() {
-   const WORDCHAIN_WINNER_DATA={
-    "winners": [
+  const WORDCHAIN_WINNER_DATA = {
+    winners: [
       {
-        "roomId": 25,
-        "winner": {
-          "id": 1,
-          "profileImage": "https://item.kakaocdn.net/do/22b3b5f6c65114f383f5986c98828993616b58f7bf017e58d417ccb3283deeb3",
-          "name": "서지수"
-        }
-      }
+        roomId: 25,
+        winner: {
+          id: 1,
+          profileImage: 'https://item.kakaocdn.net/do/22b3b5f6c65114f383f5986c98828993616b58f7bf017e58d417ccb3283deeb3',
+          name: '서지수',
+        },
+      },
     ],
-    "hasNext": true
-  }
+    hasNext: true,
+  };
 
-  const rommId=WORDCHAIN_WINNER_DATA.winners[0]?.roomId
-  const profileImage=WORDCHAIN_WINNER_DATA.winners[0]?.winner?.profileImage
-  const name=WORDCHAIN_WINNER_DATA.winners[0]?.winner?.name
+  const rommId = WORDCHAIN_WINNER_DATA.winners[0]?.roomId;
+  const profileImage = WORDCHAIN_WINNER_DATA.winners[0]?.winner?.profileImage;
+  const name = WORDCHAIN_WINNER_DATA.winners[0]?.winner?.name;
 
   return (
     <WordChainWinnerContainer>
-        <WinRound>{rommId}번째</WinRound>
-        <WinnerImageBox>
-            <WinnerImage src={profileImage} alt="우승자 이미지"/>
-        </WinnerImageBox>
-        <WinnerName>{name}</WinnerName>
+      <WinRound>{rommId}번째</WinRound>
+      <WinnerImageBox>
+        <WinnerImage src={profileImage} alt='우승자 이미지' />
+      </WinnerImageBox>
+      <WinnerName>{name}</WinnerName>
     </WordChainWinnerContainer>
-  )
+  );
 }
 
-const WordChainWinnerContainer=styled.article`
+const WordChainWinnerContainer = styled.article`
+  display: grid;
+  grid: [row1-start] 'winRound winnerImageBox winnerName' min-content [row1-end]/ auto;
+  margin-top: 12px;
+  border-radius: 10px;
+  background-color: ${colors.black60};
+  padding: 14px 20px;
+  width: 268px;
+
+  @media ${MOBILE_MEDIA_QUERY} {
     display: grid;
-    grid:    
-        [row1-start] 'winRound winnerImageBox winnerName' min-content [row1-end]/ auto;
-    margin-top:12px;
-    border-radius: 10px;
-    background-color: ${colors.black60};
-    padding: 14px 20px;
-    width: 268px;
+    grid:
+      [row1-start] 'winnerImageBox winRound' auto [row1-end]
+      [row2-start] 'winnerImageBox winnerName' auto [row2-end]/ auto;
+    margin-right: 16px;
+    background-color: transparent;
+    padding: 0;
+    width: 76px;
+    height: 32px;
+  }
+`;
 
-    @media ${MOBILE_MEDIA_QUERY} {
-        display: grid;
-        grid:
-            [row1-start] 'winnerImageBox winRound' auto [row1-end]
-            [row2-start] 'winnerImageBox winnerName' auto [row2-end]/ auto;
-        margin-right:16px;
-        background-color: transparent;
-        padding: 0;
-        width: 76px;
-        height: 32px;
-    }
-`
+const WinRound = styled.p`
+  grid-area: winRound;
+  width: 105px;
+  color: ${colors.white};
+  ${textStyles.SUIT_16_SB}
 
-const WinRound=styled.p`
-    grid-area:winRound;
-    width: 105px;
-    color: ${colors.white};
-    ${textStyles.SUIT_16_SB}    
+  &::after {
+    content: ' 우승자  | ';
+  }
 
-    &::after {
-        content: " 우승자  | ";
-    }
-  
   @media ${MOBILE_MEDIA_QUERY} {
     margin-top: 2px;
     width: 35px;
     height: 12px;
     color: ${colors.gray60};
-    ${textStyles.SUIT_10_M}    
+    ${textStyles.SUIT_10_M}
 
     &::after {
-        content: "";
+      content: '';
     }
   }
-`
+`;
 
-const WinnerImageBox=styled.div`
-    display: flex;
-    grid-area:winnerImageBox;
-    align-items: center;
-    justify-content: center;
-    margin-right: 6px;
-    border-radius: 50%;
-    width:20px;
-    height:20px;
-    overflow: hidden;
+const WinnerImageBox = styled.div`
+  display: flex;
+  grid-area: winnerImageBox;
+  align-items: center;
+  justify-content: center;
+  margin-right: 6px;
+  border-radius: 50%;
+  width: 20px;
+  height: 20px;
+  overflow: hidden;
 
-    @media ${MOBILE_MEDIA_QUERY} {
-        margin-right: 12px;
-        width:32px;
-        height:32px;
-    }
-`
+  @media ${MOBILE_MEDIA_QUERY} {
+    margin-right: 12px;
+    width: 32px;
+    height: 32px;
+  }
+`;
 
-const WinnerImage=styled.img`
-    transform: translate(50, 50);
-    margin: auto;
-    width: 100%;
-    height: 100%;
-    object-fit: cover;
-`
+const WinnerImage = styled.img`
+  transform: translate(50, 50);
+  margin: auto;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+`;
 
-const WinnerName=styled.p`
-    grid-area:winnerName;
-    width: 110px;
-    color: ${colors.white};
-    ${textStyles.SUIT_16_SB}   
+const WinnerName = styled.p`
+  grid-area: winnerName;
+  width: 110px;
+  color: ${colors.white};
+  ${textStyles.SUIT_16_SB}
 
-    @media ${MOBILE_MEDIA_QUERY} {
-        width: 35px;
-        ${textStyles.SUIT_12_M}  
-    }
-`
+  @media ${MOBILE_MEDIA_QUERY} {
+    width: 35px;
+    ${textStyles.SUIT_12_M}
+  }
+`;

--- a/src/components/wordchain/WordchainWinners/WordChainWinner.tsx
+++ b/src/components/wordchain/WordchainWinners/WordChainWinner.tsx
@@ -1,0 +1,20 @@
+
+export default function WordChainWinner() {
+   const WORDCHAIN_WINNER_DATA={
+    "winners": [
+      {
+        "roomId": 25,
+        "winner": {
+          "id": 1,
+          "profileImage": "https://item.kakaocdn.net/do/cefb8ed496e0541d2a99293a1fa06233616b58f7bf017e58d417ccb3283deeb3",
+          "name": "서지수"
+        }
+      }
+    ],
+    "hasNext": true
+  }
+
+  return (
+    <></>
+  )
+}

--- a/src/components/wordchain/WordchainWinners/WordChainWinner.tsx
+++ b/src/components/wordchain/WordchainWinners/WordChainWinner.tsx
@@ -14,7 +14,15 @@ export default function WordChainWinner() {
     "hasNext": true
   }
 
+  const rommId=WORDCHAIN_WINNER_DATA.winners[0]?.roomId
+  const profileImage=WORDCHAIN_WINNER_DATA.winners[0]?.winner?.profileImage
+  const name=WORDCHAIN_WINNER_DATA.winners[0]?.winner?.name
+
   return (
-    <></>
+    <>
+    <p>{rommId}</p>
+    <img src={profileImage} alt="우승자 이미지"/>
+    <p>{name}</p>
+    </>
   )
 }


### PR DESCRIPTION
### 🤫 쉿, 나한테만 말해줘요. 이슈넘버
- close #952 

### 🧐 어떤 것을 변경했어요~?
<!-- 실제로 변경한 사항을 설명해주세요.-->
- 역대 우승자 한 칸을 만들었어요
- 스토리북도 만들었습니다
- 반응형을 포함한 스타일링을 구현했어요

### 🤔 그렇다면, 어떻게 구현했어요~?
<!-- 실제로 구현한 로직에 대해 설명해주세요.-->
- 우선은 api를 연결하지 않고, 상수 데이터를 넣어서 구현해보았어요(api 연결 로직을 짠 뒤 해당 코드는 삭제할 예정이에요!)
- grid를 이용해서 데스크탑과 모바일에서 디자인이 다르게 보일 수 있도록 구현했어요

### ❤️‍🔥 당신이 생각하는 PR포인트, 내겐 매력포인트.
<!-- 해당 PR에서 논의가 필요한 사항을 적어주세요. -->
- MentoringCard의 코드를 뜯어보면서 스토리북과 반응형을 구현했답니다!
- grid를 구현할 때, grid-area로 네이밍을 해주어야한다는 사실을 처음에 몰라서 엄청 헤매다가 시간을 많이 날렸어요! [이 자료](https://velog.io/@forest0501/CSS-Grid-Grid-Template-Areas%EC%99%80-Grid-Row-Grid-Column)를 참고해서 깨달음을 얻었고... 그 뒤에 MentoringCard를 다시 보니 네이밍이 모두 적용되어있다는 사실을 알게 되었답니다... 왕 뿌듯하면서 왕 허무했어요ㅎㅎ

### 📸 스크린샷, 없으면 이것 참,, 섭섭한데요?
데스크탑 뷰
<img width="305" alt="스크린샷 2023-09-12 오전 12 40 20" src="https://github.com/sopt-makers/sopt-playground-frontend/assets/76681519/7aa2d323-c06b-4906-bf4f-bb0eecb25e6d">

모바일 뷰
<img width="161" alt="스크린샷 2023-09-12 오전 12 40 41" src="https://github.com/sopt-makers/sopt-playground-frontend/assets/76681519/e3066ac1-3f6e-46b6-9446-38bf7e8c1f75">

### 🤔 기타
프리티어가 적용되지 않는 이슈 발생... 아무래도 제 vscode는 .prettierrc를 탐색하고 있는데, 실제로는 .prettierrc.json 이 있어서 파일명이 달라 생긴 이슈가 아닐까 싶어요.. 얼른 해결해보겠나이다!
