### PR TITLE
feat: playground-commons 헤더에 @sopt-makers/colors 의존성 추가

### DIFF
--- a/playground-common/package.json
+++ b/playground-common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sopt-makers/playground-common",
-  "version": "1.2.2",
+  "version": "1.3.2",
   "license": "MIT",
   "source": "src/index.ts",
   "main": "dist/index.js",
@@ -19,6 +19,7 @@
     "@emotion/styled": "^11.8.1",
     "@radix-ui/react-dialog": "1.0.2",
     "@radix-ui/react-dropdown-menu": "2.0.2",
+    "@sopt-makers/colors": "^2.2.0",
     "react-remove-scroll": "2.5.5"
   },
   "peerDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -4966,6 +4966,7 @@ __metadata:
     "@emotion/styled": ^11.8.1
     "@radix-ui/react-dialog": 1.0.2
     "@radix-ui/react-dropdown-menu": 2.0.2
+    "@sopt-makers/colors": ^2.2.0
     react-remove-scroll: 2.5.5
   peerDependencies:
     react: ^16.8 || ^17.0 || ^18.0


### PR DESCRIPTION
### 🤫 쉿, 나한테만 말해줘요. 이슈넘버
- close #1035 

### 🧐 어떤 것을 변경했어요~?
<!-- 실제로 변경한 사항을 설명해주세요.-->
- 기존 colors를 makers-colors로 옮기면서 헤더쪽에 의존성을 누락하여 이를 추가하고 버전을 올립니다.

### 🤔 그렇다면, 어떻게 구현했어요~?
<!-- 실제로 구현한 로직에 대해 설명해주세요.-->

### ❤️‍🔥 당신이 생각하는 PR포인트, 내겐 매력포인트.
<!-- 해당 PR에서 논의가 필요한 사항을 적어주세요. -->

### 📸 스크린샷, 없으면 이것 참,, 섭섭한데요?
