### PR TITLE
fix: 피드 상세 카드 및 모바일 몇몇 수정

### DIFF
--- a/src/components/feed/detail/DetailFeedCard.stories.tsx
+++ b/src/components/feed/detail/DetailFeedCard.stories.tsx
@@ -82,7 +82,14 @@ export const Default = () => {
 
   return (
     <DetailFeedCard>
-      <DetailFeedCard.Header category='파트' tag='기획' />
+      <DetailFeedCard.Header
+        left={
+          <>
+            <DetailFeedCard.Icon name='chevronLeft' />
+            <DetailFeedCard.Chip category='파트' tag='기획' />
+          </>
+        }
+      />
       <DetailFeedCard.Body>
         <DetailFeedCard.Main>
           <DetailFeedCard.Top

--- a/src/components/feed/detail/DetailFeedCard.tsx
+++ b/src/components/feed/detail/DetailFeedCard.tsx
@@ -2,7 +2,7 @@ import styled from '@emotion/styled';
 import { colors } from '@sopt-makers/colors';
 import { Flex, Stack } from '@toss/emotion-utils';
 import { m } from 'framer-motion';
-import { forwardRef, PropsWithChildren, ReactNode, useEffect, useRef, useState } from 'react';
+import { forwardRef, HTMLAttributes, PropsWithChildren, ReactNode, useEffect, useRef, useState } from 'react';
 
 import Checkbox from '@/components/common/Checkbox';
 import Text from '@/components/common/Text';
@@ -32,23 +32,14 @@ const StyledBase = styled(Flex)`
 `;
 
 interface HeaderProps {
-  category: string;
-  tag: string;
   left?: ReactNode;
   right?: ReactNode;
 }
 
-const Header = ({ category, tag, left, right }: HeaderProps) => {
+const Header = ({ left, right }: HeaderProps) => {
   return (
     <StyledHeader align='center' justify='space-between' as='header'>
-      <Flex.Center css={{ gap: 8 }}>
-        {left}
-        <Chip align='center' as='button'>
-          <Text typography='SUIT_13_M'>{category}</Text>
-          <IconChevronRight />
-          <Text typography='SUIT_13_M'>{tag}</Text>
-        </Chip>
-      </Flex.Center>
+      <Flex.Center css={{ gap: 8 }}>{left}</Flex.Center>
       {right ? <Flex.Center css={{ gap: 8 }}>{right}</Flex.Center> : null}
     </StyledHeader>
   );
@@ -62,7 +53,21 @@ const StyledHeader = styled(Flex)`
   }
 `;
 
-const Chip = styled(Flex)`
+interface ChipProps extends HTMLAttributes<HTMLDivElement> {
+  category: string;
+  tag: string;
+}
+const Chip = ({ category, tag, ...props }: ChipProps) => {
+  return (
+    <StyledChip as='button' {...props}>
+      <Text typography='SUIT_13_M'>{category}</Text>
+      <IconChevronRight />
+      <Text typography='SUIT_13_M'>{tag}</Text>
+    </StyledChip>
+  );
+};
+
+const StyledChip = styled(Flex)`
   transition: background-color 0.2s ease-in-out;
   border-radius: 21px;
   background-color: ${colors.gray800};
@@ -426,4 +431,5 @@ export default Object.assign(Base, {
   Comment,
   Input,
   Icon,
+  Chip,
 });

--- a/src/components/feed/detail/FeedDetail.tsx
+++ b/src/components/feed/detail/FeedDetail.tsx
@@ -1,3 +1,6 @@
+import { QS } from '@toss/utils';
+import Link from 'next/link';
+import { playgroundLink } from 'playground-common/export';
 import React, { useRef, useState } from 'react';
 
 import { useGetCommentQuery } from '@/api/endpoint/feed/getComment';
@@ -6,20 +9,21 @@ import { usePostCommentMutation } from '@/api/endpoint/feed/postComment';
 import { useGetMemberOfMe } from '@/api/endpoint/members/getMemberOfMe';
 import useAlert from '@/components/common/Modal/useAlert';
 import useConfirm from '@/components/common/Modal/useConfirm';
+import Responsive from '@/components/common/Responsive';
 import useToast from '@/components/common/Toast/useToast';
 import FeedDropdown from '@/components/feed/common/FeedDropdown';
 import { useDeleteComment } from '@/components/feed/common/hooks/useDeleteComment';
 import { useDeleteFeed } from '@/components/feed/common/hooks/useDeleteFeed';
 import { useShareFeed } from '@/components/feed/common/hooks/useShareFeed';
-import { FeedDetailLink } from '@/components/feed/common/queryParam';
 import { getMemberInfo } from '@/components/feed/common/utils';
 import DetailFeedCard from '@/components/feed/detail/DetailFeedCard';
 
 interface FeedDetailProps {
-  postId: string;
+  feedId: string;
+  isDetailPage?: boolean;
 }
 
-const FeedDetail = ({ postId }: FeedDetailProps) => {
+const FeedDetail = ({ feedId }: FeedDetailProps) => {
   const [value, setValue] = useState<string>('');
   const [isBlindWriter, setIsBlindWriter] = useState<boolean>(false);
   const toast = useToast();
@@ -29,9 +33,9 @@ const FeedDetail = ({ postId }: FeedDetailProps) => {
   const { handleDeleteComment } = useDeleteComment();
   const { handleDeleteFeed } = useDeleteFeed();
   const { data: meData } = useGetMemberOfMe();
-  const { data: postData } = useGetPostQuery(postId);
-  const { data: commentData, refetch: refetchCommentQuery } = useGetCommentQuery(postId);
-  const { mutate: postComment } = usePostCommentMutation(postId);
+  const { data: postData } = useGetPostQuery(feedId);
+  const { data: commentData, refetch: refetchCommentQuery } = useGetCommentQuery(feedId);
+  const { mutate: postComment } = usePostCommentMutation(feedId);
   const containerRef = useRef<HTMLDivElement>(null);
 
   const is내글여부 = meData?.id === postData?.member.id;
@@ -84,18 +88,28 @@ const FeedDetail = ({ postId }: FeedDetailProps) => {
 
   return (
     <DetailFeedCard>
-      {/* TODO: 하드코딩 제거 */}
       <DetailFeedCard.Header
-        category='저는 하드코딩 되어있습니다 ㅎㅎㅎ'
-        tag='태그좀 넣어주세요 감사합니당 ㅎㅎ'
         left={
-          <FeedDetailLink feedId={undefined}>
-            <DetailFeedCard.Icon name='chevronLeft' />
-          </FeedDetailLink>
+          <>
+            <Responsive only='desktop' asChild>
+              <Link href={`${playgroundLink.feedList()}${QS.create({ feed: feedId })}`}>
+                <DetailFeedCard.Icon name='chevronLeft' />
+              </Link>
+            </Responsive>
+            <Responsive only='mobile' asChild>
+              <Link href={playgroundLink.feedList()}>
+                <DetailFeedCard.Icon name='chevronLeft' />
+              </Link>
+            </Responsive>
+            {/* TODO: 하드코딩 제거 */}
+            <Link href={playgroundLink.feedList()}>
+              <DetailFeedCard.Chip category='하드코딩카테고리' tag='하드코딩태그' />
+            </Link>
+          </>
         }
         right={
           <>
-            <button onClick={() => handleShareFeed(postId)}>
+            <button onClick={() => handleShareFeed(feedId)}>
               <DetailFeedCard.Icon name='share' />
             </button>
             <FeedDropdown
@@ -111,7 +125,7 @@ const FeedDetail = ({ postId }: FeedDetailProps) => {
                 </FeedDropdown.Item>
               ) : null}
               {is내글여부 ? (
-                <FeedDropdown.Item type='danger' onClick={() => handleDeleteFeed({ postId })}>
+                <FeedDropdown.Item type='danger' onClick={() => handleDeleteFeed({ postId: feedId })}>
                   삭제
                 </FeedDropdown.Item>
               ) : null}

--- a/src/components/feed/detail/FeedDetail.tsx
+++ b/src/components/feed/detail/FeedDetail.tsx
@@ -15,15 +15,17 @@ import FeedDropdown from '@/components/feed/common/FeedDropdown';
 import { useDeleteComment } from '@/components/feed/common/hooks/useDeleteComment';
 import { useDeleteFeed } from '@/components/feed/common/hooks/useDeleteFeed';
 import { useShareFeed } from '@/components/feed/common/hooks/useShareFeed';
+import { FeedDetailLink } from '@/components/feed/common/queryParam';
 import { getMemberInfo } from '@/components/feed/common/utils';
 import DetailFeedCard from '@/components/feed/detail/DetailFeedCard';
+import { SwitchCase } from '@/utils/components/switch-case/SwitchCase';
 
 interface FeedDetailProps {
   feedId: string;
-  isDetailPage?: boolean;
+  mode?: 'detail' | 'list';
 }
 
-const FeedDetail = ({ feedId }: FeedDetailProps) => {
+const FeedDetail = ({ mode = 'list', feedId }: FeedDetailProps) => {
   const [value, setValue] = useState<string>('');
   const [isBlindWriter, setIsBlindWriter] = useState<boolean>(false);
   const toast = useToast();
@@ -92,9 +94,21 @@ const FeedDetail = ({ feedId }: FeedDetailProps) => {
         left={
           <>
             <Responsive only='desktop' asChild>
-              <Link href={`${playgroundLink.feedList()}${QS.create({ feed: feedId })}`}>
-                <DetailFeedCard.Icon name='chevronLeft' />
-              </Link>
+              <SwitchCase
+                value={mode}
+                caseBy={{
+                  detail: (
+                    <Link href={`${playgroundLink.feedList()}${QS.create({ feed: feedId })}`}>
+                      <DetailFeedCard.Icon name='chevronLeft' />
+                    </Link>
+                  ),
+                  list: (
+                    <FeedDetailLink feedId={undefined}>
+                      <DetailFeedCard.Icon name='chevronLeft' />
+                    </FeedDetailLink>
+                  ),
+                }}
+              />
             </Responsive>
             <Responsive only='mobile' asChild>
               <Link href={playgroundLink.feedList()}>

--- a/src/components/feed/list/FeedCard.tsx
+++ b/src/components/feed/list/FeedCard.tsx
@@ -176,12 +176,13 @@ const StyledComment = styled(Flex)`
 interface CommentItemProps {
   name: string;
   comment: string;
+  isBlindWriter?: boolean;
 }
 
-const CommentItem = ({ name, comment }: CommentItemProps) => {
+const CommentItem = ({ name, comment, isBlindWriter = false }: CommentItemProps) => {
   return (
     <StyledCommentItem>
-      <Text color={colors.gray10}>{name}</Text>
+      <Text color={colors.gray10}>{isBlindWriter ? '익명' : name}</Text>
       <Text color={colors.gray300}>{comment}</Text>
     </StyledCommentItem>
   );

--- a/src/components/feed/list/FeedList.tsx
+++ b/src/components/feed/list/FeedList.tsx
@@ -113,7 +113,12 @@ const FeedList: FC<FeedListProps> = ({}) => {
                 </FeedCard.Image>
                 <FeedCard.Comment>
                   {post.comments.map((comment) => (
-                    <FeedCard.CommentItem key={comment.id} comment={comment.content} name={comment.member.name} />
+                    <FeedCard.CommentItem
+                      key={comment.id}
+                      comment={comment.content}
+                      name={comment.member.name}
+                      isBlindWriter={comment.isBlindWriter}
+                    />
                   ))}
                 </FeedCard.Comment>
               </FeedCard>

--- a/src/components/feed/list/FeedList.tsx
+++ b/src/components/feed/list/FeedList.tsx
@@ -1,12 +1,15 @@
 import styled from '@emotion/styled';
 import { colors } from '@sopt-makers/colors';
 import { useQuery } from '@tanstack/react-query';
+import Link from 'next/link';
+import { playgroundLink } from 'playground-common/export';
 import { FC } from 'react';
 import { Virtuoso } from 'react-virtuoso';
 
 import { getCategory } from '@/api/endpoint/feed/getCategory';
 import { useGetPostsInfiniteQuery } from '@/api/endpoint/feed/getPosts';
 import { useGetMemberOfMe } from '@/api/endpoint/members/getMemberOfMe';
+import Responsive from '@/components/common/Responsive';
 import FeedDropdown from '@/components/feed/common/FeedDropdown';
 import { useDeleteFeed } from '@/components/feed/common/hooks/useDeleteFeed';
 import { useShareFeed } from '@/components/feed/common/hooks/useShareFeed';
@@ -51,78 +54,156 @@ const FeedList: FC<FeedListProps> = ({}) => {
         itemContent={(_, post) => {
           const is내글여부 = post.writerId === meData?.id;
           return (
-            <FeedDetailLink css={{ width: '100%' }} feedId={`${post.id}`}>
-              <FeedCard
-                name={post.member.name}
-                title={post.title}
-                content={post.content}
-                profileImage={post.member.profileImage}
-                createdAt={post.createdAt}
-                commentLength={post.commentCount}
-                hits={post.hits}
-                isBlindWriter={post.isBlindWriter}
-                isQuestion={post.isQuestion}
-                info={getMemberInfo({
-                  categoryId: post.categoryId,
-                  categoryName: post.categoryName,
-                  member: {
-                    activity: post.member.activity,
-                    careers: post.member.careers,
-                  },
-                })}
-                rightIcon={
-                  <FeedDropdown
-                    trigger={
-                      <button>
-                        <FeedCard.Icon name='moreHorizon' />
-                      </button>
+            <>
+              <Responsive only='desktop'>
+                <FeedDetailLink css={{ width: '100%' }} feedId={`${post.id}`}>
+                  <FeedCard
+                    name={post.member.name}
+                    title={post.title}
+                    content={post.content}
+                    profileImage={post.member.profileImage}
+                    createdAt={post.createdAt}
+                    commentLength={post.commentCount}
+                    hits={post.hits}
+                    isBlindWriter={post.isBlindWriter}
+                    isQuestion={post.isQuestion}
+                    info={getMemberInfo({
+                      categoryId: post.categoryId,
+                      categoryName: post.categoryName,
+                      member: {
+                        activity: post.member.activity,
+                        careers: post.member.careers,
+                      },
+                    })}
+                    rightIcon={
+                      <FeedDropdown
+                        trigger={
+                          <button>
+                            <FeedCard.Icon name='moreHorizon' />
+                          </button>
+                        }
+                      >
+                        {is내글여부 ? <FeedDropdown.Item>수정</FeedDropdown.Item> : null}
+                        <FeedDropdown.Item
+                          onClick={(e) => {
+                            e.stopPropagation();
+                            handleShareFeed(`${post.id}`);
+                          }}
+                        >
+                          공유
+                        </FeedDropdown.Item>
+                        {is내글여부 ? (
+                          <FeedDropdown.Item
+                            onClick={(e) => {
+                              e.stopPropagation();
+                              handleDeleteFeed({
+                                postId: `${post.id}`,
+                                onSuccess: () => {
+                                  refetch();
+                                },
+                              });
+                            }}
+                          >
+                            삭제
+                          </FeedDropdown.Item>
+                        ) : null}
+                        <FeedDropdown.Item>신고</FeedDropdown.Item>
+                      </FeedDropdown>
                     }
                   >
-                    {is내글여부 ? <FeedDropdown.Item>수정</FeedDropdown.Item> : null}
-                    <FeedDropdown.Item
-                      onClick={(e) => {
-                        e.stopPropagation();
-                        handleShareFeed(`${post.id}`);
-                      }}
-                    >
-                      공유
-                    </FeedDropdown.Item>
-                    {is내글여부 ? (
-                      <FeedDropdown.Item
-                        onClick={(e) => {
-                          e.stopPropagation();
-                          handleDeleteFeed({
-                            postId: `${post.id}`,
-                            onSuccess: () => {
-                              refetch();
-                            },
-                          });
-                        }}
+                    <FeedCard.Image>
+                      {post.images.map((image, index) => (
+                        <FeedCard.ImageItem key={`${image}-${index}`} src={image} />
+                      ))}
+                    </FeedCard.Image>
+                    <FeedCard.Comment>
+                      {post.comments.map((comment) => (
+                        <FeedCard.CommentItem
+                          key={comment.id}
+                          comment={comment.content}
+                          name={comment.member.name}
+                          isBlindWriter={comment.isBlindWriter}
+                        />
+                      ))}
+                    </FeedCard.Comment>
+                  </FeedCard>
+                </FeedDetailLink>
+              </Responsive>
+              <Responsive only='mobile'>
+                <Link href={playgroundLink.feedDetail(post.id)}>
+                  <FeedCard
+                    name={post.member.name}
+                    title={post.title}
+                    content={post.content}
+                    profileImage={post.member.profileImage}
+                    createdAt={post.createdAt}
+                    commentLength={post.commentCount}
+                    hits={post.hits}
+                    isBlindWriter={post.isBlindWriter}
+                    isQuestion={post.isQuestion}
+                    info={getMemberInfo({
+                      categoryId: post.categoryId,
+                      categoryName: post.categoryName,
+                      member: {
+                        activity: post.member.activity,
+                        careers: post.member.careers,
+                      },
+                    })}
+                    rightIcon={
+                      <FeedDropdown
+                        trigger={
+                          <button>
+                            <FeedCard.Icon name='moreHorizon' />
+                          </button>
+                        }
                       >
-                        삭제
-                      </FeedDropdown.Item>
-                    ) : null}
-                    <FeedDropdown.Item>신고</FeedDropdown.Item>
-                  </FeedDropdown>
-                }
-              >
-                <FeedCard.Image>
-                  {post.images.map((image, index) => (
-                    <FeedCard.ImageItem key={`${image}-${index}`} src={image} />
-                  ))}
-                </FeedCard.Image>
-                <FeedCard.Comment>
-                  {post.comments.map((comment) => (
-                    <FeedCard.CommentItem
-                      key={comment.id}
-                      comment={comment.content}
-                      name={comment.member.name}
-                      isBlindWriter={comment.isBlindWriter}
-                    />
-                  ))}
-                </FeedCard.Comment>
-              </FeedCard>
-            </FeedDetailLink>
+                        {is내글여부 ? <FeedDropdown.Item>수정</FeedDropdown.Item> : null}
+                        <FeedDropdown.Item
+                          onClick={(e) => {
+                            e.stopPropagation();
+                            handleShareFeed(`${post.id}`);
+                          }}
+                        >
+                          공유
+                        </FeedDropdown.Item>
+                        {is내글여부 ? (
+                          <FeedDropdown.Item
+                            onClick={(e) => {
+                              e.stopPropagation();
+                              handleDeleteFeed({
+                                postId: `${post.id}`,
+                                onSuccess: () => {
+                                  refetch();
+                                },
+                              });
+                            }}
+                          >
+                            삭제
+                          </FeedDropdown.Item>
+                        ) : null}
+                        <FeedDropdown.Item>신고</FeedDropdown.Item>
+                      </FeedDropdown>
+                    }
+                  >
+                    <FeedCard.Image>
+                      {post.images.map((image, index) => (
+                        <FeedCard.ImageItem key={`${image}-${index}`} src={image} />
+                      ))}
+                    </FeedCard.Image>
+                    <FeedCard.Comment>
+                      {post.comments.map((comment) => (
+                        <FeedCard.CommentItem
+                          key={comment.id}
+                          comment={comment.content}
+                          name={comment.member.name}
+                          isBlindWriter={comment.isBlindWriter}
+                        />
+                      ))}
+                    </FeedCard.Comment>
+                  </FeedCard>
+                </Link>
+              </Responsive>
+            </>
           );
         }}
       />

--- a/src/components/feed/page/FeedHomePage.tsx
+++ b/src/components/feed/page/FeedHomePage.tsx
@@ -8,9 +8,9 @@ import DesktopCommunityLayout from '@/components/feed/page/layout/DesktopCommuni
 import MobileCommunityLayout from '@/components/feed/page/layout/MobileCommunityLayout';
 
 const CommunityPage: FC = () => {
-  const [postId] = useFeedDetailParam();
+  const [feedId] = useFeedDetailParam();
 
-  const isDetailOpen = postId != null && postId !== '';
+  const isDetailOpen = feedId != null && feedId !== '';
 
   return (
     <>
@@ -18,14 +18,14 @@ const CommunityPage: FC = () => {
         <DesktopCommunityLayout
           isDetailOpen={isDetailOpen}
           listSlot={<FeedList />}
-          detailSlot={postId ? <FeedDetail postId={postId} /> : null}
+          detailSlot={feedId ? <FeedDetail feedId={feedId} /> : null}
         />
       </Responsive>
       <Responsive only='mobile'>
         <MobileCommunityLayout
           isDetailOpen={isDetailOpen}
           listSlot={<FeedList />}
-          detailSlot={postId ? <FeedDetail postId={postId} /> : null}
+          detailSlot={feedId ? <FeedDetail feedId={feedId} /> : null}
         />
       </Responsive>
     </>

--- a/src/constants/links.ts
+++ b/src/constants/links.ts
@@ -26,6 +26,7 @@ export const playgroundLink = {
   sopticleSuccess: () => `/sopticle/success`,
   mentoringDetail: (id: number) => `/mentoring/${id}`,
   wordchain: () => `/wordchain`,
-  feedList: () => `/feed`,
+  // TODO: 경로 '/' 로 배포 이전에 수정 필요
+  feedList: () => `/community`,
   feedDetail: (id: string | number) => `/feed/${id}`,
 };

--- a/src/pages/feed/[id].tsx
+++ b/src/pages/feed/[id].tsx
@@ -4,6 +4,7 @@ import AuthRequired from '@/components/auth/AuthRequired';
 import FeedDetail from '@/components/feed/detail/FeedDetail';
 import { layoutCSSVariable } from '@/components/layout/utils';
 import useStringRouterQuery from '@/hooks/useStringRouterQuery';
+import { MOBILE_MEDIA_QUERY } from '@/styles/mediaQuery';
 import { setLayout } from '@/utils/layout';
 
 const FeedDetailPage = () => {
@@ -16,7 +17,7 @@ const FeedDetailPage = () => {
         <Container>
           <DetailSlot>
             {/* TODO: 링크 바뀌면 뒤로가기 시 링크 반영 */}
-            <FeedDetail postId={query.id} />
+            <FeedDetail feedId={query.id} />
           </DetailSlot>
         </Container>
       ) : null}
@@ -30,11 +31,15 @@ export default FeedDetailPage;
 
 const Container = styled.div`
   display: flex;
-  flex-basis: 560px;
   justify-content: center;
-  width: 100%;
 `;
 
 const DetailSlot = styled.div`
+  min-width: 560px;
   height: ${layoutCSSVariable.contentAreaHeight};
+
+  @media ${MOBILE_MEDIA_QUERY} {
+    width: 100%;
+    min-width: auto;
+  }
 `;

--- a/src/pages/feed/[id].tsx
+++ b/src/pages/feed/[id].tsx
@@ -16,8 +16,7 @@ const FeedDetailPage = () => {
       {status === 'success' ? (
         <Container>
           <DetailSlot>
-            {/* TODO: 링크 바뀌면 뒤로가기 시 링크 반영 */}
-            <FeedDetail feedId={query.id} />
+            <FeedDetail feedId={query.id} mode='detail' />
           </DetailSlot>
         </Container>
       ) : null}


### PR DESCRIPTION
### 🤫 쉿, 나한테만 말해줘요. 이슈넘버
- close #1104

### 🧐 어떤 것을 변경했어요~?
<!-- 실제로 변경한 사항을 설명해주세요.-->
- 상세 피드 카드의 Chip에 링크를 달아줘야 해서 바깥에서 조합해서 쓸 수 있는 형태로 변경
- 뒤로가기 아이콘을 눌렀을 때 모바일 / 데탑 별로 이동하는 링크가 달라서 이를 Responsive로 대응 => [정책 쓰레드](https://sopt-makers.slack.com/archives/C04326AHDRT/p1700406661390089)
- 모바일에선 리스트의 카드를 클릭하면 열리는게 아니라 상세페이지로 이동해야 해서 이를 Responsive로 대응

### 🤔 그렇다면, 어떻게 구현했어요~?
<!-- 실제로 구현한 로직에 대해 설명해주세요.-->

### ❤️‍🔥 당신이 생각하는 PR포인트, 내겐 매력포인트.
<!-- 해당 PR에서 논의가 필요한 사항을 적어주세요. -->

### 📸 스크린샷, 없으면 이것 참,, 섭섭한데요?
