### PR TITLE
chore: 디버그 패널 > 토큰 복사 기능 추가 및 스타일 개선

### DIFF
--- a/src/components/debug/Panel.tsx
+++ b/src/components/debug/Panel.tsx
@@ -1,7 +1,10 @@
 import { css } from '@emotion/react';
+import styled from '@emotion/styled';
 import * as Collapsible from '@radix-ui/react-collapsible';
 import { colors } from '@sopt-makers/colors';
 import { FC, ReactNode, useState } from 'react';
+
+import { textStyles } from '@/styles/typography';
 
 const ARROW_DOWN_SYMBOL = `\u25bc`;
 const ARROW_UP_SYMBOL = `\u25b2`;
@@ -15,9 +18,9 @@ const Panel: FC<PanelProps> = ({ title, children }) => {
   const [open, setOpen] = useState(true);
 
   return (
-    <Collapsible.Root open={open} onOpenChange={setOpen}>
+    <Collapsible.Root open={open} onOpenChange={setOpen} css={rootStyle}>
       <Collapsible.Trigger css={disclosureButtonStyle}>
-        <span>{title}</span>
+        <Title>{title}</Title>
         <span>{open ? ARROW_UP_SYMBOL : ARROW_DOWN_SYMBOL}</span>
       </Collapsible.Trigger>
       <Collapsible.Content css={collapsibleContentStyle}>{children}</Collapsible.Content>
@@ -25,24 +28,28 @@ const Panel: FC<PanelProps> = ({ title, children }) => {
   );
 };
 
+const rootStyle = css`
+  padding: 0 15px;
+`;
+
 const disclosureButtonStyle = css`
   display: flex;
   justify-content: space-between;
-  margin: 0 15px;
+  margin-bottom: 15px;
   border-radius: 5px;
   background-color: ${colors.blue50};
   cursor: pointer;
   padding: 8px 16px;
-  width: calc(100% - 30px);
+  width: 100%;
   color: ${colors.gray20};
 `;
 
 const collapsibleContentStyle = css`
-  margin: 8px 15px;
   padding: 5px 0 0;
   overflow: hidden;
 
   &[data-state='open'] {
+    padding: 0;
     animation: slide-down 200ms ease-out;
   }
 
@@ -69,6 +76,10 @@ const collapsibleContentStyle = css`
       height: 0;
     }
   }
+`;
+
+const Title = styled.div`
+  ${textStyles.SUIT_17_SB}
 `;
 
 export default Panel;

--- a/src/components/debug/SideBar.tsx
+++ b/src/components/debug/SideBar.tsx
@@ -66,11 +66,12 @@ const StyledSidePanel = styled.div<{ isOpen: boolean }>`
 const Header = styled.div`
   display: flex;
   align-items: center;
+  margin-top: 3px;
 `;
 
 const HeaderTitle = styled.h2`
   flex-grow: 1;
-  margin-left: 10px;
+  margin-left: 15px;
 `;
 
 const Content = styled.div`

--- a/src/components/debug/SideBar.tsx
+++ b/src/components/debug/SideBar.tsx
@@ -74,11 +74,13 @@ const HeaderTitle = styled.h2`
 `;
 
 const Content = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 15px;
   padding: 15px 0 0;
 `;
 
 const CloseButton = styled.button`
-  /* padding: 8px 10px; */
   display: flex;
   align-items: center;
   justify-content: center;

--- a/src/components/debug/panels/AccessTokenPanel.tsx
+++ b/src/components/debug/panels/AccessTokenPanel.tsx
@@ -10,6 +10,7 @@ import Button from '@/components/common/Button';
 import TextArea from '@/components/common/TextArea';
 import useToast from '@/components/common/Toast/useToast';
 import Panel from '@/components/debug/Panel';
+import { textStyles } from '@/styles/typography';
 import { copyToClipboard } from '@/utils';
 
 const AccessTokenPanel: FC = () => {
@@ -57,7 +58,7 @@ const AccessTokenPanel: FC = () => {
   return (
     <Panel title='저장된 액세스 토큰'>
       {editState.type === 'editing' ? (
-        <>
+        <Wrapper>
           <StyledTextArea
             value={editState.value}
             onChange={(e) => dispatchEdit({ type: 'change', value: e.target.value })}
@@ -75,9 +76,9 @@ const AccessTokenPanel: FC = () => {
               확인
             </StyledButton>
           </ActionBox>
-        </>
+        </Wrapper>
       ) : (
-        <>
+        <Wrapper>
           <StyledTextArea value={accessToken ?? ''} disabled />
           <ActionBox>
             <StyledButton variant='primary' onClick={handleClickCopyButton}>
@@ -87,9 +88,11 @@ const AccessTokenPanel: FC = () => {
               변경
             </StyledButton>
           </ActionBox>
-          <InSectionTitle>디코드된 토큰 정보</InSectionTitle>
-          <StyledTextArea value={JSON.stringify(decodedToken, null, 2)} disabled />
-        </>
+          <div>
+            <InSectionTitle>디코드된 토큰 정보</InSectionTitle>
+            <StyledTextArea value={JSON.stringify(decodedToken, null, 2)} disabled />
+          </div>
+        </Wrapper>
       )}
     </Panel>
   );
@@ -111,16 +114,25 @@ const StyledTextArea = styled(TextArea)`
 const ActionBox = styled.div`
   display: flex;
   gap: 10px;
-  margin: 15px 0;
   width: 100%;
 `;
 
