### PR TITLE
chore: 솝티클 링크 변경

### DIFF
--- a/src/components/sopticle/Success.tsx
+++ b/src/components/sopticle/Success.tsx
@@ -19,7 +19,7 @@ const UploadSuccess: FC<UploadSuccessProps> = ({}) => {
       <SubTitle>등록하신 솝티클은 SOPT 공식 홈페이지에서 확인할 수 있어요.</SubTitle>
 
       <ButtonGroup>
-        <ViewButton href={'https://sopt.org/sopticle'} target='_blank'>
+        <ViewButton href={'https://sopt.org/blog'} target='_blank'>
           {goSvg} 솝티클 보러가기
         </ViewButton>
         <UploadMoreButton href={playgroundLink.sopticle()}>{plusSvg} 추가로 업로드하기</UploadMoreButton>

--- a/src/components/sopticle/UploadSopticle.tsx
+++ b/src/components/sopticle/UploadSopticle.tsx
@@ -58,7 +58,7 @@ const UploadSopticle: FC<UploadSopticleProps> = ({ state, errorMessage, onSubmit
         title='SOPT 공식 홈페이지에 솝티클 보러가기'
         content='앗! 업로드가 아니라 솝티클을 읽고 싶으신가요?
 솝트 회원들이 직접 작성한 솝티클은 공홈에서 확인할 수 있어요.'
-        href='https://www.sopt.org/sopticle'
+        href='https://www.sopt.org/blog'
       />
     </Container>
   );


### PR DESCRIPTION
### 🤫 쉿, 나한테만 말해줘요. 이슈넘버
- close #1153

### 🧐 어떤 것을 변경했어요~?
<!-- 실제로 변경한 사항을 설명해주세요.-->

<img width="594" alt="스크린샷 2023-11-23 오전 6 11 22" src="https://github.com/sopt-makers/sopt-playground-frontend/assets/76681519/cc623c4a-8927-4f05-8561-70ca6c0a19bb">

[해당 스레드](https://sopt-makers.slack.com/archives/C042T81PW80/p1699861773937109)

- 공홈에서도 리다이렉트 되어있어서 유저가 사용하는데에는 문제없긴 하겠만, https://sopt.org/sopticle 주소가 더이상 유효하지 않아서, 변경해주었습니다!

### 🤔 그렇다면, 어떻게 구현했어요~?
<!-- 실제로 구현한 로직에 대해 설명해주세요.-->
- 링크만 변경해주었어요!

### ❤️‍🔥 당신이 생각하는 PR포인트, 내겐 매력포인트.
<!-- 해당 PR에서 논의가 필요한 사항을 적어주세요. -->

### 📸 스크린샷, 없으면 이것 참,, 섭섭한데요?
