### PR TITLE
fix: 무한스크롤 안되는 이슈 해결

### DIFF
--- a/src/components/wordchain/WordchainWinners/index.tsx
+++ b/src/components/wordchain/WordchainWinners/index.tsx
@@ -51,9 +51,7 @@ export default function WordchainWinners() {
   );
 }
 
-const Target = styled.div`
-  /* height: 5px; */
-`;
+const Target = styled.div``;
 
 const WinnerBoard = styled.aside`
   display: flex;

--- a/src/components/wordchain/WordchainWinners/index.tsx
+++ b/src/components/wordchain/WordchainWinners/index.tsx
@@ -51,7 +51,9 @@ export default function WordchainWinners() {
   );
 }
 
-const Target = styled.div``;
+const Target = styled.div`
+  /* height: 5px; */
+`;
 
 const WinnerBoard = styled.aside`
   display: flex;
@@ -87,6 +89,7 @@ const WinnerList = styled.section`
   display: flex;
   flex-direction: column;
   margin-bottom: -4px;
+  padding-bottom: 2px;
   height: 312px;
   overflow-y: scroll;
 


### PR DESCRIPTION
### 🤫 쉿, 나한테만 말해줘요. 이슈넘버
- close #1008 

### 🧐 어떤 것을 변경했어요~?
<!-- 실제로 변경한 사항을 설명해주세요.-->
- 13인치 노트북 화면배율 90%에서 명예의 전당 무한스크롤이 안되는 이슈를 해결했어요.

### 🤔 그렇다면, 어떻게 구현했어요~?
<!-- 실제로 구현한 로직에 대해 설명해주세요.-->
- 명예의전당 데이터 + 무한스크롤Target 을 감싸는 박스 태그에 overflow:hidden을 먹여두었더니, Target에 접근하지 못했던 것 같아요.
- 위의 박스 태그에 padding-bottom을 주었더니 해결되었습니다. 

### ❤️‍🔥 당신이 생각하는 PR포인트, 내겐 매력포인트.
<!-- 해당 PR에서 논의가 필요한 사항을 적어주세요. -->

### 📸 스크린샷, 없으면 이것 참,, 섭섭한데요?
