### PR TITLE
feat: 우승자 탄생 시 역대 우승자에 바로 반영되도록 구현

### DIFF
--- a/src/components/wordchain/WordchainChatting/Wordchain/index.tsx
+++ b/src/components/wordchain/WordchainChatting/Wordchain/index.tsx
@@ -1,4 +1,5 @@
 import styled from '@emotion/styled';
+import { useQueryClient } from '@tanstack/react-query';
 import TrophyIcon from 'public/icons/icon-trophy.svg';
 
 import { useGetMemberOfMe } from '@/api/endpoint/members/getMemberOfMe';
@@ -46,6 +47,7 @@ export default function Wordchain({ initial, order, wordList, isProgress, winner
   const { data: currentWinnerName } = useGetCurrentWinnerName();
   const { mutate } = useNewGameMutation();
   const { data: me } = useGetMemberOfMe();
+  const queryClient = useQueryClient();
 
   const onClickGiveUp = async () => {
     const confirm = await Confirm({
@@ -58,6 +60,7 @@ export default function Wordchain({ initial, order, wordList, isProgress, winner
       mutate(undefined, {
         onSuccess: () => {
           logSubmitEvent('wordchainNewGame');
+          queryClient.invalidateQueries(['getWordchainWinners']);
         },
       });
     }


### PR DESCRIPTION
### 🤫 쉿, 나한테만 말해줘요. 이슈넘버
- close #971 

### 🧐 어떤 것을 변경했어요~?
<!-- 실제로 변경한 사항을 설명해주세요.-->
- 우승자가 탄생하면, 바로 역대 우승자 리스트에 반영되도록 구현했어요. 

### 🤔 그렇다면, 어떻게 구현했어요~?
<!-- 실제로 구현한 로직에 대해 설명해주세요.-->
- 우승자가 탄생하는 로직인 onClickGiveUp함수에서 mutate onSuccess에서`queryClient.invalidateQueries(['getWordchainWinners']);`를 하도록 했습니다!

### ❤️‍🔥 당신이 생각하는 PR포인트, 내겐 매력포인트.
<!-- 해당 PR에서 논의가 필요한 사항을 적어주세요. -->

### 📸 스크린샷, 없으면 이것 참,, 섭섭한데요?

<img width="1440" alt="스크린샷 2023-09-14 오전 12 34 47" src="https://github.com/sopt-makers/sopt-playground-frontend/assets/76681519/2eec50bd-4368-4e80-9020-b299ea19dab7">
