### PR TITLE
feat: 피드 업로드 디테일 수정

### DIFF
--- a/src/components/common/BottomSheet/index.tsx
+++ b/src/components/common/BottomSheet/index.tsx
@@ -23,7 +23,7 @@ export const BottomSheet: FC<BottomSheetProps> = (props) => {
 };
 
 const CustomSheet = styled(Sheet)`
-  margin: 0 16px 42px;
+  margin: 0 16px 8px;
 
   .react-modal-sheet-backdrop {
     display: flex;

--- a/src/components/feed/page/FeedUploadPage.tsx
+++ b/src/components/feed/page/FeedUploadPage.tsx
@@ -55,11 +55,11 @@ export default function FeedUploadPage() {
     }
   };
 
-  const DesktopContentsRef = useRef<HTMLTextAreaElement>(null);
+  const desktopContentsRef = useRef<HTMLTextAreaElement>(null);
   const handleDesktopKeyPressToContents = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
     if (e.key === 'Enter' && !e.nativeEvent.isComposing) {
       e.preventDefault();
-      DesktopContentsRef.current && DesktopContentsRef.current.focus();
+      desktopContentsRef.current && desktopContentsRef.current.focus();
     }
   };
 
@@ -115,8 +115,12 @@ export default function FeedUploadPage() {
           }
           body={
             <>
-              <TitleInput onChange={handleSaveTitle} onKeyDown={handleDesktopKeyPressToContents} />
-              <ContentsInput onChange={handleSaveContent} ref={DesktopContentsRef} />
+              <TitleInput
+                onChange={handleSaveTitle}
+                onKeyDown={handleDesktopKeyPressToContents}
+                value={feedData.title}
+              />
+              <ContentsInput onChange={handleSaveContent} ref={desktopContentsRef} />
             </>
           }
           footer={
@@ -184,7 +188,11 @@ export default function FeedUploadPage() {
                   />
                 </CheckboxFormItem>
               </CheckBoxesWrapper>
-              <TitleInput onChange={handleSaveTitle} onKeyDown={handleMobileKeyPressToContents} />
+              <TitleInput
+                onChange={handleSaveTitle}
+                onKeyDown={handleDesktopKeyPressToContents}
+                value={feedData.title}
+              />
               <ContentsInput onChange={handleSaveContent} ref={mobileContentsRef} />
               <ImagePreview images={feedData.images} onRemove={removeImage} />
               <TagsWrapper>

--- a/src/components/feed/page/FeedUploadPage.tsx
+++ b/src/components/feed/page/FeedUploadPage.tsx
@@ -1,7 +1,7 @@
 import { css } from '@emotion/react';
 import styled from '@emotion/styled';
 import { colors } from '@sopt-makers/colors';
-import { FormEvent } from 'react';
+import { FormEvent, useRef } from 'react';
 
 import { useSaveUploadFeedData } from '@/api/endpoint/feed/uploadFeed';
 import Checkbox from '@/components/common/Checkbox';
@@ -47,6 +47,21 @@ export default function FeedUploadPage() {
     isBlindWriter: false,
     images: [],
   });
+  const mobileContentsRef = useRef<HTMLTextAreaElement>(null);
+  const handleMobileKeyPressToContents = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
+    if (e.key === 'Enter' && e.nativeEvent.isComposing === false) {
+      e.preventDefault();
+      mobileContentsRef.current && mobileContentsRef.current.focus();
+    }
+  };
+
+  const DesktopContentsRef = useRef<HTMLTextAreaElement>(null);
+  const handleDesktopKeyPressToContents = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
+    if (e.key === 'Enter' && e.nativeEvent.isComposing === false) {
+      e.preventDefault();
+      DesktopContentsRef.current && DesktopContentsRef.current.focus();
+    }
+  };
 
   const { imageInputRef: desktopRef, handleClickImageInput: handleDesktopClickImageInput } =
     useImageUploader(saveImageUrls);
@@ -100,8 +115,8 @@ export default function FeedUploadPage() {
           }
           body={
             <>
-              <TitleInput onChange={handleSaveTitle} />
-              <ContentsInput onChange={handleSaveContent} />
+              <TitleInput onChange={handleSaveTitle} onKeyDown={handleDesktopKeyPressToContents} />
+              <ContentsInput onChange={handleSaveContent} ref={DesktopContentsRef} />
             </>
           }
           footer={
@@ -169,8 +184,8 @@ export default function FeedUploadPage() {
                   />
                 </CheckboxFormItem>
               </CheckBoxesWrapper>
-              <TitleInput onChange={handleSaveTitle} />
-              <ContentsInput onChange={handleSaveContent} />
+              <TitleInput onChange={handleSaveTitle} onKeyDown={handleMobileKeyPressToContents} />
+              <ContentsInput onChange={handleSaveContent} ref={mobileContentsRef} />
               <ImagePreview images={feedData.images} onRemove={removeImage} />
               <TagsWrapper>
                 <ImageUploadButton

--- a/src/components/feed/page/FeedUploadPage.tsx
+++ b/src/components/feed/page/FeedUploadPage.tsx
@@ -49,7 +49,7 @@ export default function FeedUploadPage() {
   });
   const mobileContentsRef = useRef<HTMLTextAreaElement>(null);
   const handleMobileKeyPressToContents = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
-    if (e.key === 'Enter' && e.nativeEvent.isComposing === false) {
+    if (e.key === 'Enter' && !e.nativeEvent.isComposing) {
       e.preventDefault();
       mobileContentsRef.current && mobileContentsRef.current.focus();
     }
@@ -57,7 +57,7 @@ export default function FeedUploadPage() {
 
   const DesktopContentsRef = useRef<HTMLTextAreaElement>(null);
   const handleDesktopKeyPressToContents = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
-    if (e.key === 'Enter' && e.nativeEvent.isComposing === false) {
+    if (e.key === 'Enter' && !e.nativeEvent.isComposing) {
       e.preventDefault();
       DesktopContentsRef.current && DesktopContentsRef.current.focus();
     }

--- a/src/components/feed/upload/CodeUploadButton/index.tsx
+++ b/src/components/feed/upload/CodeUploadButton/index.tsx
@@ -7,6 +7,7 @@ import Modal from '@/components/common/Modal';
 import useModalState from '@/components/common/Modal/useModalState';
 import Responsive from '@/components/common/Responsive';
 import carbonCodeBlockImg from '@/public/icons/img/carbon_code_block.png';
+import { MOBILE_MEDIA_QUERY } from '@/styles/mediaQuery';
 import { textStyles } from '@/styles/typography';
 
 const CARBON_LINK = 'https://carbon.now.sh/';
@@ -86,16 +87,26 @@ const Title = styled.div`
 
 const Description = styled.div`
   margin-bottom: 10px;
+  max-width: 326px;
   line-height: 22px;
   letter-spacing: -0.14px;
   white-space: pre-line;
   color: ${colors.gray10};
 
   ${textStyles.SUIT_14_R}
+
+  @media ${MOBILE_MEDIA_QUERY} {
+    max-width: 100%;
+  }
 `;
 
 const CarbonCodeBlockImage = styled.img`
-  min-height: 180px;
+  max-width: 326px;
+
+  @media ${MOBILE_MEDIA_QUERY} {
+    max-width: 100%;
+    min-height: 180px;
+  }
 `;
 
 const CarbonLink = styled.a`

--- a/src/components/feed/upload/CodeUploadButton/index.tsx
+++ b/src/components/feed/upload/CodeUploadButton/index.tsx
@@ -86,7 +86,6 @@ const Title = styled.div`
 
 const Description = styled.div`
   margin-bottom: 10px;
-  max-width: 326px;
   line-height: 22px;
   letter-spacing: -0.14px;
   white-space: pre-line;
@@ -96,8 +95,7 @@ const Description = styled.div`
 `;
 
 const CarbonCodeBlockImage = styled.img`
