### PR TITLE
fix: meta tag에 key를 부여해 페이지에서 override 되도록 수정

### DIFF
--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -47,9 +47,9 @@ function MyApp({ Component, pageProps }: AppProps) {
     <QueryClientProvider client={queryClient}>
       <Head>
         <title>SOPT Playground</title>
-        <meta property='og:title' content='SOPT Playground' />
-        <meta property='og:description' content='솝트와 연결되고 싶으신가요?' />
-        <meta property='og:image' content={`${ORIGIN}/icons/img/og_playground.jpeg`} />
+        <meta key='og:title' property='og:title' content='SOPT Playground' />
+        <meta key='og:description' property='og:description' content='솝트와 연결되고 싶으신가요?' />
+        <meta key='og:image' property='og:image' content={`${ORIGIN}/icons/img/og_playground.jpeg`} />
         <meta name='theme-color' media='(prefers-color-scheme: dark)' content={colors.gray80} />
       </Head>
       <GoogleTagManagerScript />

--- a/src/pages/members/[id].tsx
+++ b/src/pages/members/[id].tsx
@@ -23,9 +23,9 @@ const UserPage: FC = () => {
       <AuthRequired>
         <Head>
           <title>SOPT | 회원 프로필 보기</title>
-          <meta property='og:title' content='SOPT | 회원 프로필 보기' />
-          <meta property='og:description' content='이 회원이 알고 싶으신가요?' />
-          <meta property='og:image' content={`${ORIGIN}/icons/img/og_profile.jpg`} />
+          <meta key='og:title' property='og:title' content='SOPT | 회원 프로필 보기' />
+          <meta key='og:description' property='og:description' content='이 회원이 알고 싶으신가요?' />
+          <meta key='og:image' property='og:image' content={`${ORIGIN}/icons/img/og_profile.jpg`} />
         </Head>
         <MemberDetail memberId={query.id} />
       </AuthRequired>

--- a/src/pages/projects/[id].tsx
+++ b/src/pages/projects/[id].tsx
@@ -23,9 +23,9 @@ const ProjectPage: FC = () => {
       <AuthRequired>
         <Head>
           <title>SOPT | 프로젝트 둘러보기</title>
-          <meta property='og:title' content='SOPT | 프로젝트 둘러보기' />
-          <meta property='og:description' content='자세한 내용이 궁금하신가요?' />
-          <meta property='og:image' content={`${ORIGIN}/icons/img/og_project.jpg`} />
+          <meta key='og:title' property='og:title' content='SOPT | 프로젝트 둘러보기' />
+          <meta key='og:description' property='og:description' content='자세한 내용이 궁금하신가요?' />
+          <meta key='og:image' property='og:image' content={`${ORIGIN}/icons/img/og_project.jpg`} />
         </Head>
         <ProjectDetail projectId={query.id} />
       </AuthRequired>


### PR DESCRIPTION
### 🤫 쉿, 나한테만 말해줘요. 이슈넘버
- close #

### 🧐 어떤 것을 변경했어요~?
<!-- 실제로 변경한 사항을 설명해주세요.-->
- 공통의 `meta tag`를 주입하기 위해서 `_app.tsx`에 우선 주입하고, 개별 페이지에서 추가로 주입하면 override 되길 기대했으나, 중복으로 태그가 주입되고, 크롤러 봇은 먼저 주입된 `_app.tsx`의 메타태그를 읽는 문제가 있었어요.
- meta 태그에 property와 똑같은 key를 주입함으로써 해결했는데, 그러면 <Head> 태그 내부에서 같은 key를 가진 컴포넌트가 있으면 나중에 들어온 컴포넌트로 override 되도록 구현이 되어있다고 해요. 그래서 key를 주입하여 해결했습니다.

(feat. G교수님)
<img width="563" alt="image" src="https://github.com/sopt-makers/sopt-playground-frontend/assets/26808056/040c8ab9-5d7a-42d1-9181-cc34d1a6756f">


### 🤔 그렇다면, 어떻게 구현했어요~?
<!-- 실제로 구현한 로직에 대해 설명해주세요.-->

### ❤️‍🔥 당신이 생각하는 PR포인트, 내겐 매력포인트.
<!-- 해당 PR에서 논의가 필요한 사항을 적어주세요. -->

### 📸 스크린샷, 없으면 이것 참,, 섭섭한데요?
