### PR TITLE
feat: 역대 우승자 map 돌리기

### DIFF
--- a/src/components/wordchain/WordchainWinners/WordChainWinner.tsx
+++ b/src/components/wordchain/WordchainWinners/WordChainWinner.tsx
@@ -4,28 +4,16 @@ import { colors } from '@/styles/colors';
 import { MOBILE_MEDIA_QUERY } from '@/styles/mediaQuery';
 import { textStyles } from '@/styles/typography';
 
-export default function WordChainWinner() {
-  const WORDCHAIN_WINNER_DATA = {
-    winners: [
-      {
-        roomId: 25,
-        winner: {
-          id: 1,
-          profileImage: 'https://item.kakaocdn.net/do/22b3b5f6c65114f383f5986c98828993616b58f7bf017e58d417ccb3283deeb3',
-          name: '서지수',
-        },
-      },
-    ],
-    hasNext: true,
-  };
+interface WordChainWinnerProps {
+  roomId: number;
+  profileImage: string;
+  name: string;
+}
 
-  const rommId = WORDCHAIN_WINNER_DATA.winners[0]?.roomId;
-  const profileImage = WORDCHAIN_WINNER_DATA.winners[0]?.winner?.profileImage;
-  const name = WORDCHAIN_WINNER_DATA.winners[0]?.winner?.name;
-
+export default function WordChainWinner({ roomId, profileImage, name }: WordChainWinnerProps) {
   return (
     <WordChainWinnerContainer>
-      <WinRound>{rommId}번째</WinRound>
+      <WinRound>{roomId}번째</WinRound>
       <WinnerImageBox>
         <WinnerImage src={profileImage} alt='우승자 이미지' />
       </WinnerImageBox>

--- a/src/components/wordchain/WordchainWinners/index.stories.tsx
+++ b/src/components/wordchain/WordchainWinners/index.stories.tsx
@@ -1,0 +1,56 @@
+import { Meta } from '@storybook/react';
+
+import WordchainWinners from '@/components/wordchain/WordchainWinners';
+
+export default {
+  component: WordchainWinners,
+} as Meta<typeof WordchainWinners>;
+
+export const Default = {
+  args: {
+    winners: [
+      {
+        roomId: 25,
+        winner: {
+          id: 1,
+          profileImage: 'https://item.kakaocdn.net/do/22b3b5f6c65114f383f5986c98828993616b58f7bf017e58d417ccb3283deeb3',
+          name: '남주영',
+        },
+      },
+      {
+        roomId: 24,
+        winner: {
+          id: 2,
+          profileImage: 'https://item.kakaocdn.net/do/22b3b5f6c65114f383f5986c98828993616b58f7bf017e58d417ccb3283deeb3',
+          name: '박건영',
+        },
+      },
+      {
+        roomId: 23,
+        winner: {
+          id: 3,
+          profileImage: 'https://item.kakaocdn.net/do/22b3b5f6c65114f383f5986c98828993616b58f7bf017e58d417ccb3283deeb3',
+          name: '서지수',
+        },
+      },
+      {
+        roomId: 22,
+        winner: {
+          id: 4,
+          profileImage: 'https://item.kakaocdn.net/do/22b3b5f6c65114f383f5986c98828993616b58f7bf017e58d417ccb3283deeb3',
+          name: '이준호',
+        },
+      },
+      {
+        roomId: 21,
+        winner: {
+          id: 5,
+          profileImage: 'https://item.kakaocdn.net/do/22b3b5f6c65114f383f5986c98828993616b58f7bf017e58d417ccb3283deeb3',
+          name: '솝트짱',
+        },
+      },
+    ],
+    hasNext: true,
+  },
+  name: '기본',
+};

--- a/src/components/wordchain/WordchainWinners/index.tsx
+++ b/src/components/wordchain/WordchainWinners/index.tsx
@@ -86,13 +86,11 @@ const WinnerBoard = styled.aside`
 `;
 
 const WinnerHeader = styled.h1`
-  /* margin-bottom: 16px; */
   color: ${colors.white};
 
   ${textStyles.SUIT_20_B}
 
   @media ${MOBILE_MEDIA_QUERY} {
-    /* margin-bottom: 12px; */
     ${textStyles.SUIT_14_SB}
   }
 `;

--- a/src/components/wordchain/WordchainWinners/index.tsx
+++ b/src/components/wordchain/WordchainWinners/index.tsx
@@ -1,0 +1,111 @@
+import styled from '@emotion/styled';
+
+import WordChainWinner from '@/components/wordchain/WordchainWinners/WordChainWinner';
+import { colors } from '@/styles/colors';
+import { MOBILE_MEDIA_QUERY } from '@/styles/mediaQuery';
+import { textStyles } from '@/styles/typography';
+
+export default function WordchainWinners() {
+  const WORDCHAIN_WINNERS_DATA = {
+    winners: [
+      {
+        roomId: 25,
+        winner: {
+          id: 1,
+          profileImage: 'https://item.kakaocdn.net/do/22b3b5f6c65114f383f5986c98828993616b58f7bf017e58d417ccb3283deeb3',
+          name: '남주영',
+        },
+      },
+      {
+        roomId: 24,
+        winner: {
+          id: 2,
+          profileImage: 'https://item.kakaocdn.net/do/22b3b5f6c65114f383f5986c98828993616b58f7bf017e58d417ccb3283deeb3',
+          name: '박건영',
+        },
+      },
+      {
+        roomId: 23,
+        winner: {
+          id: 3,
+          profileImage: 'https://item.kakaocdn.net/do/22b3b5f6c65114f383f5986c98828993616b58f7bf017e58d417ccb3283deeb3',
+          name: '서지수',
+        },
+      },
+      {
+        roomId: 22,
+        winner: {
+          id: 4,
+          profileImage: 'https://item.kakaocdn.net/do/22b3b5f6c65114f383f5986c98828993616b58f7bf017e58d417ccb3283deeb3',
+          name: '이준호',
+        },
+      },
+      {
+        roomId: 21,
+        winner: {
+          id: 5,
+          profileImage: 'https://item.kakaocdn.net/do/22b3b5f6c65114f383f5986c98828993616b58f7bf017e58d417ccb3283deeb3',
+          name: '솝트짱',
+        },
+      },
+    ],
+    hasNext: true,
+  };
+
+  return (
+    <WinnerBoard>
+      <WinnerHeader>👑 역대 우승자 명예의 전당 👑</WinnerHeader>
+      <WinnerList>
+        {WORDCHAIN_WINNERS_DATA.winners?.map(({ roomId, winner }) => {
+          const { id, profileImage, name } = winner;
+          return <WordChainWinner key={id} roomId={roomId} profileImage={profileImage} name={name} />;
+        })}
+      </WinnerList>
+    </WinnerBoard>
+  );
+}
+
+const WinnerBoard = styled.aside`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  border-radius: 20px;
+  background-color: ${colors.black80};
+  padding: 28px;
+  width: 324px;
+  height: 382px;
+
+  @media ${MOBILE_MEDIA_QUERY} {
+    align-items: flex-start;
+    margin-left: 20px;
+    background-color: transparent;
+    padding: 0;
+    width: 352px;
+    height: 63px;
+  }
+`;
+
+const WinnerHeader = styled.h1`
+  /* margin-bottom: 16px; */
+  color: ${colors.white};
+
+  ${textStyles.SUIT_20_B}
+
+  @media ${MOBILE_MEDIA_QUERY} {
+    /* margin-bottom: 12px; */
+    ${textStyles.SUIT_14_SB}
+  }
+`;
+
+const WinnerList = styled.section`
+  display: flex;
+  flex-direction: column;
+  height: 312px;
+  overflow: scroll;
+
+  @media ${MOBILE_MEDIA_QUERY} {
+    flex-direction: row;
+    width: 352px;
+    height: 45px;
+  }
+`;


### PR DESCRIPTION
### 🤫 쉿, 나한테만 말해줘요. 이슈넘버
- close #967 

### 🧐 어떤 것을 변경했어요~?
<!-- 실제로 변경한 사항을 설명해주세요.-->
- 역대 우승자 여러명 보이도록 구현했어요

### 🤔 그렇다면, 어떻게 구현했어요~?
<!-- 실제로 구현한 로직에 대해 설명해주세요.-->
- 역대 우승자 상수 데이터를 map으로 돌렸어요

### ❤️‍🔥 당신이 생각하는 PR포인트, 내겐 매력포인트.
<!-- 해당 PR에서 논의가 필요한 사항을 적어주세요. -->
- 데스크탑 뷰에서 가장 최근 우승자 색깔이 다른 것은 api 연결 이후 마저 작업하려고 합니다!

### 📸 스크린샷, 없으면 이것 참,, 섭섭한데요?
<img width="355" alt="스크린샷 2023-09-13 오전 2 49 51" src="https://github.com/sopt-makers/sopt-playground-frontend/assets/76681519/91536d71-1d6f-4ecb-a207-fd22bce7862d">

<img width="405" alt="스크린샷 2023-09-13 오전 2 50 07" src="https://github.com/sopt-makers/sopt-playground-frontend/assets/76681519/3edd33fd-fd2b-4875-9936-49e54e28adde">

