### PR TITLE
fix: 메이커스 소개 기수 탭 스크롤 수정

### DIFF
--- a/src/components/makers/MakersMembers.tsx
+++ b/src/components/makers/MakersMembers.tsx
@@ -1,5 +1,6 @@
 import styled from '@emotion/styled';
 import * as Tabs from '@radix-ui/react-tabs';
+import { colors } from '@sopt-makers/colors';
 import Link from 'next/link';
 import { FC, Fragment, useMemo } from 'react';
 
@@ -8,7 +9,6 @@ import { MakersGeneration } from '@/components/makers/data/types';
 import TeamBlock from '@/components/makers/TeamBlock';
 import MemberBlock from '@/components/members/common/MemberBlock';
 import { playgroundLink } from '@/constants/links';
-import { colors } from '@sopt-makers/colors';
 import { MOBILE_MEDIA_QUERY } from '@/styles/mediaQuery';
 import { textStyles } from '@/styles/typography';
 
@@ -104,6 +104,7 @@ const TabButton = styled.a`
   border: 2px solid transparent;
   cursor: pointer;
   padding: 12px 24px;
+  min-width: max-content;
   color: ${colors.gray60};
 
   &[data-state='active'] {
@@ -120,6 +121,7 @@ const TabButton = styled.a`
 
 const TabList = styled.div`
   display: flex;
+  overflow-x: auto;
 `;
 
 const TabBottomLine = styled.div`


### PR DESCRIPTION
### 🤫 쉿, 나한테만 말해줘요. 이슈넘버

### 🧐 어떤 것을 변경했어요~?
<!-- 실제로 변경한 사항을 설명해주세요.-->

메이커스 소개 페이지의 기수 탭이 스크롤이 안생기고 뭉개지는 오류를 해결했습니다.

### 🤔 그렇다면, 어떻게 구현했어요~?
<!-- 실제로 구현한 로직에 대해 설명해주세요.-->


### ❤️‍🔥 당신이 생각하는 PR포인트, 내겐 매력포인트.
<!-- 해당 PR에서 논의가 필요한 사항을 적어주세요. -->

### 📸 스크린샷, 없으면 이것 참,, 섭섭한데요?
![image](https://github.com/sopt-makers/sopt-playground-frontend/assets/36122585/c5e4da3d-2f87-492b-ba17-96878953ce27)
