### PR TITLE
chore: 끝말잇기 배너에 불필요한 margin 제거

### DIFF
--- a/src/components/wordchain/WordchainEntry/WordChainEntry.tsx
+++ b/src/components/wordchain/WordchainEntry/WordChainEntry.tsx
@@ -251,6 +251,5 @@ const GotoWordChainSub = styled.div`
 `;
 
 const LastWord = styled.span`
-  margin-left: 4px;
   color: ${colors.orange100};
 `;


### PR DESCRIPTION
### 🤫 쉿, 나한테만 말해줘요. 이슈넘버
<img width="394" alt="CleanShot 2023-09-24 at 22 35 09@2x" src="https://github.com/sopt-makers/sopt-playground-frontend/assets/28650320/9c3deed5-bcac-4f86-b7d8-68b862f6d61f">
<img width="405" alt="CleanShot 2023-09-24 at 22 35 13@2x" src="https://github.com/sopt-makers/sopt-playground-frontend/assets/28650320/2ffd943e-c053-4f4c-90d9-a7923baea0ed">

### 🧐 어떤 것을 변경했어요~?
<!-- 실제로 변경한 사항을 설명해주세요.-->
제보 받았는데 넘 사소한거라 그냥 작업해봤어요 하하