### PR TITLE
fix: 모바일 뷰 멘토링 카드 radius 수정

### DIFF
--- a/src/components/mentoring/MentoringCard/index.tsx
+++ b/src/components/mentoring/MentoringCard/index.tsx
@@ -229,6 +229,7 @@ const Closed = styled.div<{ isActive: boolean }>`
   }
 
   @media ${MOBILE_MEDIA_QUERY} {
+    border-radius: 10px;
     width: 233px;
     height: 104px;
   }


### PR DESCRIPTION
### 🤫 쉿, 나한테만 말해줘요. 이슈넘버
- close #1013 

### 🧐 어떤 것을 변경했어요~?
<!-- 실제로 변경한 사항을 설명해주세요.-->
- 간소화한 모바일뷰의 멘토링카드 중 더이상 멘토링을 받지 않는 멘토링카드의 border-radius를 수정했어요. 

### 🤔 그렇다면, 어떻게 구현했어요~?
<!-- 실제로 구현한 로직에 대해 설명해주세요.-->
- border-radius를 수정했어요. 
### ❤️‍🔥 당신이 생각하는 PR포인트, 내겐 매력포인트.
<!-- 해당 PR에서 논의가 필요한 사항을 적어주세요. -->

### 📸 스크린샷, 없으면 이것 참,, 섭섭한데요?
