### PR TITLE
fix: 업로드 피드 뒤로가기 구현

### DIFF
--- a/src/components/feed/page/FeedUploadPage.tsx
+++ b/src/components/feed/page/FeedUploadPage.tsx
@@ -1,6 +1,7 @@
 import { css } from '@emotion/react';
 import styled from '@emotion/styled';
 import { colors } from '@sopt-makers/colors';
+import { useRouter } from 'next/router';
 import { FormEvent } from 'react';
 
 import { useSaveUploadFeedData } from '@/api/endpoint/feed/uploadFeed';
@@ -48,6 +49,8 @@ export default function FeedUploadPage() {
     images: [],
   });
 
+  const router = useRouter();
+
   const { imageInputRef: desktopRef, handleClickImageInput: handleDesktopClickImageInput } =
     useImageUploader(saveImageUrls);
   const { imageInputRef: mobileRef, handleClickImageInput: handleMobileClickImageInput } =
@@ -67,6 +70,11 @@ export default function FeedUploadPage() {
     });
   };
 
+  const hanldeQuitUpload = () => {
+    resetFeedData();
+    router.push('/community');
+  };
+
   const checkIsOpenCategorys = () => {
     return isDropDown === 'openUsingRules' || isDropDown === 'closeAll';
   };
@@ -80,7 +88,7 @@ export default function FeedUploadPage() {
           header={
             <>
               <BackArrowWrapper>
-                <BackArrow onClick={resetFeedData} />
+                <BackArrow onClick={hanldeQuitUpload} />
               </BackArrowWrapper>
               <Category
                 feedData={feedData}
@@ -137,7 +145,7 @@ export default function FeedUploadPage() {
           header={
             <>
               <TopHeader>
-                <Button type='button' disabled={false} onClick={resetFeedData}>
+                <Button type='button' disabled={false} onClick={hanldeQuitUpload}>
                   취소
                 </Button>
                 <Button type='submit' disabled={!checkReadyToUpload()}>

--- a/src/components/feed/page/FeedUploadPage.tsx
+++ b/src/components/feed/page/FeedUploadPage.tsx
@@ -71,7 +71,6 @@ export default function FeedUploadPage() {
   };
 
   const hanldeQuitUpload = () => {
-    resetFeedData();
     router.push('/community');
   };
 


### PR DESCRIPTION
### 🤫 쉿, 나한테만 말해줘요. 이슈넘버
- close #1125

### 🧐 어떤 것을 변경했어요~?
<!-- 실제로 변경한 사항을 설명해주세요.-->
- 업로드 페이지에서 뒤로가기 로직을 구현했어요. 

### 🤔 그렇다면, 어떻게 구현했어요~?
<!-- 실제로 구현한 로직에 대해 설명해주세요.-->
```
  const hanldeQuitUpload = () => {
    resetFeedData();
    router.push('/community');
  };
```
다음과 같이 라우터에 커뮤니티를 쌓아주었습니다. 

### ❤️‍🔥 당신이 생각하는 PR포인트, 내겐 매력포인트.
<!-- 해당 PR에서 논의가 필요한 사항을 적어주세요. -->

### 📸 스크린샷, 없으면 이것 참,, 섭섭한데요?