-  width: 326px;
-  height: 180px;
+  min-height: 180px;
 `;
 
 const CarbonLink = styled.a`

--- a/src/components/feed/upload/Input/ContentsInput/index.tsx
+++ b/src/components/feed/upload/Input/ContentsInput/index.tsx
@@ -1,6 +1,6 @@
 import styled from '@emotion/styled';
 import { colors } from '@sopt-makers/colors';
-import { ChangeEvent } from 'react';
+import { ChangeEvent, forwardRef, Ref } from 'react';
 import TextareaAutosize from 'react-textarea-autosize';
 
 import { MOBILE_MEDIA_QUERY } from '@/styles/mediaQuery';
@@ -10,9 +10,13 @@ interface ContentsInputProp {
   onChange: (e: ChangeEvent<HTMLInputElement> | ChangeEvent<HTMLTextAreaElement>) => void;
 }
 
-export default function ContentsInput({ onChange }: ContentsInputProp) {
-  return <Contents placeholder='내용을 입력해주세요' maxLength={20000} spellCheck='false' onChange={onChange} />;
-}
+const ContentsInput = forwardRef(({ onChange }: ContentsInputProp, ref: Ref<HTMLTextAreaElement> | undefined) => {
+  return (
+    <Contents placeholder='내용을 입력해주세요' maxLength={20000} spellCheck='false' onChange={onChange} ref={ref} />
+  );
+});
+
+export default ContentsInput;
 
 const Contents = styled(TextareaAutosize)`
   outline: none;

--- a/src/components/feed/upload/Input/TitleInput/index.tsx
+++ b/src/components/feed/upload/Input/TitleInput/index.tsx
@@ -9,9 +9,10 @@ import { textStyles } from '@/styles/typography';
 interface TitleInputProp {
   onChange: (e: ChangeEvent<HTMLInputElement> | ChangeEvent<HTMLTextAreaElement>) => void;
   onKeyDown: (e: React.KeyboardEvent<HTMLTextAreaElement>) => void;
+  value: string | null;
 }
 
-export default function TitleInput({ onChange, onKeyDown }: TitleInputProp) {
+export default function TitleInput({ onChange, onKeyDown, value }: TitleInputProp) {
   return (
     <Title
       placeholder='(선택) 제목을 입력해주세요'
@@ -19,6 +20,7 @@ export default function TitleInput({ onChange, onKeyDown }: TitleInputProp) {
       spellCheck='false'
       onChange={onChange}
       onKeyDown={onKeyDown}
+      value={value??""}
     />
   );
 }

--- a/src/components/feed/upload/Input/TitleInput/index.tsx
+++ b/src/components/feed/upload/Input/TitleInput/index.tsx
@@ -8,10 +8,19 @@ import { textStyles } from '@/styles/typography';
 
 interface TitleInputProp {
   onChange: (e: ChangeEvent<HTMLInputElement> | ChangeEvent<HTMLTextAreaElement>) => void;
+  onKeyDown: (e: React.KeyboardEvent<HTMLTextAreaElement>) => void;
 }
 
-export default function TitleInput({ onChange }: TitleInputProp) {
-  return <Title placeholder='(선택) 제목을 입력해주세요' maxLength={255} spellCheck='false' onChange={onChange} />;
+export default function TitleInput({ onChange, onKeyDown }: TitleInputProp) {
+  return (
+    <Title
+      placeholder='(선택) 제목을 입력해주세요'
+      maxLength={255}
+      spellCheck='false'
+      onChange={onChange}
+      onKeyDown={onKeyDown}
+    />
+  );
 }
 
 const Title = styled(TextareaAutosize)`

