### PR TITLE
fix: 피드 업로드시 카테고리 선택창이 자동으로 닫히는 문제 해결

### DIFF
--- a/functions/feed/[id].ts
+++ b/functions/feed/[id].ts
@@ -1,0 +1,10 @@
+// /feed/[id] 주소로 직접 접근 시 /feed/[id].html 로 보내기
+export const onRequest: PagesFunction = async (context) => {
+  const { next, params } = context;
+
+  if (/\d+/.test(`${params.id}`)) {
+    return next('/feed/[id]');
+  }
+
+  return next();
+};

--- a/src/components/feed/page/FeedUploadPage.tsx
+++ b/src/components/feed/page/FeedUploadPage.tsx
@@ -10,7 +10,7 @@ import Responsive from '@/components/common/Responsive';
 import Category from '@/components/feed/upload/Category';
 import CheckboxFormItem from '@/components/feed/upload/CheckboxFormItem';
 import CodeUploadButton from '@/components/feed/upload/CodeUploadButton';
-import { useCategorySelect } from '@/components/feed/upload/hooks/useCategorySelect';
+import { useCategorySelect, useCategoryUsingRulesPreview } from '@/components/feed/upload/hooks/useCategorySelect';
 import useUploadFeedData from '@/components/feed/upload/hooks/useUploadFeedData';
 import ImagePreview from '@/components/feed/upload/ImagePreview';
 import ImageUploadButton from '@/components/feed/upload/ImageUploadButton';
@@ -47,12 +47,14 @@ export default function FeedUploadPage() {
     isBlindWriter: false,
     images: [],
   });
-
   const { imageInputRef: desktopRef, handleClickImageInput: handleDesktopClickImageInput } =
     useImageUploader(saveImageUrls);
   const { imageInputRef: mobileRef, handleClickImageInput: handleMobileClickImageInput } =
     useImageUploader(saveImageUrls);
-  const { isSelectorOpen, closeAll, openCategory, openTag, openUsingRules } = useCategorySelect('openCategory');
+
+  const { isSelectorOpen, closeAll, openCategory, openTag } = useCategorySelect('openCategory');
+  const { isPreviewOpen, openUsingRules, closeUsingRules } = useCategoryUsingRulesPreview(false);
+
   const { mutate: handleUploadFeed, isPending } = useSaveUploadFeedData();
 
   const handleSubmit = (e: FormEvent<HTMLFormElement>) => {
@@ -65,10 +67,6 @@ export default function FeedUploadPage() {
       isBlindWriter: feedData.isBlindWriter,
       images: feedData.images,
     });
-  };
-
-  const checkIsOpenCategorys = () => {
-    return isSelectorOpen === 'openUsingRules' || isSelectorOpen === 'closeAll';
   };
 
   if (isPending) return <Loading />;
