### PR TITLE
feat: 명예의 전당 우승자 클릭 시 프로필로 넘어가도록 & 글자색 수정

### DIFF
--- a/src/components/wordchain/WordchainWinners/WordchainWinner/index.tsx
+++ b/src/components/wordchain/WordchainWinners/WordchainWinner/index.tsx
@@ -145,6 +145,7 @@ const WinnerName = styled.p<{ isRecent: boolean }>`
 
   @media ${MOBILE_MEDIA_QUERY} {
     width: 35px;
+    color: ${colors.white};
     ${textStyles.SUIT_12_M}
   }
 `;

--- a/src/components/wordchain/WordchainWinners/WordchainWinner/index.tsx
+++ b/src/components/wordchain/WordchainWinners/WordchainWinner/index.tsx
@@ -1,7 +1,9 @@
 import { css } from '@emotion/react';
 import styled from '@emotion/styled';
 import { colors } from '@sopt-makers/colors';
+import Link from 'next/link';
 
+import { playgroundLink } from '@/constants/links';
 import { MOBILE_MEDIA_QUERY } from '@/styles/mediaQuery';
 import { textStyles } from '@/styles/typography';
 
@@ -10,11 +12,12 @@ interface WordChainWinnerProps {
   profileImage: string;
   name: string;
   isRecent: boolean;
+  userId: number;
 }
 
-export default function WordChainWinner({ roomId, profileImage, name, isRecent }: WordChainWinnerProps) {
+export default function WordChainWinner({ roomId, profileImage, userId, name, isRecent }: WordChainWinnerProps) {
   return (
-    <WordChainWinnerContainer isRecent={isRecent}>
+    <WordChainWinnerContainer href={playgroundLink.memberDetail(userId)} isRecent={isRecent}>
       <WinRound isRecent={isRecent}>
         {roomId}번째 <WinnerTag> 우승자 | </WinnerTag>
       </WinRound>
@@ -30,7 +33,7 @@ export default function WordChainWinner({ roomId, profileImage, name, isRecent }
   );
 }
 
-const WordChainWinnerContainer = styled.article<{ isRecent: boolean }>`
+const WordChainWinnerContainer = styled(Link)<{ isRecent: boolean }>`
   display: grid;
   grid: [row1-start] 'winRound winnerImageBox winnerName' min-content [row1-end]/ auto;
   border-radius: 10px;

--- a/src/components/wordchain/WordchainWinners/index.stories.tsx
+++ b/src/components/wordchain/WordchainWinners/index.stories.tsx
@@ -55,7 +55,16 @@ export const Default: StoryObj = {
   render: () => (
     <Fragment>
       {winnerList.map(({ roomId, winner: { id, profileImage, name } }) => {
-        return <WordChainWinner key={id} roomId={roomId} profileImage={profileImage} name={name} isRecent={false} />;
+        return (
+          <WordChainWinner
+            userId={id}
+            key={id}
+            roomId={roomId}
+            profileImage={profileImage}
+            name={name}
+            isRecent={false}
+          />
+        );
       })}
     </Fragment>
   ),

--- a/src/components/wordchain/WordchainWinners/index.tsx
+++ b/src/components/wordchain/WordchainWinners/index.tsx
@@ -36,6 +36,7 @@ export default function WordchainWinners() {
                 <WordChainWinner
                   key={`${roomId}` + `${id}`}
                   roomId={roomId}
+                  userId={id}
                   profileImage={profileImage}
                   name={name}
                   isRecent={isRecent}


### PR DESCRIPTION
### 🤫 쉿, 나한테만 말해줘요. 이슈넘버
최신 우승자의 이름색이 안보이는 이슈
<img width="350" alt="CleanShot 2023-09-23 at 16 03 25@2x" src="https://github.com/sopt-makers/sopt-playground-frontend/assets/28650320/e2e1fd6c-a314-4cfc-9f99-a5cfd854e0b5">


### 🧐 어떤 것을 변경했어요~?
<!-- 실제로 변경한 사항을 설명해주세요.-->
- 명예의 전당 우승자 클릭 시 프로필로 넘어가도록 해줬어요.
- 최신 우승자의 이름색이 안보이는 이슈가 있어 글자색을 추가했어요.

### 🤔 그렇다면, 어떻게 구현했어요~?
<!-- 실제로 구현한 로직에 대해 설명해주세요.-->

### ❤️‍🔥 당신이 생각하는 PR포인트, 내겐 매력포인트.
<!-- 해당 PR에서 논의가 필요한 사항을 적어주세요. -->

### 📸 스크린샷, 없으면 이것 참,, 섭섭한데요?