--- a/src/components/feed/upload/hooks/useUploadFeedData.ts
+++ b/src/components/feed/upload/hooks/useUploadFeedData.ts
@@ -23,7 +23,9 @@ export default function useUploadFeedData(initialForm: UploadFeedDataType) {
   };
 
   const handleSaveTitle = (e: React.ChangeEvent<HTMLInputElement> | React.ChangeEvent<HTMLTextAreaElement>) => {
-    setFeedData((feedData) => ({ ...feedData, title: e.target.value }));
+    const title = e.target.value.replace(/\n/g, '');
+
+    setFeedData((feedData) => ({ ...feedData, title: title }));
   };
 
   const handleSaveContent = (e: React.ChangeEvent<HTMLInputElement> | React.ChangeEvent<HTMLTextAreaElement>) => {


### PR DESCRIPTION
### 🤫 쉿, 나한테만 말해줘요. 이슈넘버
- close #1098

### 🧐 어떤 것을 변경했어요~?
<!-- 실제로 변경한 사항을 설명해주세요.-->
- css 수정
- 타이틀 input에서 엔터 클릭 시, 콘텐츠 input으로 자동 이동하도록 했어요.

### 🤔 그렇다면, 어떻게 구현했어요~?
<!-- 실제로 구현한 로직에 대해 설명해주세요.-->
- onKeyDown 이벤트로 ref.current.focus() 되도록 구현했어요. 

### ❤️‍🔥 당신이 생각하는 PR포인트, 내겐 매력포인트.
<!-- 해당 PR에서 논의가 필요한 사항을 적어주세요. -->
- 타이틀 인풋에서 엔터를 치면 \n이 함께 넘어가는 문제를 해결하기 위해, e.preventDefault()를 사용했어요.
- 한글인 경우, 제목을 `안녕하세요` 라고 입력한 뒤 엔터를 치면 콘텐츠 인풋에 `요\n`가 딸려 들어가는 문제가 있었어요. 
    - !e.nativeEvent.isComposing인지를 체크해주어 문제를 해결했어요. 

### 📸 스크린샷, 없으면 이것 참,, 섭섭한데요?

https://github.com/sopt-makers/sopt-playground-frontend/assets/76681519/e591706a-35ad-4e21-afb9-d0bf1f28a607