@@ -89,12 +87,12 @@ export default function FeedUploadPage() {
                 isSelectorOpen={isSelectorOpen}
                 openCategory={openCategory}
                 openTag={openTag}
+                onClose={closeAll}
                 openUsingRules={openUsingRules}
-                checkIsOpenCategorys={checkIsOpenCategorys()}
-                onClose={onClose}
+                closeUsingRules={closeUsingRules}
               />
               <ButtonContainer>
-                <UsingRules isSelectorOpen={isSelectorOpen} closeAll={closeAll} />
+                <UsingRules isPreviewOpen={isPreviewOpen} onClose={closeUsingRules} />
                 <SubmitButton disabled={!checkReadyToUpload()}>올리기</SubmitButton>
               </ButtonContainer>
             </>
@@ -152,8 +150,9 @@ export default function FeedUploadPage() {
                 isSelectorOpen={isSelectorOpen}
                 openCategory={openCategory}
                 openTag={openTag}
+                onClose={closeAll}
                 openUsingRules={openUsingRules}
-                checkIsOpenCategorys={checkIsOpenCategorys()}
+                closeUsingRules={closeUsingRules}
               />
             </>
           }
@@ -185,7 +184,7 @@ export default function FeedUploadPage() {
           }
           footer={
             <>
-              <UsingRules isSelectorOpen={isSelectorOpen} closeAll={closeAll} />
+              <UsingRules isPreviewOpen={isPreviewOpen} onClose={closeUsingRules} />
             </>
           }
         />

--- a/src/components/feed/page/FeedUploadPage.tsx
+++ b/src/components/feed/page/FeedUploadPage.tsx
@@ -10,7 +10,7 @@ import Responsive from '@/components/common/Responsive';
 import Category from '@/components/feed/upload/Category';
 import CheckboxFormItem from '@/components/feed/upload/CheckboxFormItem';
 import CodeUploadButton from '@/components/feed/upload/CodeUploadButton';
-import { useCategorySelect, useCategoryUsingRulesPreview } from '@/components/feed/upload/hooks/useCategorySelect';
+import { useCategoryUsingRulesPreview } from '@/components/feed/upload/hooks/useCategorySelect';
 import useUploadFeedData from '@/components/feed/upload/hooks/useUploadFeedData';
 import ImagePreview from '@/components/feed/upload/ImagePreview';
 import ImageUploadButton from '@/components/feed/upload/ImageUploadButton';
@@ -37,10 +37,9 @@ export default function FeedUploadPage() {
     handleSaveContent,
     resetFeedData,
     checkReadyToUpload,
-    checkReadyToShowUsingRules,
   } = useUploadFeedData({
-    mainCategoryId: 0,
-    categoryId: 0,
+    mainCategoryId: null,
+    categoryId: null,
     title: '',
     content: '',
     isQuestion: false,
@@ -52,7 +51,6 @@ export default function FeedUploadPage() {
   const { imageInputRef: mobileRef, handleClickImageInput: handleMobileClickImageInput } =
     useImageUploader(saveImageUrls);
 
-  const { isSelectorOpen, closeAll, openCategory, openTag } = useCategorySelect('openCategory');
   const { isPreviewOpen, openUsingRules, closeUsingRules } = useCategoryUsingRulesPreview(false);
 
   const { mutate: handleUploadFeed, isPending } = useSaveUploadFeedData();
@@ -60,7 +58,7 @@ export default function FeedUploadPage() {
   const handleSubmit = (e: FormEvent<HTMLFormElement>) => {
     e.preventDefault();
     handleUploadFeed({
-      categoryId: feedData.categoryId,
+      categoryId: feedData.categoryId ?? 0,
       title: feedData.title,
       content: feedData.content,
       isQuestion: feedData.isQuestion,
@@ -84,10 +82,6 @@ export default function FeedUploadPage() {
                 feedData={feedData}
                 onSaveCategory={handleSaveCategory}
                 onSaveMainCategory={handleSaveMainCategory}
-                isSelectorOpen={isSelectorOpen}
-                openCategory={openCategory}
-                openTag={openTag}
-                onClose={closeAll}
                 openUsingRules={openUsingRules}
                 closeUsingRules={closeUsingRules}
               />
@@ -147,10 +141,6 @@ export default function FeedUploadPage() {
                 feedData={feedData}
                 onSaveCategory={handleSaveCategory}
                 onSaveMainCategory={handleSaveMainCategory}
-                isSelectorOpen={isSelectorOpen}
-                openCategory={openCategory}
-                openTag={openTag}
-                onClose={closeAll}
                 openUsingRules={openUsingRules}
                 closeUsingRules={closeUsingRules}
               />

--- a/src/components/feed/page/FeedUploadPage.tsx
+++ b/src/components/feed/page/FeedUploadPage.tsx
@@ -52,7 +52,7 @@ export default function FeedUploadPage() {
     useImageUploader(saveImageUrls);
   const { imageInputRef: mobileRef, handleClickImageInput: handleMobileClickImageInput } =
     useImageUploader(saveImageUrls);
-  const { isDropDown, closeAll, openCategory, openTag, openUsingRules } = useCategorySelect('openCategory');
+  const { isSelectorOpen, closeAll, openCategory, openTag, openUsingRules } = useCategorySelect('openCategory');
   const { mutate: handleUploadFeed, isPending } = useSaveUploadFeedData();
 
   const handleSubmit = (e: FormEvent<HTMLFormElement>) => {
@@ -68,7 +68,7 @@ export default function FeedUploadPage() {
   };
 
   const checkIsOpenCategorys = () => {
-    return isDropDown === 'openUsingRules' || isDropDown === 'closeAll';
+    return isSelectorOpen === 'openUsingRules' || isSelectorOpen === 'closeAll';
   };
 
   if (isPending) return <Loading />;
@@ -86,14 +86,15 @@ export default function FeedUploadPage() {
                 feedData={feedData}
                 onSaveCategory={handleSaveCategory}
                 onSaveMainCategory={handleSaveMainCategory}
-                isDropDown={isDropDown}
+                isSelectorOpen={isSelectorOpen}
                 openCategory={openCategory}
                 openTag={openTag}
                 openUsingRules={openUsingRules}
                 checkIsOpenCategorys={checkIsOpenCategorys()}
+                onClose={onClose}
               />
               <ButtonContainer>
-                <UsingRules isDropDown={isDropDown} closeAll={closeAll} />
+                <UsingRules isSelectorOpen={isSelectorOpen} closeAll={closeAll} />
                 <SubmitButton disabled={!checkReadyToUpload()}>올리기</SubmitButton>
               </ButtonContainer>
             </>
@@ -148,7 +149,7 @@ export default function FeedUploadPage() {
                 feedData={feedData}
                 onSaveCategory={handleSaveCategory}
                 onSaveMainCategory={handleSaveMainCategory}
-                isDropDown={isDropDown}
+                isSelectorOpen={isSelectorOpen}
                 openCategory={openCategory}
                 openTag={openTag}
                 openUsingRules={openUsingRules}
@@ -184,7 +185,7 @@ export default function FeedUploadPage() {
           }
           footer={
             <>
-              <UsingRules isDropDown={isDropDown} closeAll={closeAll} />
+              <UsingRules isSelectorOpen={isSelectorOpen} closeAll={closeAll} />
             </>
           }
         />

--- a/src/components/feed/upload/Category/CategoryHeader/index.tsx
+++ b/src/components/feed/upload/Category/CategoryHeader/index.tsx
@@ -35,7 +35,7 @@ export default function CategoryHeader({ feedData, openCategory, openTag }: Cate
 
   return (
     <>
-      {feedData.categoryId <= 0 ? (
+      {feedData.categoryId && feedData.categoryId <= 0 ? (
         <CategorySelectorStarter onClick={openCategory}>
           <UploadTitle>어디에 올릴까요?</UploadTitle>
           <OpenArrow fill='white' />

--- a/src/components/feed/upload/Category/TagSelector/TagSelectOptions.tsx
+++ b/src/components/feed/upload/Category/TagSelector/TagSelectOptions.tsx
@@ -54,12 +54,12 @@ export default function TagSelectOptions({ onClose, onSave, feedData }: TagSelec
             {parentCategory.hasAll && (
               <>
                 <Responsive only='desktop'>
-                  <Option onClick={() => handleSelectTagDesktop(feedData.mainCategoryId)}>
+                  <Option onClick={() => handleSelectTagDesktop(feedData.mainCategoryId ?? 0)}>
                     주제 선택 안 함{!isInitial && <CheckIcon />}
                   </Option>
                 </Responsive>
                 <Responsive only='mobile'>
-                  <Option onClick={() => handleSelectTagMobile(feedData.mainCategoryId)}>
+                  <Option onClick={() => handleSelectTagMobile(feedData.mainCategoryId ?? 0)}>
                     주제 선택 안 함{!isInitial && <CheckIcon />}
                   </Option>
                 </Responsive>

--- a/src/components/feed/upload/Category/TagSelector/index.tsx
+++ b/src/components/feed/upload/Category/TagSelector/index.tsx
@@ -35,14 +35,14 @@ export default function TagSelector({ isOpen = false, onBack, onClose, onSave, f
   return (
     <>
       <Responsive only='desktop'>
-        <DropDown isOpen={isOpen} onClose={onBack} className='tag-drop'>
+        <DropDown isOpen={isOpen} onClose={onClose} className='tag-drop'>
           <TagSelectOptions feedData={feedData} onClose={onClose} onSave={onSave} />
         </DropDown>
       </Responsive>
       <Responsive only='mobile'>
         <BottomSheet
           isOpen={isOpen}
-          onClose={onBack}
+          onClose={onClose}
           header={
             <Title>
               <BackArrowIc onClick={onBack} />

--- a/src/components/feed/upload/Category/index.tsx
+++ b/src/components/feed/upload/Category/index.tsx
@@ -6,16 +6,13 @@ import { useGetMemberProfileOfMe } from '@/api/endpoint_LEGACY/hooks';
 import CategoryHeader from '@/components/feed/upload/Category/CategoryHeader';
 import CategorySelector from '@/components/feed/upload/Category/CategorySelector';
 import TagSelector from '@/components/feed/upload/Category/TagSelector';
+import { useCategorySelect } from '@/components/feed/upload/hooks/useCategorySelect';
 import { UploadFeedDataType } from '@/components/feed/upload/types';
 
 interface CateogryProps {
   feedData: UploadFeedDataType;
   onSaveCategory: (categoryId: number) => void;
   onSaveMainCategory: (categoryId: number) => void;
-  isSelectorOpen: 'openCategory' | 'openTag' | 'closeAll';
-  openCategory: () => void;
-  openTag: () => void;
-  onClose: () => void;
   openUsingRules: () => void;
   closeUsingRules: () => void;
 }
@@ -24,13 +21,11 @@ export default function Category({
   feedData,
   onSaveCategory,
   onSaveMainCategory,
-  isSelectorOpen,
-  openCategory,
-  openTag,
-  onClose,
   openUsingRules,
   closeUsingRules,
 }: CateogryProps) {
+  const { isSelectorOpen, closeAll, openCategory, openTag } = useCategorySelect('openCategory');
+
   const { data: categories } = useQuery({
     queryKey: getCategory.cacheKey(),
     queryFn: getCategory.request,
@@ -62,7 +57,7 @@ export default function Category({
 
     if (selectedMainCategory.children.length === 0) {
       onSaveCategory(categoryId);
-      onClose();
+      closeAll();
       openUsingRules();
       const timer = setTimeout(() => {
         closeUsingRules();
@@ -88,12 +83,12 @@ export default function Category({
     }
 
     onSaveCategory(selectedMainCategory.children[0].id);
-    onClose();
+    closeAll();
   };
 
   const handleCloseTag = () => {
     openUsingRules();
-    onClose();
+    closeAll();
     const timer = setTimeout(() => {
       closeUsingRules();
     }, 5000);
@@ -106,7 +101,7 @@ export default function Category({
     <>
       <CategorySelector
         isOpen={isSelectorOpen === 'openCategory'}
-        onClose={onClose}
+        onClose={closeAll}
         onSelect={handleSaveMainCategory}
         feedData={feedData}
       />

--- a/src/components/feed/upload/Category/index.tsx
+++ b/src/components/feed/upload/Category/index.tsx
@@ -12,10 +12,11 @@ interface CateogryProps {
   feedData: UploadFeedDataType;
   onSaveCategory: (categoryId: number) => void;
   onSaveMainCategory: (categoryId: number) => void;
-  isDropDown: 'openCategory' | 'openTag' | 'closeAll' | 'openUsingRules';
+  isSelectorOpen: 'openCategory' | 'openTag' | 'closeAll' | 'openUsingRules';
   openCategory: () => void;
   openTag: () => void;
   openUsingRules: () => void;
+  onClose: () => void;
   checkIsOpenCategorys: boolean;
 }
 
@@ -23,10 +24,11 @@ export default function Category({
   feedData,
   onSaveCategory,
   onSaveMainCategory,
-  isDropDown,
+  isSelectorOpen,
   openCategory,
   openTag,
   openUsingRules,
+  onClose,
 }: CateogryProps) {
   const { data: categories } = useQuery({
     queryKey: getCategory.cacheKey(),
@@ -59,6 +61,8 @@ export default function Category({
 
     if (selectedMainCategory.children.length === 0) {
       onSaveCategory(categoryId);
+      openUsingRules();
+
       return;
     }
 
@@ -83,13 +87,13 @@ export default function Category({
   return (
     <>
       <CategorySelector
-        isOpen={isDropDown === 'openCategory'}
+        isOpen={isSelectorOpen === 'openCategory'}
         onClose={openUsingRules}
         onSelect={handleSaveMainCategory}
         feedData={feedData}
       />
       <TagSelector
-        isOpen={isDropDown === 'openTag'}
+        isOpen={isSelectorOpen === 'openTag'}
         onBack={openCategory}
         onClose={openUsingRules}
         onSave={onSaveCategory}

--- a/src/components/feed/upload/Category/index.tsx
+++ b/src/components/feed/upload/Category/index.tsx
@@ -12,12 +12,12 @@ interface CateogryProps {
   feedData: UploadFeedDataType;
   onSaveCategory: (categoryId: number) => void;
   onSaveMainCategory: (categoryId: number) => void;
-  isSelectorOpen: 'openCategory' | 'openTag' | 'closeAll' | 'openUsingRules';
+  isSelectorOpen: 'openCategory' | 'openTag' | 'closeAll';
   openCategory: () => void;
   openTag: () => void;
-  openUsingRules: () => void;
   onClose: () => void;
-  checkIsOpenCategorys: boolean;
+  openUsingRules: () => void;
+  closeUsingRules: () => void;
 }
 
 export default function Category({
@@ -27,8 +27,9 @@ export default function Category({
   isSelectorOpen,
   openCategory,
   openTag,
-  openUsingRules,
   onClose,
+  openUsingRules,
+  closeUsingRules,
 }: CateogryProps) {
   const { data: categories } = useQuery({
     queryKey: getCategory.cacheKey(),
@@ -61,9 +62,14 @@ export default function Category({
 
     if (selectedMainCategory.children.length === 0) {
       onSaveCategory(categoryId);
+      onClose();
       openUsingRules();
-
-      return;
+      const timer = setTimeout(() => {
+        closeUsingRules();
+      }, 5000);
+      return () => {
+        clearTimeout(timer);
+      };
     }
 
     openTag();
@@ -82,20 +88,32 @@ export default function Category({
     }
 
     onSaveCategory(selectedMainCategory.children[0].id);
+    onClose();
+  };
+
+  const handleCloseTag = () => {
+    openUsingRules();
+    onClose();
+    const timer = setTimeout(() => {
+      closeUsingRules();
+    }, 5000);
+    return () => {
+      clearTimeout(timer);
+    };
   };
 
   return (
     <>
       <CategorySelector
         isOpen={isSelectorOpen === 'openCategory'}
-        onClose={openUsingRules}
+        onClose={onClose}
         onSelect={handleSaveMainCategory}
         feedData={feedData}
       />
       <TagSelector
         isOpen={isSelectorOpen === 'openTag'}
         onBack={openCategory}
-        onClose={openUsingRules}
+        onClose={handleCloseTag}
         onSave={onSaveCategory}
         feedData={feedData}
       />

--- a/src/components/feed/upload/UsingRules/UsingRulesPreview/index.tsx
+++ b/src/components/feed/upload/UsingRules/UsingRulesPreview/index.tsx
@@ -3,7 +3,6 @@ import { Content, Overlay, Root } from '@radix-ui/react-dialog';
 import { colors } from '@sopt-makers/colors';
 import { fonts } from '@sopt-makers/fonts';
 import dynamic from 'next/dynamic';
-import { useEffect } from 'react';
 
 import Responsive from '@/components/common/Responsive';
 import { COMMUNITY_RULES_PREVIEW } from '@/components/feed/upload/UsingRules/constants';
@@ -18,16 +17,6 @@ interface UsingRulesPreviewProp {
 }
 
 export default function UsingRulesPreview({ isOpen, onClose }: UsingRulesPreviewProp) {
-  useEffect(() => {
-    const timer = setTimeout(() => {
-      onClose();
-    }, 5000);
-
-    if (!isOpen) {
-      clearTimeout(timer);
-    }
-  }, [isOpen]);
-
   return (
     <>
       <Responsive only='desktop'>

--- a/src/components/feed/upload/UsingRules/index.tsx
+++ b/src/components/feed/upload/UsingRules/index.tsx
@@ -5,16 +5,16 @@ import UsingRulesDetail from '@/components/feed/upload/UsingRules/UsingRulesDeta
 import UsingRulesPreview from '@/components/feed/upload/UsingRules/UsingRulesPreview';
 
 interface UsingRulesProps {
-  isDropDown: 'openCategory' | 'openTag' | 'closeAll' | 'openUsingRules';
+  isSelectorOpen: 'openCategory' | 'openTag' | 'closeAll' | 'openUsingRules';
   closeAll: () => void;
 }
 
-export default function UsingRules({ isDropDown, closeAll }: UsingRulesProps) {
+export default function UsingRules({ isSelectorOpen, closeAll }: UsingRulesProps) {
   const [isDetailOpen, setIsDetailOpen] = useState(false);
 
   return (
     <>
-      <UsingRulesPreview isOpen={isDropDown === 'openUsingRules'} onClose={closeAll} />
+      <UsingRulesPreview isOpen={isSelectorOpen === 'openUsingRules'} onClose={closeAll} />
       <UsingRulesButton onClick={() => setIsDetailOpen(true)} />
       <UsingRulesDetail isOpen={isDetailOpen} onClose={() => setIsDetailOpen(false)} />
     </>

--- a/src/components/feed/upload/UsingRules/index.tsx
+++ b/src/components/feed/upload/UsingRules/index.tsx
@@ -5,16 +5,16 @@ import UsingRulesDetail from '@/components/feed/upload/UsingRules/UsingRulesDeta
 import UsingRulesPreview from '@/components/feed/upload/UsingRules/UsingRulesPreview';
 
 interface UsingRulesProps {
-  isSelectorOpen: 'openCategory' | 'openTag' | 'closeAll' | 'openUsingRules';
-  closeAll: () => void;
+  isPreviewOpen: boolean;
+  onClose: () => void;
 }
 
-export default function UsingRules({ isSelectorOpen, closeAll }: UsingRulesProps) {
+export default function UsingRules({ isPreviewOpen, onClose }: UsingRulesProps) {
   const [isDetailOpen, setIsDetailOpen] = useState(false);
 
   return (
     <>
-      <UsingRulesPreview isOpen={isSelectorOpen === 'openUsingRules'} onClose={closeAll} />
+      <UsingRulesPreview isOpen={isPreviewOpen} onClose={onClose} />
       <UsingRulesButton onClick={() => setIsDetailOpen(true)} />
       <UsingRulesDetail isOpen={isDetailOpen} onClose={() => setIsDetailOpen(false)} />
     </>

--- a/src/components/feed/upload/hooks/useCategorySelect.ts
+++ b/src/components/feed/upload/hooks/useCategorySelect.ts
@@ -1,23 +1,23 @@
 import { useState } from 'react';
 
 export function useCategorySelect(initialState: 'openCategory' | 'openTag' | 'closeAll' | 'openUsingRules') {
-  const [isDropDown, setIsDropDown] = useState(initialState);
+  const [isSelectorOpen, setisSelectorOpen] = useState(initialState);
 
   const closeAll = () => {
-    setIsDropDown('closeAll');
+    setisSelectorOpen('closeAll');
   };
 
   const openCategory = () => {
-    setIsDropDown('openCategory');
+    setisSelectorOpen('openCategory');
   };
 
   const openTag = () => {
-    setIsDropDown('openTag');
+    setisSelectorOpen('openTag');
   };
 
   const openUsingRules = () => {
-    setIsDropDown('openUsingRules');
+    setisSelectorOpen('openUsingRules');
   };
 
-  return { isDropDown, closeAll, openCategory, openTag, openUsingRules };
+  return { isSelectorOpen, closeAll, openCategory, openTag, openUsingRules };
 }

--- a/src/components/feed/upload/hooks/useCategorySelect.ts
+++ b/src/components/feed/upload/hooks/useCategorySelect.ts
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 
-export function useCategorySelect(initialState: 'openCategory' | 'openTag' | 'closeAll' | 'openUsingRules') {
+export function useCategorySelect(initialState: 'openCategory' | 'openTag' | 'closeAll') {
   const [isSelectorOpen, setisSelectorOpen] = useState(initialState);
 
   const closeAll = () => {
@@ -15,9 +15,19 @@ export function useCategorySelect(initialState: 'openCategory' | 'openTag' | 'cl
     setisSelectorOpen('openTag');
   };
 
+  return { isSelectorOpen, closeAll, openCategory, openTag };
+}
+
+export function useCategoryUsingRulesPreview(initialState: boolean) {
+  const [isPreviewOpen, setIsPreviewOpen] = useState(initialState);
+
   const openUsingRules = () => {
-    setisSelectorOpen('openUsingRules');
+    setIsPreviewOpen(true);
   };
 
-  return { isSelectorOpen, closeAll, openCategory, openTag, openUsingRules };
+  const closeUsingRules = () => {
+    setIsPreviewOpen(false);
+  };
+
+  return { isPreviewOpen, openUsingRules, closeUsingRules };
 }

--- a/src/components/feed/upload/hooks/useUploadFeedData.ts
+++ b/src/components/feed/upload/hooks/useUploadFeedData.ts
@@ -1,6 +1,5 @@
 import { useState } from 'react';
 
-import { categories } from '@/components/feed/upload/Category/constants';
 import { UploadFeedDataType } from '@/components/feed/upload/types';
 
 export default function useUploadFeedData(initialForm: UploadFeedDataType) {
@@ -39,29 +38,13 @@ export default function useUploadFeedData(initialForm: UploadFeedDataType) {
     setFeedData((feedData) => ({ ...feedData, images: removeImages }));
   };
 
-  const checkReadyToShowUsingRules = () => {
-    return feedData.categoryId !== 0;
-  };
-
   const checkReadyToUpload = () => {
-    return feedData.categoryId !== 0 && feedData.content !== '' && feedData.title !== '';
+    return feedData.categoryId !== null && !feedData.content && !feedData.title;
   };
 
   const resetFeedData = () => {
     setFeedData(initialForm);
   };
-
-  const parentCategory =
-    categories.find(
-      (category) =>
-        category.id === feedData.mainCategoryId || category.children.some((tag) => tag.id === feedData.categoryId),
-    ) ?? null;
-
-  const isInitial =
-    categories.find(
-      (category) =>
-        category.id === feedData.mainCategoryId && category.children.some((tag) => tag.id === feedData.categoryId),
-    ) ?? null;
 
   return {
     feedData,
@@ -75,8 +58,5 @@ export default function useUploadFeedData(initialForm: UploadFeedDataType) {
     handleSaveContent,
     resetFeedData,
     checkReadyToUpload,
-    checkReadyToShowUsingRules,
-    parentCategory,
-    isInitial,
   };
 }

--- a/src/components/feed/upload/types.ts
+++ b/src/components/feed/upload/types.ts
@@ -1,6 +1,6 @@
 export interface UploadFeedDataType {
-  mainCategoryId: number;
-  categoryId: number;
+  mainCategoryId: number | null;
+  categoryId: number | null;
   title: string | null;
   content: string;
   isQuestion: boolean;


### PR DESCRIPTION
### 🤫 쉿, 나한테만 말해줘요. 이슈넘버
- close #1099

### 🧐 어떤 것을 변경했어요~?
<!-- 실제로 변경한 사항을 설명해주세요.-->
- 피드 업로드시 카테고리 선택창이 자동으로 닫히는 문제를 해결했어요.
- 동시에 뒤로가기 로직을 수정했어요.(태그셀렉터에서 딤드 누르면, 카테고리셀렉터로 뒤로가기 =>태그셀렉터 닫기)

### 🤔 그렇다면, 어떻게 구현했어요~?
<!-- 실제로 구현한 로직에 대해 설명해주세요.-->
- 원래는 단계별로 isSelectorOpen의 값을 openCategory->openTag->openUsingRules->closeAll과 같이 관리했었는데요, 이렇게 하다보니, 원하지 않는때에 closeAll이 발생해버리는 이슈가 있었습니다. 
    - 카테고리 셀렉터는 isSelectorOpen<'openCategory' | 'openTag' | 'closeAll'>으로, 커뮤니티 이용규칙 프리뷰는 isPreviewOpen<boolean> 으로 값을 따로 관리해주었습니다. 


### ❤️‍🔥 당신이 생각하는 PR포인트, 내겐 매력포인트.
<!-- 해당 PR에서 논의가 필요한 사항을 적어주세요. -->
- 원래는 카테고리 셀렉터 로직이 끝나면(=카테고리, 태그 선택이 끝나면) 프리뷰 모달이 열리고 5초 뒤에 닫히는 내용을 useEffect에서 관리했는데요, 그러다보니 원하지 않을 때에도 5초 뒤에 닫혀버려서.... useEffect를 없애고, 이벤트핸들링 함수에서 해당 내용이 이루어지도록 했습니다. 
  
- 커뮤니티 이용규칙 프리뷰가 열리면 5초 뒤에 닫히고, 클린업해주었습니다. 
```
      openUsingRules();
      const timer = setTimeout(() => {
        closeUsingRules();
      }, 5000);
      return () => {
        clearTimeout(timer);
      };
```

### 📸 스크린샷, 없으면 이것 참,, 섭섭한데요?