-const InSectionTitle = styled.h3`
+const InSectionTitle = styled.div`
   margin: 5px 0;
 `;
 
 const StyledButton = styled(Button)`
   width: 100%;
+  line-height: 100%;
+
+  ${textStyles.SUIT_16_M}
+`;
+
+const Wrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  padding-bottom: 15px;
 `;
 
 type States =

--- a/src/components/debug/panels/AccessTokenPanel.tsx
+++ b/src/components/debug/panels/AccessTokenPanel.tsx
@@ -6,11 +6,10 @@ import { useRecoilState } from 'recoil';
 
 import { accessTokenAtom } from '@/components/auth/states/accessTokenAtom';
 import { safeDecodeAccessToken } from '@/components/auth/util/accessToken';
-import Button from '@/components/common/Button';
 import TextArea from '@/components/common/TextArea';
 import useToast from '@/components/common/Toast/useToast';
 import Panel from '@/components/debug/Panel';
-import { textStyles } from '@/styles/typography';
+import { ActionBox, ActionButton, PanelContent } from '@/components/debug/styles';
 import { copyToClipboard } from '@/utils';
 
 const AccessTokenPanel: FC = () => {
@@ -58,41 +57,41 @@ const AccessTokenPanel: FC = () => {
   return (
     <Panel title='저장된 액세스 토큰'>
       {editState.type === 'editing' ? (
-        <Wrapper>
+        <PanelContent>
           <StyledTextArea
             value={editState.value}
             onChange={(e) => dispatchEdit({ type: 'change', value: e.target.value })}
             error={isEditError}
           />
           <ActionBox>
-            <StyledButton
+            <ActionButton
               variant='primary'
               onClick={() => dispatchEdit({ type: 'end' })}
               css={{ backgroundColor: colors.gray100, marginLeft: '5px' }}
             >
               취소
-            </StyledButton>
-            <StyledButton variant='primary' onClick={applyEdit}>
+            </ActionButton>
+            <ActionButton variant='primary' onClick={applyEdit}>
               확인
-            </StyledButton>
+            </ActionButton>
           </ActionBox>
-        </Wrapper>
+        </PanelContent>
       ) : (
-        <Wrapper>
+        <PanelContent>
           <StyledTextArea value={accessToken ?? ''} disabled />
           <ActionBox>
-            <StyledButton variant='primary' onClick={handleClickCopyButton}>
+            <ActionButton variant='primary' onClick={handleClickCopyButton}>
               복사
-            </StyledButton>
-            <StyledButton variant='primary' onClick={() => dispatchEdit({ type: 'change', value: accessToken ?? '' })}>
+            </ActionButton>
+            <ActionButton variant='primary' onClick={() => dispatchEdit({ type: 'change', value: accessToken ?? '' })}>
               변경
-            </StyledButton>
+            </ActionButton>
           </ActionBox>
           <div>
             <InSectionTitle>디코드된 토큰 정보</InSectionTitle>
             <StyledTextArea value={JSON.stringify(decodedToken, null, 2)} disabled />
           </div>
-        </Wrapper>
+        </PanelContent>
       )}
     </Panel>
   );
@@ -111,28 +110,8 @@ const StyledTextArea = styled(TextArea)`
       : ''}
 `;
 
-const ActionBox = styled.div`
-  display: flex;
-  gap: 10px;
-  width: 100%;
-`;
-
 const InSectionTitle = styled.div`
   margin: 5px 0;
-`;
-
-const StyledButton = styled(Button)`
-  width: 100%;
-  line-height: 100%;
-
-  ${textStyles.SUIT_16_M}
-`;
-
-const Wrapper = styled.div`
-  display: flex;
-  flex-direction: column;
-  gap: 10px;
-  padding-bottom: 15px;
 `;
 
 type States =

--- a/src/components/debug/panels/AccessTokenPanel.tsx
+++ b/src/components/debug/panels/AccessTokenPanel.tsx
@@ -8,12 +8,16 @@ import { accessTokenAtom } from '@/components/auth/states/accessTokenAtom';
 import { safeDecodeAccessToken } from '@/components/auth/util/accessToken';
 import Button from '@/components/common/Button';
 import TextArea from '@/components/common/TextArea';
+import useToast from '@/components/common/Toast/useToast';
 import Panel from '@/components/debug/Panel';
+import { copyToClipboard } from '@/utils';
 
 const AccessTokenPanel: FC = () => {
   const [accessToken, setAccessToken] = useRecoilState(accessTokenAtom);
 
   const [editState, dispatchEdit] = useReducer(reducer, { type: 'idle' });
+
+  const toast = useToast();
 
   const applyEdit = () => {
     if (editState.type !== 'editing') {
@@ -43,6 +47,13 @@ const AccessTokenPanel: FC = () => {
     return safeDecodeAccessToken(editState.value) === null;
   }, [editState]);
 
+  const handleClickCopyButton = () => {
+    if (!accessToken) {
+      return null;
+    }
+    copyToClipboard(accessToken, { onSuccess: () => toast.show({ message: '토큰이 복사되었습니다.' }) });
+  };
+
   return (
     <Panel title='저장된 액세스 토큰'>
       {editState.type === 'editing' ? (
@@ -53,25 +64,28 @@ const AccessTokenPanel: FC = () => {
             error={isEditError}
           />
           <ActionBox>
-            <Button
+            <StyledButton
               variant='primary'
               onClick={() => dispatchEdit({ type: 'end' })}
               css={{ backgroundColor: colors.gray100, marginLeft: '5px' }}
             >
               취소
-            </Button>
-            <Button variant='primary' onClick={applyEdit}>
+            </StyledButton>
+            <StyledButton variant='primary' onClick={applyEdit}>
               확인
-            </Button>
+            </StyledButton>
           </ActionBox>
         </>
       ) : (
         <>
           <StyledTextArea value={accessToken ?? ''} disabled />
           <ActionBox>
-            <Button variant='primary' onClick={() => dispatchEdit({ type: 'change', value: accessToken ?? '' })}>
+            <StyledButton variant='primary' onClick={handleClickCopyButton}>
+              복사
+            </StyledButton>
+            <StyledButton variant='primary' onClick={() => dispatchEdit({ type: 'change', value: accessToken ?? '' })}>
               변경
-            </Button>
+            </StyledButton>
           </ActionBox>
           <InSectionTitle>디코드된 토큰 정보</InSectionTitle>
           <StyledTextArea value={JSON.stringify(decodedToken, null, 2)} disabled />
@@ -96,12 +110,17 @@ const StyledTextArea = styled(TextArea)`
 
 const ActionBox = styled.div`
   display: flex;
-  flex-direction: row-reverse;
-  margin-top: 8px;
+  gap: 10px;
+  margin: 15px 0;
+  width: 100%;
 `;
 
 const InSectionTitle = styled.h3`
   margin: 5px 0;
+`;
+
+const StyledButton = styled(Button)`
+  width: 100%;
 `;
 
 type States =

--- a/src/components/debug/panels/NavigationPanel.tsx
+++ b/src/components/debug/panels/NavigationPanel.tsx
@@ -2,21 +2,22 @@ import styled from '@emotion/styled';
 import Link from 'next/link';
 import { FC } from 'react';
 
-import Button from '@/components/common/Button';
 import Panel from '@/components/debug/Panel';
+import { ActionBox, ActionButton } from '@/components/debug/styles';
 import { playgroundLink } from '@/constants/links';
-import { textStyles } from '@/styles/typography';
 
 const NavigationPanel: FC = () => {
   return (
     <Panel title='주요 페이지 이동'>
       <PanelContent>
-        <Link href={playgroundLink.memberList()} passHref legacyBehavior>
-          <StyledButton variant='primary'>홈</StyledButton>
-        </Link>
-        <Link href={playgroundLink.login()} passHref legacyBehavior>
-          <StyledButton variant='primary'>로그인</StyledButton>
-        </Link>
+        <ActionBox>
+          <Link href={playgroundLink.memberList()} passHref legacyBehavior>
+            <ActionButton variant='primary'>홈</ActionButton>
+          </Link>
+          <Link href={playgroundLink.login()} passHref legacyBehavior>
+            <ActionButton variant='primary'>로그인</ActionButton>
+          </Link>
+        </ActionBox>
       </PanelContent>
     </Panel>
   );
@@ -29,11 +30,4 @@ const PanelContent = styled.div`
   gap: 10px;
   padding-bottom: 15px;
   width: 100%;
-`;
-
-const StyledButton = styled(Button)`
-  width: 100%;
-  line-height: 100%;
-
-  ${textStyles.SUIT_16_M}
 `;

--- a/src/components/debug/panels/NavigationPanel.tsx
+++ b/src/components/debug/panels/NavigationPanel.tsx
@@ -5,16 +5,17 @@ import { FC } from 'react';
 import Button from '@/components/common/Button';
 import Panel from '@/components/debug/Panel';
 import { playgroundLink } from '@/constants/links';
+import { textStyles } from '@/styles/typography';
 
 const NavigationPanel: FC = () => {
   return (
     <Panel title='주요 페이지 이동'>
       <PanelContent>
         <Link href={playgroundLink.memberList()} passHref legacyBehavior>
-          <Button variant='primary'>홈</Button>
+          <StyledButton variant='primary'>홈</StyledButton>
         </Link>
         <Link href={playgroundLink.login()} passHref legacyBehavior>
-          <Button variant='primary'>로그인</Button>
+          <StyledButton variant='primary'>로그인</StyledButton>
         </Link>
       </PanelContent>
     </Panel>
@@ -25,6 +26,14 @@ export default NavigationPanel;
 
 const PanelContent = styled.div`
   display: flex;
-  flex-wrap: wrap;
-  column-gap: 10px;
+  gap: 10px;
+  padding-bottom: 15px;
+  width: 100%;
+`;
+
+const StyledButton = styled(Button)`
+  width: 100%;
+  line-height: 100%;
+
+  ${textStyles.SUIT_16_M}
 `;

--- a/src/components/debug/styles.ts
+++ b/src/components/debug/styles.ts
@@ -1,0 +1,25 @@
+import styled from '@emotion/styled';
+
+import Button from '@/components/common/Button';
+import { textStyles } from '@/styles/typography';
+
+export const PanelContent = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  padding-bottom: 15px;
+  width: 100%;
+`;
+
+export const ActionBox = styled.div`
+  display: flex;
+  gap: 10px;
+  width: 100%;
+`;
+
+export const ActionButton = styled(Button)`
+  width: 100%;
+  line-height: 100%;
+
+  ${textStyles.SUIT_16_M}
+`;


### PR DESCRIPTION
### 🤫 쉿, 나한테만 말해줘요. 이슈넘버
- close #1016

### 🧐 어떤 것을 변경했어요~?
<!-- 실제로 변경한 사항을 설명해주세요.-->

- 토큰 복사 버튼 추가
- 스타일 개선

### 🤔 그렇다면, 어떻게 구현했어요~?
<!-- 실제로 구현한 로직에 대해 설명해주세요.-->

제가 옛날에 야무지게 만들어놓은 copyToClipboard 유틸을 사용함ㅎ


### ❤️‍🔥 당신이 생각하는 PR포인트, 내겐 매력포인트.
<!-- 해당 PR에서 논의가 필요한 사항을 적어주세요. -->

스타일 개선은 하는 김에 해봤는데 의견 주세요 ㅎ.ㅎ

주요 개선: 타이틀 크기 위계 정리, 버튼 박스 스타일 통일, 각종 마진 패딩 정리

### 📸 스크린샷, 없으면 이것 참,, 섭섭한데요?

- 토큰 복사 기능

https://github.com/sopt-makers/sopt-playground-frontend/assets/73823388/69ac3154-cddb-4138-9613-0e3808c6f033



- 스타일 개선

전

<img width="1512" alt="image" src="https://github.com/sopt-makers/sopt-playground-frontend/assets/73823388/df4bd510-114f-45d0-bfaf-b05cf50b3ff7">


후

<img width="1512" alt="image" src="https://github.com/sopt-makers/sopt-playground-frontend/assets/73823388/0ccd3e8d-220d-4844-86df-4e0e35b98c65">
