### PR TITLE
feat: 역대 우승자 get api 연결 및 무한스크롤

### DIFF
--- a/src/api/endpoint/wordchain/getWordchainWinners.ts
+++ b/src/api/endpoint/wordchain/getWordchainWinners.ts
@@ -1,0 +1,28 @@
+import { z } from 'zod';
+
+import { createEndpoint } from '@/api/typedAxios';
+
+const userSchema = z.object({
+  id: z.number(),
+  profileImage: z
+    .string()
+    .nullable()
+    .transform((profileImage) => profileImage ?? ''),
+  name: z.string(),
+});
+
+const winnerSchema = z.object({
+  roomId: z.number(),
+  winner: userSchema,
+});
+
+export const getWordchainWinners = createEndpoint({
+  request: (options: { limit: number; cursor: number }) => ({
+    method: 'GET',
+    url: `/api/v1/chainWordGame/winners?limit=${options.limit}&cursor=${options.cursor}`,
+  }),
+  serverResponseScheme: z.object({
+    winners: z.array(winnerSchema),
+    hasNext: z.boolean(),
+  }),
+});

--- a/src/components/wordchain/WordchainWinners/WordChainWinner.tsx
+++ b/src/components/wordchain/WordchainWinners/WordChainWinner.tsx
@@ -15,7 +15,11 @@ export default function WordChainWinner({ roomId, profileImage, name }: WordChai
     <WordChainWinnerContainer>
       <WinRound>{roomId}번째</WinRound>
       <WinnerImageBox>
-        <WinnerImage src={profileImage} alt='우승자 이미지' />
+        {profileImage ? (
+          <WinnerImage src={profileImage} alt='우승자 이미지' />
+        ) : (
+          <DefaultImage src='/icons/icon-member-default.svg' alt='default_member_image' />
+        )}
       </WinnerImageBox>
       <WinnerName>{name}</WinnerName>
     </WordChainWinnerContainer>
@@ -90,6 +94,13 @@ const WinnerImage = styled.img`
   margin: auto;
   width: 100%;
   height: 100%;
+  object-fit: cover;
+`;
+
+const DefaultImage = styled.img`
+  transform: translate(50, 50);
+  margin: auto;
+  width: 40%;
   object-fit: cover;
 `;
 

--- a/src/components/wordchain/WordchainWinners/WordChainWinner.tsx
+++ b/src/components/wordchain/WordchainWinners/WordChainWinner.tsx
@@ -31,14 +31,15 @@ export default function WordChainWinner({ roomId, profileImage, name, isRecent }
 const WordChainWinnerContainer = styled.article<{ isRecent: boolean }>`
   display: grid;
   grid: [row1-start] 'winRound winnerImageBox winnerName' min-content [row1-end]/ auto;
-  margin-top: 12px;
   border-radius: 10px;
   ${({ isRecent }) =>
     isRecent
       ? css`
+          margin-top: 16px;
           background-color: ${colors.purple100};
         `
       : css`
+          margin-top: 12px;
           background-color: ${colors.black60};
         `}
 
@@ -50,6 +51,7 @@ const WordChainWinnerContainer = styled.article<{ isRecent: boolean }>`
     grid:
       [row1-start] 'winnerImageBox winRound' auto [row1-end]
       [row2-start] 'winnerImageBox winnerName' auto [row2-end]/ auto;
+    margin-top: 12px;
     margin-right: 16px;
     background-color: transparent;
     padding: 0;

--- a/src/components/wordchain/WordchainWinners/WordChainWinner.tsx
+++ b/src/components/wordchain/WordchainWinners/WordChainWinner.tsx
@@ -90,6 +90,7 @@ const WinnerImageBox = styled.div`
   justify-content: center;
   margin-right: 6px;
   border-radius: 50%;
+  background-color: ${colors.black60};
   width: 20px;
   height: 20px;
   overflow: hidden;

--- a/src/components/wordchain/WordchainWinners/WordChainWinner.tsx
+++ b/src/components/wordchain/WordchainWinners/WordChainWinner.tsx
@@ -90,7 +90,7 @@ const WinnerImageBox = styled.div`
   justify-content: center;
   margin-right: 6px;
   border-radius: 50%;
-  background-color: ${colors.black60};
+  background-color: ${colors.black40};
   width: 20px;
   height: 20px;
   overflow: hidden;

--- a/src/components/wordchain/WordchainWinners/WordChainWinner.tsx
+++ b/src/components/wordchain/WordchainWinners/WordChainWinner.tsx
@@ -1,3 +1,4 @@
+import { css } from '@emotion/react';
 import styled from '@emotion/styled';
 
 import { colors } from '@/styles/colors';
@@ -8,11 +9,12 @@ interface WordChainWinnerProps {
   roomId: number;
   profileImage: string;
   name: string;
+  isRecent: boolean;
 }
 
-export default function WordChainWinner({ roomId, profileImage, name }: WordChainWinnerProps) {
+export default function WordChainWinner({ roomId, profileImage, name, isRecent }: WordChainWinnerProps) {
   return (
-    <WordChainWinnerContainer>
+    <WordChainWinnerContainer isRecent={isRecent}>
       <WinRound>{roomId}번째</WinRound>
       <WinnerImageBox>
         {profileImage ? (
@@ -26,12 +28,20 @@ export default function WordChainWinner({ roomId, profileImage, name }: WordChai
   );
 }
 
-const WordChainWinnerContainer = styled.article`
+const WordChainWinnerContainer = styled.article<{ isRecent: boolean }>`
   display: grid;
   grid: [row1-start] 'winRound winnerImageBox winnerName' min-content [row1-end]/ auto;
   margin-top: 12px;
   border-radius: 10px;
-  background-color: ${colors.black60};
+  ${({ isRecent }) =>
+    isRecent
+      ? css`
+          background-color: ${colors.purple100};
+        `
+      : css`
+          background-color: ${colors.black60};
+        `}
+
   padding: 14px 20px;
   width: 268px;
 

--- a/src/components/wordchain/WordchainWinners/hooks/useWordchainWinnersQuery.ts
+++ b/src/components/wordchain/WordchainWinners/hooks/useWordchainWinnersQuery.ts
@@ -1,0 +1,31 @@
+import { QueryKey, useInfiniteQuery } from '@tanstack/react-query';
+
+import { getWordchainWinners } from '@/api/endpoint/wordchain/getWordchainWinners';
+
+interface UseWordchainWinnersQueryVariables {
+  limit: number;
+  queryKey?: QueryKey;
+}
+
+export const useWordchainWinnersQuery = ({ limit, queryKey }: UseWordchainWinnersQueryVariables) => {
+  const _queryKey = (typeof queryKey === 'string' ? [queryKey] : queryKey) ?? [];
+
+  return useInfiniteQuery({
+    queryKey: ['getWordchainWinners', limit, ..._queryKey],
+    queryFn: async ({ pageParam: cursor = 0 }) => {
+      const response = await getWordchainWinners.request({ limit, cursor });
+      const page = { hasNext: response.hasNext, winners: response.winners };
+      return page;
+    },
+    getNextPageParam: (lastPage, pages) => {
+      if (!lastPage.hasNext) {
+        return undefined;
+      }
+      const totalPageNum = pages.length * limit;
+      return totalPageNum;
+    },
+    onError: (error: { message: string }) => {
+      console.error(error.message);
+    },
+  });
+};

--- a/src/components/wordchain/WordchainWinners/index.tsx
+++ b/src/components/wordchain/WordchainWinners/index.tsx
@@ -12,52 +12,6 @@ import { textStyles } from '@/styles/typography';
 const PAGE_LIMIT = 5;
 
 export default function WordchainWinners() {
-  const WORDCHAIN_WINNERS_DATA = {
-    winners: [
-      {
-        roomId: 25,
-        winner: {
-          id: 1,
-          profileImage: 'https://item.kakaocdn.net/do/22b3b5f6c65114f383f5986c98828993616b58f7bf017e58d417ccb3283deeb3',
-          name: '남주영',
-        },
-      },
-      {
-        roomId: 24,
-        winner: {
-          id: 2,
-          profileImage: 'https://item.kakaocdn.net/do/22b3b5f6c65114f383f5986c98828993616b58f7bf017e58d417ccb3283deeb3',
-          name: '박건영',
-        },
-      },
-      {
-        roomId: 23,
-        winner: {
-          id: 3,
-          profileImage: 'https://item.kakaocdn.net/do/22b3b5f6c65114f383f5986c98828993616b58f7bf017e58d417ccb3283deeb3',
-          name: '서지수',
-        },
-      },
-      {
-        roomId: 22,
-        winner: {
-          id: 4,
-          profileImage: 'https://item.kakaocdn.net/do/22b3b5f6c65114f383f5986c98828993616b58f7bf017e58d417ccb3283deeb3',
-          name: '이준호',
-        },
-      },
-      {
-        roomId: 21,
-        winner: {
-          id: 5,
-          profileImage: 'https://item.kakaocdn.net/do/22b3b5f6c65114f383f5986c98828993616b58f7bf017e58d417ccb3283deeb3',
-          name: '솝트짱',
-        },
-      },
-    ],
-    hasNext: true,
-  };
-
   const { ref, isVisible } = useIntersectionObserver();
 
   const { data: wordchainWinnersData, fetchNextPage } = useWordchainWinnersQuery({

--- a/src/components/wordchain/WordchainWinners/index.tsx
+++ b/src/components/wordchain/WordchainWinners/index.tsx
@@ -39,11 +39,14 @@ export default function WordchainWinners() {
     <WinnerBoard>
       <WinnerHeader>👑 역대 우승자 명예의 전당 👑</WinnerHeader>
       <WinnerList>
-        {wordchainWinners?.map((winnerList, index) => (
-          <Fragment key={index}>
-            {winnerList?.map(({ roomId, winner }) => {
+        {wordchainWinners?.map((winnerList, totalListIndex) => (
+          <Fragment key={totalListIndex}>
+            {winnerList?.map(({ roomId, winner }, winnerIndex) => {
+              const isRecent = totalListIndex === 0 && winnerIndex === 0;
               const { id, profileImage, name } = winner;
-              return <WordChainWinner key={id} roomId={roomId} profileImage={profileImage} name={name} />;
+              return (
+                <WordChainWinner key={id} roomId={roomId} profileImage={profileImage} name={name} isRecent={isRecent} />
+              );
             })}
           </Fragment>
         ))}
@@ -70,10 +73,10 @@ const WinnerBoard = styled.aside`
 
   @media ${MOBILE_MEDIA_QUERY} {
     align-items: flex-start;
-    margin-left: 20px;
+    margin: 20px 3px 24px 20px;
     background-color: transparent;
     padding: 0;
-    width: 352px;
+    width: 100%;
     height: 63px;
   }
 `;
@@ -98,7 +101,7 @@ const WinnerList = styled.section`
 
   @media ${MOBILE_MEDIA_QUERY} {
     flex-direction: row;
-    width: 352px;
+    width: 100%;
     height: 45px;
   }
 `;

--- a/src/components/wordchain/WordchainWinners/index.tsx
+++ b/src/components/wordchain/WordchainWinners/index.tsx
@@ -1,9 +1,15 @@
 import styled from '@emotion/styled';
+// import router from 'next/router';
+import { useEffect } from 'react';
 
+import { useWordchainWinnersQuery } from '@/components/wordchain/WordchainWinners/hooks/useWordchainWinnersQuery';
 import WordChainWinner from '@/components/wordchain/WordchainWinners/WordChainWinner';
+import useIntersectionObserver from '@/hooks/useIntersectionObserver';
 import { colors } from '@/styles/colors';
 import { MOBILE_MEDIA_QUERY } from '@/styles/mediaQuery';
 import { textStyles } from '@/styles/typography';
+
+const PAGE_LIMIT = 5;
 
 export default function WordchainWinners() {
   const WORDCHAIN_WINNERS_DATA = {
@@ -52,6 +58,22 @@ export default function WordchainWinners() {
     hasNext: true,
   };
 
+  const { ref, isVisible } = useIntersectionObserver();
+
+  const { data: wordchainWinnersData, fetchNextPage } = useWordchainWinnersQuery({
+    limit: PAGE_LIMIT,
+    queryKey: ['getWordchainWinners'],
+  });
+
+  console.log('Asdfjdkfjkdfjdk');
+  console.log(wordchainWinnersData);
+
+  useEffect(() => {
+    if (isVisible) {
+      fetchNextPage();
+    }
+  }, [isVisible, fetchNextPage]);
+
   return (
     <WinnerBoard>
       <WinnerHeader>👑 역대 우승자 명예의 전당 👑</WinnerHeader>
@@ -60,10 +82,16 @@ export default function WordchainWinners() {
           const { id, profileImage, name } = winner;
           return <WordChainWinner key={id} roomId={roomId} profileImage={profileImage} name={name} />;
         })}
+        <Target ref={ref} />
       </WinnerList>
     </WinnerBoard>
   );
 }
+
+const Target = styled.div`
+  /* 임시 */
+  background-color: ${colors.white};
+`;
 
 const WinnerBoard = styled.aside`
   display: flex;

--- a/src/components/wordchain/WordchainWinners/index.tsx
+++ b/src/components/wordchain/WordchainWinners/index.tsx
@@ -65,7 +65,6 @@ export default function WordchainWinners() {
     queryKey: ['getWordchainWinners'],
   });
 
-  console.log('Asdfjdkfjkdfjdk');
   console.log(wordchainWinnersData);
 
   useEffect(() => {

--- a/src/components/wordchain/WordchainWinners/index.tsx
+++ b/src/components/wordchain/WordchainWinners/index.tsx
@@ -56,10 +56,7 @@ export default function WordchainWinners() {
   );
 }
 
-const Target = styled.div`
-  /* 임시 */
-  background-color: ${colors.white};
-`;
+const Target = styled.div``;
 
 const WinnerBoard = styled.aside`
   display: flex;
@@ -88,7 +85,6 @@ const WinnerHeader = styled.h1`
   ${textStyles.SUIT_20_B}
 
   @media ${MOBILE_MEDIA_QUERY} {
-    /* margin-bottom: 12px; */
     ${textStyles.SUIT_14_SB}
   }
 `;
@@ -96,11 +92,13 @@ const WinnerHeader = styled.h1`
 const WinnerList = styled.section`
   display: flex;
   flex-direction: column;
+  margin-bottom: -4px;
   height: 312px;
   overflow: scroll;
 
   @media ${MOBILE_MEDIA_QUERY} {
     flex-direction: row;
+    margin-bottom: 0;
     width: 100%;
     height: 45px;
   }

--- a/src/components/wordchain/WordchainWinners/index.tsx
+++ b/src/components/wordchain/WordchainWinners/index.tsx
@@ -73,7 +73,7 @@ const WinnerBoard = styled.aside`
 
   @media ${MOBILE_MEDIA_QUERY} {
     align-items: flex-start;
-    margin: 20px 3px 24px 20px;
+    margin: 20px 3px 24px 0;
     background-color: transparent;
     padding: 0;
     width: 100%;

--- a/src/components/wordchain/WordchainWinners/index.tsx
+++ b/src/components/wordchain/WordchainWinners/index.tsx
@@ -1,5 +1,4 @@
 import styled from '@emotion/styled';
-// import router from 'next/router';
 import { Fragment, useEffect, useMemo } from 'react';
 
 import { useWordchainWinnersQuery } from '@/components/wordchain/WordchainWinners/hooks/useWordchainWinnersQuery';

--- a/src/components/wordchain/WordchainWinners/index.tsx
+++ b/src/components/wordchain/WordchainWinners/index.tsx
@@ -1,6 +1,6 @@
 import styled from '@emotion/styled';
 // import router from 'next/router';
-import { useEffect } from 'react';
+import { Fragment, useEffect, useMemo } from 'react';
 
 import { useWordchainWinnersQuery } from '@/components/wordchain/WordchainWinners/hooks/useWordchainWinnersQuery';
 import WordChainWinner from '@/components/wordchain/WordchainWinners/WordChainWinner';
@@ -65,7 +65,15 @@ export default function WordchainWinners() {
     queryKey: ['getWordchainWinners'],
   });
 
-  console.log(wordchainWinnersData);
+  const wordchainWinners = useMemo(
+    () =>
+      wordchainWinnersData?.pages.map((page) =>
+        page.winners.map((winner) => ({
+          ...winner,
+        })),
+      ),
+    [wordchainWinnersData],
+  );
 
   useEffect(() => {
     if (isVisible) {
@@ -77,10 +85,14 @@ export default function WordchainWinners() {
     <WinnerBoard>
       <WinnerHeader>👑 역대 우승자 명예의 전당 👑</WinnerHeader>
       <WinnerList>
-        {WORDCHAIN_WINNERS_DATA.winners?.map(({ roomId, winner }) => {
-          const { id, profileImage, name } = winner;
-          return <WordChainWinner key={id} roomId={roomId} profileImage={profileImage} name={name} />;
-        })}
+        {wordchainWinners?.map((winnerList, index) => (
+          <Fragment key={index}>
+            {winnerList?.map(({ roomId, winner }) => {
+              const { id, profileImage, name } = winner;
+              return <WordChainWinner key={id} roomId={roomId} profileImage={profileImage} name={name} />;
+            })}
+          </Fragment>
+        ))}
         <Target ref={ref} />
       </WinnerList>
     </WinnerBoard>

--- a/src/components/wordchain/WordchainWinners/types.ts
+++ b/src/components/wordchain/WordchainWinners/types.ts
@@ -1,0 +1,12 @@
+export interface Winner {
+  roomId: number;
+  winner: {
+    id: number;
+    profileImage: string;
+    name: string;
+  };
+}
+
+export interface FinishedWordchainWinners {
+  winners: Winner[];
+}

--- a/src/pages/wordchain/index.tsx
+++ b/src/pages/wordchain/index.tsx
@@ -7,6 +7,7 @@ import useEventLogger from '@/components/eventLogger/hooks/useEventLogger';
 import { SMALL_MEDIA_QUERY } from '@/components/wordchain/mediaQuery';
 import WordchainChatting from '@/components/wordchain/WordchainChatting';
 import WordchainRules from '@/components/wordchain/WordchainRules';
+import WordchainWinners from '@/components/wordchain/WordchainWinners';
 import { useRunOnce } from '@/hooks/useRunOnce';
 import IconArrow from '@/public/icons/icon-wordchain-arrow.svg';
 import IconWordChainMessage from '@/public/icons/icon-wordchain-message.svg';
@@ -21,6 +22,8 @@ const WordchainPage = () => {
   useRunOnce(() => {
     logPageViewEvent('wordchain');
   }, [logPageViewEvent]);
+
+  console.log('안녕하세요');
 
   return (
     <AuthRequired>
@@ -43,7 +46,8 @@ const WordchainPage = () => {
                   }
                 />
               </RuleWrapper>
-              <Winners>
+              <WordchainWinners />
+              {/* <Winners>
                 <DimmedWinners>
                   <Text as='h2' typography='SUIT_20_B'>
                     아직 준비 중인 기능이에요 🛠️
@@ -52,7 +56,7 @@ const WordchainPage = () => {
                 <Text as='h2' typography='SUIT_20_B'>
                   👑 역대 우승자 명예의 전당 👑
                 </Text>
-              </Winners>
+              </Winners> */}
             </Sidebar>
           </Wrapper>
         </Responsive>
@@ -71,7 +75,8 @@ const WordchainPage = () => {
               }
             />
             <Divider />
-            <Winners>
+            <WordchainWinners />
+            {/* <Winners>
               <DimmedWinners>
                 <Text as='h2' typography='SUIT_15_B'>
                   아직 준비 중인 기능이에요 🛠️
@@ -80,7 +85,7 @@ const WordchainPage = () => {
               <Text as='h2' typography='SUIT_14_B'>
                 👑 역대 우승자 명예의 전당 👑
               </Text>
-            </Winners>
+            </Winners> */}
           </Wrapper>
           <StyledWordchainChatting />
         </MobileResponsive>

--- a/src/pages/wordchain/index.tsx
+++ b/src/pages/wordchain/index.tsx
@@ -23,8 +23,6 @@ const WordchainPage = () => {
     logPageViewEvent('wordchain');
   }, [logPageViewEvent]);
 
-  console.log('안녕하세요');
-
   return (
     <AuthRequired>
       <Container>
@@ -47,16 +45,6 @@ const WordchainPage = () => {
                 />
               </RuleWrapper>
               <WordchainWinners />
-              {/* <Winners>
-                <DimmedWinners>
-                  <Text as='h2' typography='SUIT_20_B'>
-                    아직 준비 중인 기능이에요 🛠️
-                  </Text>
-                </DimmedWinners>
-                <Text as='h2' typography='SUIT_20_B'>
-                  👑 역대 우승자 명예의 전당 👑
-                </Text>
-              </Winners> */}
             </Sidebar>
           </Wrapper>
         </Responsive>
@@ -76,16 +64,6 @@ const WordchainPage = () => {
             />
             <Divider />
             <WordchainWinners />
-            {/* <Winners>
-              <DimmedWinners>
-                <Text as='h2' typography='SUIT_15_B'>
-                  아직 준비 중인 기능이에요 🛠️
-                </Text>
-              </DimmedWinners>
-              <Text as='h2' typography='SUIT_14_B'>
-                👑 역대 우승자 명예의 전당 👑
-              </Text>
-            </Winners> */}
           </Wrapper>
           <StyledWordchainChatting />
         </MobileResponsive>


### PR DESCRIPTION
### 🤫 쉿, 나한테만 말해줘요. 이슈넘버
- close #968

### 🧐 어떤 것을 변경했어요~?
<!-- 실제로 변경한 사항을 설명해주세요.-->
- 역대 우승자 get api 연결
- 무한스크롤 구현

### 🤔 그렇다면, 어떻게 구현했어요~?
<!-- 실제로 구현한 로직에 대해 설명해주세요.-->
- 끝말잇기와 멤버프로필의 get api, 무한스크롤을 많이 참고해서 구현했어요!
- limit은 5로 두고 구현했습니다

### ❤️‍🔥 당신이 생각하는 PR포인트, 내겐 매력포인트.
<!-- 해당 PR에서 논의가 필요한 사항을 적어주세요. -->
- yarn dev와 yarn start의 차이점을 모른 채 start로만 하다가 몇 시간을 안녕했어요..흑흑 도와주신 주노 선상님 정말 감사합니다!

### 📸 스크린샷, 없으면 이것 참,, 섭섭한데요?

https://github.com/sopt-makers/sopt-playground-frontend/assets/76681519/6f4b9ac5-0a44-41d2-837b-5d9bc57e25fa


https://github.com/sopt-makers/sopt-playground-frontend/assets/76681519/23868123-e1f3-4d2e-aeb3-adfabda396c2

