### PR TITLE
feat: 모바일에서 input focus 시 화면이 확대되는 현상 막기

### DIFF
--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -44,6 +44,26 @@ function MyApp({ Component, pageProps }: AppProps) {
     };
   }, [router.events]);
 
+  useEffect(() => {
+    const isMobile = /iPhone|iPad|iPod|Android/i.test(navigator.userAgent);
+    const $existingMeta = document.querySelector('meta[name="viewport"]');
+
+    /** 모바일 환경에서 input focus 시 화면이 확대되는 현상을 막아요 */
+    if (isMobile) {
+      const $meta = $existingMeta ?? document.createElement('meta');
+
+      $meta.setAttribute('name', 'viewport');
+      $meta.setAttribute(
+        'content',
+        'width=device-width, user-scalable=no, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0',
+      );
+
+      if (!$existingMeta) {
+        document.head.appendChild($meta);
+      }
+    }
+  }, []);
+
   return (
     <QueryClientProvider client={queryClient}>
       <NextSeo


### PR DESCRIPTION
### 🧐 어떤 것을 변경했어요~?
<!-- 실제로 변경한 사항을 설명해주세요.-->
- 모바일 브라우저에선 input에 focus 시 글자 크기나 위치에 따라 화면을 알아서 확대해주는게 있어요. 이게 웹 접근성이긴 하지만 디자이너의 의도와 다른 경우가 많고 예측하기 어렵다보니 UX를 해치는 경우가 더 많아요. (ex. 아래 이미지처럼 채팅 전송 버튼이 가려짐)
- 따라서 모바일 환경에서는 input focus 시 화면 확대가 되지 않도록 작업해줬어요.

<img width="360px" src="https://github.com/sopt-makers/sopt-playground-frontend/assets/28650320/b72aca8c-7d20-4bd1-9f7c-8e6cf547cf63" />

### 🤔 그렇다면, 어떻게 구현했어요~?
<!-- 실제로 구현한 로직에 대해 설명해주세요.-->
- 이게 유저가 직접 화면을 확대/축소하는 것을 제한할 수 있어요. (아이폰, 맥북에선 확대/축소되고, 안드로이드 일부화면에서 확대/축소가 안되는 것 확인 with @Tekiter) 대부분 문제가 없을 것으로 생각되지만 안전하게 모바일 환경에만 주입해줬어요.
- Next.js에서 `<meta name="viewport" content="width=device-width">`를 기본으로 넣어주기 때문에, 이미 viewport meta 태그가 있으면 `attribute`를 추가해주도록 처리했어요.
- @Tekiter 가 플그 클라이언트에서 `isMobile` 사용을 지양한다고 해서, 공통 변수로 두진 않았어요.