### PR TITLE
feat: 커뮤니티 레이아웃 구현

### DIFF
--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -2,7 +2,9 @@ import React from 'react';
 import { themes } from '@storybook/theming';
 import { LazyMotion } from 'framer-motion';
 import { initialize, mswDecorator } from 'msw-storybook-addon';
+import NextAdapterPages from 'next-query-params/pages';
 import { RouterContext } from 'next/dist/shared/lib/router-context';
+import { QueryParamProvider } from 'use-query-params';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { RecoilRoot } from 'recoil';
 
@@ -43,18 +45,20 @@ export const parameters = {
 export const decorators = [
   (Story) => (
     <QueryClientProvider client={queryClient}>
-      <RecoilRoot>
-        <LazyMotion strict features={() => import('framer-motion').then((mod) => mod.domAnimation)}>
-          <StorybookEventLoggerProvider>
-            <StorybookToastProvider>
-              <GlobalStyle />
-              <ResponsiveProvider>
-                <Story />
-              </ResponsiveProvider>
-            </StorybookToastProvider>
-          </StorybookEventLoggerProvider>
-        </LazyMotion>
-      </RecoilRoot>
+      <QueryParamProvider adapter={NextAdapterPages}>
+        <RecoilRoot>
+          <LazyMotion strict features={() => import('framer-motion').then((mod) => mod.domAnimation)}>
+            <StorybookEventLoggerProvider>
+              <StorybookToastProvider>
+                <GlobalStyle />
+                <ResponsiveProvider>
+                  <Story />
+                </ResponsiveProvider>
+              </StorybookToastProvider>
+            </StorybookEventLoggerProvider>
+          </LazyMotion>
+        </RecoilRoot>
+      </QueryParamProvider>
     </QueryClientProvider>
   ),
   mswDecorator,

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "lodash-es": "^4.17.21",
     "nanoid": "^4.0.0",
     "next": "^13.1.1",
+    "next-query-params": "^4.2.3",
     "next-seo": "^6.1.0",
     "qs": "^6.11.0",
     "react": "^18.2.0",
@@ -62,6 +63,7 @@
     "react-remove-scroll": "^2.5.6",
     "recoil": "^0.7.2",
     "swiper": "^9.4.1",
+    "use-query-params": "^2.2.1",
     "yup": "^1.0.0",
     "zod": "^3.20.6"
   },

--- a/src/components/community/layout/DesktopCommunityLayout.tsx
+++ b/src/components/community/layout/DesktopCommunityLayout.tsx
@@ -1,0 +1,60 @@
+import styled from '@emotion/styled';
+import { m } from 'framer-motion';
+import { FC, ReactNode } from 'react';
+
+import { layoutCSSVariable } from '@/components/layout/utils';
+
+interface DesktopCommunityLayoutProps {
+  isDetailOpen: boolean;
+  listSlot: ReactNode;
+  detailSlot: ReactNode;
+}
+
+const DETAIL_SLOT_WIDTH = 560;
+
+const DesktopCommunityLayout: FC<DesktopCommunityLayoutProps> = ({ isDetailOpen, listSlot, detailSlot }) => {
+  return (
+    <Container>
+      <ListSlot>{listSlot}</ListSlot>
+      <DetailSlot
+        initial={{ width: 0 }}
+        animate={{ width: isDetailOpen ? DETAIL_SLOT_WIDTH : 0 }}
+        transition={{ bounce: 0 }}
+      >
+        <DetailSlotInner>{detailSlot}</DetailSlotInner>
+      </DetailSlot>
+    </Container>
+  );
+};
+
+export default DesktopCommunityLayout;
+
+const Container = styled.div`
+  display: flex;
+  justify-content: center;
+  width: 100%;
+  height: ${layoutCSSVariable.contentAreaHeight};
+`;
+
+const ListSlot = styled.div`
+  flex: 1 1 0;
+  max-width: 560px;
+  height: 100%;
+`;
+
+const DetailSlot = styled(m.div)`
+  position: relative;
+  width: 100%;
+  max-width: 560px;
+  height: 100%;
+  overflow: hidden;
+`;
+
+const DetailSlotInner = styled.div`
+  position: absolute;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  width: 560px;
+  min-width: ${DETAIL_SLOT_WIDTH}px;
+`;

--- a/src/components/community/layout/MobileCommunityLayout.tsx
+++ b/src/components/community/layout/MobileCommunityLayout.tsx
@@ -1,0 +1,40 @@
+import styled from '@emotion/styled';
+import { m } from 'framer-motion';
+import { FC, ReactNode } from 'react';
+
+import { layoutCSSVariable } from '@/components/layout/utils';
+
+interface MobileCommunityLayoutProps {
+  isDetailOpen: boolean;
+  listSlot: ReactNode;
+  detailSlot: ReactNode;
+}
+
+const MobileCommunityLayout: FC<MobileCommunityLayoutProps> = ({ isDetailOpen, listSlot, detailSlot }) => {
+  return (
+    <Container>
+      <ListSlotBox>{listSlot}</ListSlotBox>
+      <DetailSlotBox initial={{ x: '100%' }} animate={{ x: isDetailOpen ? '0%' : '100%' }} transition={{ bounce: 0 }}>
+        {detailSlot}
+      </DetailSlotBox>
+    </Container>
+  );
+};
+
+export default MobileCommunityLayout;
+
+const Container = styled.div`
+  position: relative;
+  height: ${layoutCSSVariable.contentAreaHeight};
+  overflow: hidden;
+`;
+
+const ListSlotBox = styled.div`
+  position: absolute;
+  inset: 0;
+`;
+
+const DetailSlotBox = styled(m.div)`
+  position: absolute;
+  inset: 0;
+`;

--- a/src/components/community/layout/MobileCommunityLayout.tsx
+++ b/src/components/community/layout/MobileCommunityLayout.tsx
@@ -1,4 +1,5 @@
 import styled from '@emotion/styled';
+import { colors } from '@sopt-makers/colors';
 import { m } from 'framer-motion';
 import { FC, ReactNode } from 'react';
 
@@ -37,4 +38,5 @@ const ListSlotBox = styled.div`
 const DetailSlotBox = styled(m.div)`
   position: absolute;
   inset: 0;
+  background-color: ${colors.background};
 `;

--- a/src/components/community/page.tsx
+++ b/src/components/community/page.tsx
@@ -1,0 +1,61 @@
+import styled from '@emotion/styled';
+import { colors } from '@sopt-makers/colors';
+import { m } from 'framer-motion';
+import { FC } from 'react';
+import { StringParam, useQueryParam, withDefault } from 'use-query-params';
+
+import { layoutCSSVariable } from '@/components/layout/utils';
+
+const CommunityPage: FC = () => {
+  const [category, setCategory] = useQueryParam('category', withDefault(StringParam, ''));
+  const [feed, setFeed] = useQueryParam('feed', withDefault(StringParam, ''));
+  const [tag, setTag] = useQueryParam('tag', withDefault(StringParam, ''));
+
+  return (
+    <Container>
+      <ListSlot>
+        <button onClick={() => setFeed('asdf')}>SET FEED </button>
+        <button onClick={() => setFeed('')}>UNSET FEED </button>
+      </ListSlot>
+      <DetailSlot initial={{ width: 0 }} animate={{ width: feed !== '' ? 560 : 0 }} transition={{ bounce: 0 }}>
+        <DetailSlotInner>{feed}</DetailSlotInner>
+      </DetailSlot>
+    </Container>
+  );
+};
+
+export default CommunityPage;
+
+const Container = styled.div`
+  display: flex;
+  justify-content: center;
+  width: 100%;
+  height: ${layoutCSSVariable.contentAreaHeight};
+`;
+
+const ListSlot = styled.div`
+  flex: 1 1 0;
+  background-color: ${colors.green400};
+  max-width: 560px;
+  height: 100%;
+  overflow-y: scroll;
+`;
+
+const DetailSlot = styled(m.div)`
+  position: relative;
+  background-color: ${colors.blue500};
+  width: 100%;
+  max-width: 560px;
+  height: 100%;
+  overflow: hidden;
+`;
+
+const DetailSlotInner = styled.div`
+  position: absolute;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  width: 560px;
+  min-width: 560px;
+  overflow-y: scroll;
+`;

--- a/src/components/community/page.tsx
+++ b/src/components/community/page.tsx
@@ -5,21 +5,27 @@ import { StringParam, useQueryParam, withDefault } from 'use-query-params';
 import Responsive from '@/components/common/Responsive';
 import DesktopCommunityLayout from '@/components/community/layout/DesktopCommunityLayout';
 import MobileCommunityLayout from '@/components/community/layout/MobileCommunityLayout';
+import { FeedDetailLink, TagLink } from '@/components/community/queryParam';
 
 const CommunityPage: FC = () => {
-  const [category, setCategory] = useQueryParam('category', withDefault(StringParam, ''));
-  const [feed, setFeed] = useQueryParam('feed', withDefault(StringParam, ''));
-  const [tag, setTag] = useQueryParam('tag', withDefault(StringParam, ''));
+  const [feed] = useQueryParam('feed', withDefault(StringParam, ''));
+  const [tag] = useQueryParam('tag', withDefault(StringParam, ''));
 
   const feedList = (
-    <div style={{ backgroundColor: colors.blue600 }}>
-      <button onClick={() => setFeed('NEW FEED')}>피드 열기</button>
+    <div style={{ backgroundColor: colors.blue600, display: 'flex', flexDirection: 'column' }}>
+      <TagLink tagId='tag1'>태그1</TagLink>
+      <TagLink tagId='tag2'>태그2</TagLink>
+      <TagLink tagId='tag3'>태그3</TagLink>
+      <div>CurrentTag: {tag}</div>
+      <FeedDetailLink feedId='ramen'>한강라면</FeedDetailLink>
+      <FeedDetailLink feedId='chicken'>치킨</FeedDetailLink>
     </div>
   );
 
   const feedDetail = (
     <div style={{ backgroundColor: colors.green600 }}>
-      <button onClick={() => setFeed(undefined)}>닫기</button>
+      <FeedDetailLink feedId={undefined}>닫기</FeedDetailLink>
+      <div>피드 ID: {feed}</div>
     </div>
   );
 

--- a/src/components/community/page.tsx
+++ b/src/components/community/page.tsx
@@ -1,15 +1,14 @@
 import { colors } from '@sopt-makers/colors';
 import { FC } from 'react';
-import { StringParam, useQueryParam, withDefault } from 'use-query-params';
 
 import Responsive from '@/components/common/Responsive';
 import DesktopCommunityLayout from '@/components/community/layout/DesktopCommunityLayout';
 import MobileCommunityLayout from '@/components/community/layout/MobileCommunityLayout';
-import { FeedDetailLink, TagLink } from '@/components/community/queryParam';
+import { FeedDetailLink, TagLink, useFeedDetailParam, useTagParam } from '@/components/community/queryParam';
 
 const CommunityPage: FC = () => {
-  const [feed] = useQueryParam('feed', withDefault(StringParam, ''));
-  const [tag] = useQueryParam('tag', withDefault(StringParam, ''));
+  const [feed] = useFeedDetailParam();
+  const [tag] = useTagParam();
 
   const feedList = (
     <div style={{ backgroundColor: colors.blue600, display: 'flex', flexDirection: 'column' }}>

--- a/src/components/community/page.tsx
+++ b/src/components/community/page.tsx
@@ -1,61 +1,38 @@
-import styled from '@emotion/styled';
 import { colors } from '@sopt-makers/colors';
-import { m } from 'framer-motion';
 import { FC } from 'react';
 import { StringParam, useQueryParam, withDefault } from 'use-query-params';
 
-import { layoutCSSVariable } from '@/components/layout/utils';
+import Responsive from '@/components/common/Responsive';
+import DesktopCommunityLayout from '@/components/community/layout/DesktopCommunityLayout';
+import MobileCommunityLayout from '@/components/community/layout/MobileCommunityLayout';
 
 const CommunityPage: FC = () => {
   const [category, setCategory] = useQueryParam('category', withDefault(StringParam, ''));
   const [feed, setFeed] = useQueryParam('feed', withDefault(StringParam, ''));
   const [tag, setTag] = useQueryParam('tag', withDefault(StringParam, ''));
 
+  const feedList = (
+    <div style={{ backgroundColor: colors.blue600 }}>
+      <button onClick={() => setFeed('NEW FEED')}>피드 열기</button>
+    </div>
+  );
+
+  const feedDetail = (
+    <div style={{ backgroundColor: colors.green600 }}>
+      <button onClick={() => setFeed(undefined)}>닫기</button>
+    </div>
+  );
+
   return (
-    <Container>
-      <ListSlot>
-        <button onClick={() => setFeed('asdf')}>SET FEED </button>
-        <button onClick={() => setFeed('')}>UNSET FEED </button>
-      </ListSlot>
-      <DetailSlot initial={{ width: 0 }} animate={{ width: feed !== '' ? 560 : 0 }} transition={{ bounce: 0 }}>
-        <DetailSlotInner>{feed}</DetailSlotInner>
-      </DetailSlot>
-    </Container>
+    <>
+      <Responsive only='desktop'>
+        <DesktopCommunityLayout isDetailOpen={feed !== ''} listSlot={feedList} detailSlot={feedDetail} />
+      </Responsive>
+      <Responsive only='mobile'>
+        <MobileCommunityLayout isDetailOpen={feed !== ''} listSlot={feedList} detailSlot={feedDetail} />
+      </Responsive>
+    </>
   );
 };
 
 export default CommunityPage;
-
-const Container = styled.div`
-  display: flex;
-  justify-content: center;
-  width: 100%;
-  height: ${layoutCSSVariable.contentAreaHeight};
-`;
-
-const ListSlot = styled.div`
-  flex: 1 1 0;
-  background-color: ${colors.green400};
-  max-width: 560px;
-  height: 100%;
-  overflow-y: scroll;
-`;
-
-const DetailSlot = styled(m.div)`
-  position: relative;
-  background-color: ${colors.blue500};
-  width: 100%;
-  max-width: 560px;
-  height: 100%;
-  overflow: hidden;
-`;
-
-const DetailSlotInner = styled.div`
-  position: absolute;
-  top: 0;
-  right: 0;
-  bottom: 0;
-  width: 560px;
-  min-width: 560px;
-  overflow-y: scroll;
-`;

--- a/src/components/community/queryParam.tsx
+++ b/src/components/community/queryParam.tsx
@@ -1,0 +1,46 @@
+import Link from 'next/link';
+import { useRouter } from 'next/router';
+import { ComponentPropsWithoutRef, forwardRef } from 'react';
+import { StringParam, useQueryParam, withDefault } from 'use-query-params';
+
+function createLinkComponent<T extends string>({ paramKey }: { paramKey: T }) {
+  type Key = {
+    [K in `${T}Id`]: string | undefined;
+  };
+
+  const ParamLink = forwardRef<
+    HTMLAnchorElement,
+    Omit<ComponentPropsWithoutRef<typeof Link>, 'href' | 'shallow'> & Key
+  >((props, ref) => {
+    const { pathname, query } = useRouter();
+
+    const value = props[`${paramKey}Id`] as string | undefined;
+
+    return (
+      <Link
+        ref={ref}
+        {...props}
+        href={{
+          pathname,
+          query: {
+            ...query,
+            [paramKey]: value,
+          },
+        }}
+        shallow
+      />
+    );
+  });
+
+  const useParam = () => {
+    return useQueryParam(paramKey, withDefault(StringParam, undefined));
+  };
+
+  return [ParamLink, useParam] as const;
+}
+
+export const [CategoryLink, useCategoryParam] = createLinkComponent({ paramKey: 'category' });
+
+export const [TagLink, useTagParam] = createLinkComponent({ paramKey: 'tag' });
+
+export const [FeedDetailLink, useFeedDetailParam] = createLinkComponent({ paramKey: 'feed' });

--- a/src/components/community/queryParam.tsx
+++ b/src/components/community/queryParam.tsx
@@ -3,6 +3,9 @@ import { useRouter } from 'next/router';
 import { ComponentPropsWithoutRef, forwardRef } from 'react';
 import { StringParam, useQueryParam, withDefault } from 'use-query-params';
 
+/**
+ * 쿼리 파라미터와 연동된 상태를 쉽게 만들 수 있게 해줍니다. paramKey가 쿼리 파라미터의 키가 됩니다.
+ */
 function createLinkComponent<T extends string>({ paramKey }: { paramKey: T }) {
   type Key = {
     [K in `${T}Id`]: string | undefined;

--- a/src/components/community/queryParam.tsx
+++ b/src/components/community/queryParam.tsx
@@ -13,13 +13,15 @@ function createLinkComponent<T extends string>({ paramKey }: { paramKey: T }) {
     Omit<ComponentPropsWithoutRef<typeof Link>, 'href' | 'shallow'> & Key
   >((props, ref) => {
     const { pathname, query } = useRouter();
-
     const value = props[`${paramKey}Id`] as string | undefined;
+
+    const newProps = { ...props };
+    delete newProps[`${paramKey}Id`];
 
     return (
       <Link
         ref={ref}
-        {...props}
+        {...newProps}
         href={{
           pathname,
           query: {
@@ -39,8 +41,8 @@ function createLinkComponent<T extends string>({ paramKey }: { paramKey: T }) {
   return [ParamLink, useParam] as const;
 }
 
-export const [CategoryLink, useCategoryParam] = createLinkComponent({ paramKey: 'category' });
-
 export const [TagLink, useTagParam] = createLinkComponent({ paramKey: 'tag' });
+
+export const [CategoryLink, useCategoryParam] = createLinkComponent({ paramKey: 'category' });
 
 export const [FeedDetailLink, useFeedDetailParam] = createLinkComponent({ paramKey: 'feed' });

--- a/src/components/layout/FullScreenLayout.tsx
+++ b/src/components/layout/FullScreenLayout.tsx
@@ -1,6 +1,8 @@
 import styled from '@emotion/styled';
 import { FC, ReactNode } from 'react';
 
+import { createLayoutCSSVariable } from '@/components/layout/utils';
+
 interface FullScreenLayoutProps {
   children: ReactNode;
 }
@@ -13,4 +15,6 @@ export default FullScreenLayout;
 
 const StyledFullScreenLayout = styled.div`
   height: 100vh;
+
+  ${createLayoutCSSVariable({ headerHeight: 0 })}
 `;

--- a/src/components/layout/HeaderFooterLayout.tsx
+++ b/src/components/layout/HeaderFooterLayout.tsx
@@ -5,6 +5,7 @@ import { RemoveScroll } from 'react-remove-scroll';
 import Footer from '@/components/common/Footer';
 import Header from '@/components/common/Header';
 import Responsive from '@/components/common/Responsive';
+import { createLayoutCSSVariable } from '@/components/layout/utils';
 import { MOBILE_MEDIA_QUERY } from '@/styles/mediaQuery';
 
 interface HeaderLayoutProps {
@@ -31,8 +32,12 @@ export default HeaderFooterLayout;
 const StyledContainer = styled.div`
   padding-top: 80px;
 
+  ${createLayoutCSSVariable({ headerHeight: 80 })}
+
   @media ${MOBILE_MEDIA_QUERY} {
     padding-top: 56px;
+
+    ${createLayoutCSSVariable({ headerHeight: 80 })}
   }
 `;
 

--- a/src/components/layout/HeaderLayout.tsx
+++ b/src/components/layout/HeaderLayout.tsx
@@ -3,6 +3,7 @@ import { FC, ReactNode } from 'react';
 import { RemoveScroll } from 'react-remove-scroll';
 
 import Header from '@/components/common/Header';
+import { createLayoutCSSVariable } from '@/components/layout/utils';
 import { MOBILE_MEDIA_QUERY } from '@/styles/mediaQuery';
 
 interface HeaderLayoutProps {
@@ -25,8 +26,12 @@ export default HeaderLayout;
 const StyledContainer = styled.div`
   padding-top: 80px;
 
+  ${createLayoutCSSVariable({ headerHeight: 80 })}
+
   @media ${MOBILE_MEDIA_QUERY} {
     padding-top: 56px;
+
+    ${createLayoutCSSVariable({ headerHeight: 56 })}
   }
 `;
 

--- a/src/components/layout/utils.ts
+++ b/src/components/layout/utils.ts
@@ -1,0 +1,22 @@
+interface CreateLayoutCSSVariableOptions {
+  headerHeight: number;
+  footerHeight?: number;
+}
+
+const layoutCSSVariableNames = {
+  globalHeaderHeight: '--global-header-height',
+  globalFooterHeight: '--global-footer-height',
+  contentAreaHeight: '--content-area-height',
+};
+
+export const layoutCSSVariable = Object.fromEntries(
+  Object.entries(layoutCSSVariableNames).map(([key, value]) => [key, `var(${value})`]),
+) as Record<keyof typeof layoutCSSVariableNames, string>;
+
+export function createLayoutCSSVariable({ headerHeight, footerHeight = 0 }: CreateLayoutCSSVariableOptions) {
+  return `
+    ${layoutCSSVariableNames.globalHeaderHeight}: ${headerHeight}px;
+    ${layoutCSSVariableNames.globalFooterHeight}: ${footerHeight}px;
+    ${layoutCSSVariableNames.contentAreaHeight}: calc(100vh - var(--global-header-height) - var(--global-footer-height));
+  `;
+}

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -7,9 +7,11 @@ import type { AppProps } from 'next/app';
 import dynamic from 'next/dynamic';
 import Head from 'next/head';
 import Router, { useRouter } from 'next/router';
+import NextAdapterPages from 'next-query-params/pages';
 import { NextSeo } from 'next-seo';
 import { useEffect } from 'react';
 import { RecoilRoot } from 'recoil';
+import { QueryParamProvider } from 'use-query-params';
 
 import ResponsiveProvider from '@/components/common/Responsive/ResponsiveProvider';
 import ToastProvider from '@/components/common/Toast/providers/ToastProvider';
@@ -57,21 +59,24 @@ function MyApp({ Component, pageProps }: AppProps) {
         <meta name='theme-color' media='(prefers-color-scheme: dark)' content={colors.gray400} />
       </Head>
       <GoogleTagManagerScript />
-      <RecoilRoot>
-        <AmplitudeProvider apiKey={AMPLITUDE_API_KEY}>
-          <LazyMotion features={() => import('framer-motion').then((mod) => mod.domAnimation)}>
-            <ToastProvider>
-              <GlobalStyle />
-              <ResponsiveProvider>
-                <Layout>
-                  <Component {...pageProps} />
-                </Layout>
-              </ResponsiveProvider>
-              {DEBUG && <Debugger />}
-            </ToastProvider>
-          </LazyMotion>
-        </AmplitudeProvider>
-      </RecoilRoot>
+
+      <QueryParamProvider adapter={NextAdapterPages}>
+        <RecoilRoot>
+          <AmplitudeProvider apiKey={AMPLITUDE_API_KEY}>
+            <LazyMotion features={() => import('framer-motion').then((mod) => mod.domAnimation)}>
+              <ToastProvider>
+                <GlobalStyle />
+                <ResponsiveProvider>
+                  <Layout>
+                    <Component {...pageProps} />
+                  </Layout>
+                </ResponsiveProvider>
+                {DEBUG && <Debugger />}
+              </ToastProvider>
+            </LazyMotion>
+          </AmplitudeProvider>
+        </RecoilRoot>
+      </QueryParamProvider>
       <ReactQueryDevtools initialIsOpen={false} />
     </QueryClientProvider>
   );

--- a/src/pages/community/index.tsx
+++ b/src/pages/community/index.tsx
@@ -1,0 +1,12 @@
+import { FC } from 'react';
+
+import CommunityPage from '@/components/community/page';
+import { setLayout } from '@/utils/layout';
+
+const Community: FC = () => {
+  return <CommunityPage />;
+};
+
+setLayout(Community, 'header');
+
+export default Community;

--- a/yarn.lock
+++ b/yarn.lock
@@ -15032,6 +15032,19 @@ __metadata:
   languageName: node
   linkType: hard
 
+"next-query-params@npm:^4.2.3":
+  version: 4.2.3
+  resolution: "next-query-params@npm:4.2.3"
+  dependencies:
+    tslib: ^2.0.3
+  peerDependencies:
+    next: ^10.0.0 || ^11.0.0 || ^12.0.0 || ^13.0.0
+    react: ^16.8.0 || ^17.0.0 || ^18.0.0
+    use-query-params: ^2.0.0
+  checksum: 19495b4cac190f8dc3b43e241930e82af7bc2aa88a47fbcf78b5ec654954ddcd14994dff6362734b619d0385ddbaa8309ccc60b6e2f13ea897c2f119f239cc27
+  languageName: node
+  linkType: hard
+
 "next-seo@npm:^6.1.0":
   version: 6.1.0
   resolution: "next-seo@npm:6.1.0"
@@ -17468,6 +17481,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"serialize-query-params@npm:^2.0.2":
+  version: 2.0.2
+  resolution: "serialize-query-params@npm:2.0.2"
+  checksum: 6dccdbd68cbec44c99599c4f77968e8685a74cc597f473ed93b15a8d03c3a67f50c958af9af3d186e64aabd7f98b59d674a05aa4e69d997ed86a5478cf133b27
+  languageName: node
+  linkType: hard
+
 "serve-favicon@npm:^2.5.0":
   version: 2.5.0
   resolution: "serve-favicon@npm:2.5.0"
@@ -17755,6 +17775,7 @@ __metadata:
     msw-storybook-addon: ^1.8.0
     nanoid: ^4.0.0
     next: ^13.1.1
+    next-query-params: ^4.2.3
     next-seo: ^6.1.0
     postcss-html: ^1.4.1
     postcss-syntax: ^0.36.2
@@ -17782,6 +17803,7 @@ __metadata:
     tsup: ^7.1.0
     typescript: ^4.9.5
     url-loader: ^4.1.1
+    use-query-params: ^2.2.1
     webpack: ^5.72.0
     yup: ^1.0.0
     zod: ^3.20.6
@@ -19464,6 +19486,25 @@ __metadata:
     "@types/react":
       optional: true
   checksum: a6532f7fc9ae222c3725ff0308aaf1f1ddbd3c00d685ef9eee6714fd0684de5cb9741b432fbf51e61a784e2955424864f7ea9f99734a02f237b17ad3e18ea5cb
+  languageName: node
+  linkType: hard
+
+"use-query-params@npm:^2.2.1":
+  version: 2.2.1
+  resolution: "use-query-params@npm:2.2.1"
+  dependencies:
+    serialize-query-params: ^2.0.2
+  peerDependencies:
+    "@reach/router": ^1.2.1
+    react: ">=16.8.0"
+    react-dom: ">=16.8.0"
+    react-router-dom: ">=5"
+  peerDependenciesMeta:
+    "@reach/router":
+      optional: true
+    react-router-dom:
+      optional: true
+  checksum: 5bf16511a561cf09902c3526950c6c88999767a1990619a322685448abbd09f5d71a17289d0f727bb3e68d5baced36b3fc0bbf855664b3dd5046d5d553204d28
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### 🤫 쉿, 나한테만 말해줘요. 이슈넘버


### 🧐 어떤 것을 변경했어요~?
<!-- 실제로 변경한 사항을 설명해주세요.-->

커뮤니티 페이지의 기본 레이아웃을 구현했습니다.

쿼리 파라미터와 연동되는 상태와, 그 상태에 기반해 상세보기를 여는 기능을 구현했습니다.

### 🤔 그렇다면, 어떻게 구현했어요~?
<!-- 실제로 구현한 로직에 대해 설명해주세요.-->

### ❤️‍🔥 당신이 생각하는 PR포인트, 내겐 매력포인트.
<!-- 해당 PR에서 논의가 필요한 사항을 적어주세요. -->

### 📸 스크린샷, 없으면 이것 참,, 섭섭한데요?


https://github.com/sopt-makers/sopt-playground-frontend/assets/36122585/260a726f-bfe4-4f38-a1d2-4ccb86fa2ec3


https://github.com/sopt-makers/sopt-playground-frontend/assets/36122585/93249649-2f28-421c-91e0-8648aab2fcf5

