### PR TITLE
feat: 익명 서약 모달 구현

### DIFF
--- a/src/components/common/Modal/parts/ModalButton.tsx
+++ b/src/components/common/Modal/parts/ModalButton.tsx
@@ -1,3 +1,4 @@
+import { css } from '@emotion/react';
 import styled from '@emotion/styled';
 import * as Dialog from '@radix-ui/react-dialog';
 import { colors } from '@sopt-makers/colors';
@@ -7,17 +8,20 @@ import { textStyles } from '@/styles/typography';
 
 interface ModalCloseButtonProps extends ComponentPropsWithoutRef<typeof Dialog.Close> {
   action?: 'normal' | 'close';
+  className?: string;
 }
 
-const ModalButton = forwardRef<HTMLButtonElement, ModalCloseButtonProps>(({ action = 'normal', ...props }, ref) => {
-  const As = action === 'normal' ? 'button' : Dialog.Close;
+const ModalButton = forwardRef<HTMLButtonElement, ModalCloseButtonProps>(
+  ({ action = 'normal', className, ...props }, ref) => {
+    const As = action === 'normal' ? 'button' : Dialog.Close;
 
-  return <StyledButton ref={ref} as={As} {...props}></StyledButton>;
-});
+    return <StyledButton ref={ref} as={As} className={className} {...props}></StyledButton>;
+  },
+);
 
 export default ModalButton;
 
-const StyledButton = styled.button`
+const StyledButton = styled.button<{ className?: string }>`
   display: flex;
   align-items: center;
   justify-content: center;
@@ -28,4 +32,11 @@ const StyledButton = styled.button`
   color: ${colors.gray10};
 
   ${textStyles.SUIT_16_SB};
+
+  ${({ className }) =>
+    className === 'white' &&
+    css`
+      background-color: ${colors.white};
+      color: ${colors.black};
+    `}
 `;

--- a/src/components/common/Modal/parts/ModalButton.tsx
+++ b/src/components/common/Modal/parts/ModalButton.tsx
@@ -1,4 +1,3 @@
-import { css } from '@emotion/react';
 import styled from '@emotion/styled';
 import * as Dialog from '@radix-ui/react-dialog';
 import { colors } from '@sopt-makers/colors';
@@ -8,20 +7,17 @@ import { textStyles } from '@/styles/typography';
 
 interface ModalCloseButtonProps extends ComponentPropsWithoutRef<typeof Dialog.Close> {
   action?: 'normal' | 'close';
-  className?: string;
 }
 
-const ModalButton = forwardRef<HTMLButtonElement, ModalCloseButtonProps>(
-  ({ action = 'normal', className, ...props }, ref) => {
-    const As = action === 'normal' ? 'button' : Dialog.Close;
+const ModalButton = forwardRef<HTMLButtonElement, ModalCloseButtonProps>(({ action = 'normal', ...props }, ref) => {
+  const As = action === 'normal' ? 'button' : Dialog.Close;
 
-    return <StyledButton ref={ref} as={As} className={className} {...props}></StyledButton>;
-  },
-);
+  return <StyledButton ref={ref} as={As} {...props}></StyledButton>;
+});
 
 export default ModalButton;
 
-const StyledButton = styled.button<{ className?: string }>`
+const StyledButton = styled.button`
   display: flex;
   align-items: center;
   justify-content: center;
@@ -32,11 +28,4 @@ const StyledButton = styled.button<{ className?: string }>`
   color: ${colors.gray10};
 
   ${textStyles.SUIT_16_SB};
-
-  ${({ className }) =>
-    className === 'white' &&
-    css`
-      background-color: ${colors.white};
-      color: ${colors.black};
-    `}
 `;

--- a/src/components/common/Modal/useAlert.tsx
+++ b/src/components/common/Modal/useAlert.tsx
@@ -16,6 +16,7 @@ const useAlert = () => {
       buttonText?: string;
       buttonColor?: string;
       buttonTextColor?: string;
+      maxWidth?: number;
     }) =>
       new Promise<boolean>((resolve) => {
         open(({ isOpen, close }) => (
@@ -27,7 +28,7 @@ const useAlert = () => {
             }}
             hideCloseButton={options.hideCloseButton ?? false}
           >
-            <StyledModalContent>
+            <StyledModalContent maxWidth={options.maxWidth}>
               <Modal.Title>{options.title}</Modal.Title>
               <StyleModalDescription>{options.description}</StyleModalDescription>
               <Modal.Footer align='stretch'>
@@ -52,8 +53,9 @@ const StyledButton = styled(Modal.Button)<{ color?: string; backgroundColor?: st
   color: ${(props) => props.color ?? colors.gray10};
 `;
 
-const StyledModalContent = styled(Modal.Content)`
-  max-width: 320px;
+const StyledModalContent = styled(Modal.Content)<{ maxWidth?: number }>`
+  min-width: 320px;
+  max-width: ${({ maxWidth }) => maxWidth}px;
 `;
 
 const StyleModalDescription = styled.div`

--- a/src/components/common/Modal/useAlert.tsx
+++ b/src/components/common/Modal/useAlert.tsx
@@ -1,4 +1,5 @@
 import styled from '@emotion/styled';
+import { colors } from '@sopt-makers/colors';
 import { useOverlay } from '@toss/use-overlay';
 import { ReactNode, useCallback } from 'react';
 
@@ -12,8 +13,9 @@ const useAlert = () => {
       title: ReactNode;
       description: ReactNode;
       hideCloseButton?: boolean;
-      buttonScript?: string;
-      className?: string;
+      buttonText?: string;
+      buttonColor?: string;
+      buttonTextColor?: string;
     }) =>
       new Promise<boolean>((resolve) => {
         open(({ isOpen, close }) => (
@@ -29,9 +31,9 @@ const useAlert = () => {
               <Modal.Title>{options.title}</Modal.Title>
               <StyleModalDescription>{options.description}</StyleModalDescription>
               <Modal.Footer align='stretch'>
-                <Modal.Button action='close' className={options.className}>
-                  {options.buttonScript ?? '확인'}
-                </Modal.Button>
+                <StyledButton action='close' color={options.buttonTextColor} backgroundColor={options.buttonColor}>
+                  {options.buttonText ?? '확인'}
+                </StyledButton>
               </Modal.Footer>
             </StyledModalContent>
           </Modal>
@@ -44,6 +46,11 @@ const useAlert = () => {
 };
 
 export default useAlert;
+
+const StyledButton = styled(Modal.Button)<{ color?: string; backgroundColor?: string }>`
+  background-color: ${(props) => props.backgroundColor ?? colors.white};
+  color: ${(props) => props.color ?? colors.black};
+`;
 
 const StyledModalContent = styled(Modal.Content)`
   max-width: 320px;

--- a/src/components/common/Modal/useAlert.tsx
+++ b/src/components/common/Modal/useAlert.tsx
@@ -48,8 +48,8 @@ const useAlert = () => {
 export default useAlert;
 
 const StyledButton = styled(Modal.Button)<{ color?: string; backgroundColor?: string }>`
-  background-color: ${(props) => props.backgroundColor ?? colors.white};
-  color: ${(props) => props.color ?? colors.black};
+  background-color: ${(props) => props.backgroundColor ?? colors.gray700};
+  color: ${(props) => props.color ?? colors.gray10};
 `;
 
 const StyledModalContent = styled(Modal.Content)`

--- a/src/components/common/Modal/useAlert.tsx
+++ b/src/components/common/Modal/useAlert.tsx
@@ -8,7 +8,13 @@ const useAlert = () => {
   const { open, close } = useOverlay();
 
   const alert = useCallback(
-    (options: { title: ReactNode; description: ReactNode }) =>
+    (options: {
+      title: ReactNode;
+      description: ReactNode;
+      hideCloseButton?: boolean;
+      buttonScript?: string;
+      className?: string;
+    }) =>
       new Promise<boolean>((resolve) => {
         open(({ isOpen, close }) => (
           <Modal
@@ -17,12 +23,15 @@ const useAlert = () => {
               resolve(false);
               close();
             }}
+            hideCloseButton={options.hideCloseButton ?? false}
           >
             <StyledModalContent>
               <Modal.Title>{options.title}</Modal.Title>
               <StyleModalDescription>{options.description}</StyleModalDescription>
               <Modal.Footer align='stretch'>
-                <Modal.Button action='close'>확인</Modal.Button>
+                <Modal.Button action='close' className={options.className}>
+                  {options.buttonScript ?? '확인'}
+                </Modal.Button>
               </Modal.Footer>
             </StyledModalContent>
           </Modal>
@@ -37,7 +46,7 @@ const useAlert = () => {
 export default useAlert;
 
 const StyledModalContent = styled(Modal.Content)`
-  min-width: 320px;
+  max-width: 320px;
 `;
 
 const StyleModalDescription = styled.div`

--- a/src/components/feed/common/hooks/useBlindWriterPromise.tsx
+++ b/src/components/feed/common/hooks/useBlindWriterPromise.tsx
@@ -1,0 +1,18 @@
+import useAlert from '@/components/common/Modal/useAlert';
+
+export default function useBlindWriterPromise() {
+  const { alert } = useAlert();
+
+  const handleShowBlindWriterPromise = () => {
+    alert({
+      title: '플레이그라운드는 건전하고 기분좋은 소통을 지향해요',
+      description:
+        '타인을 비난하거나 저격하는 글을 작성하는 등 커뮤니티 이용규칙을 위반할 경우, 서비스 이용이 제한될 수 있으며 내부 절차에 따라 익명 작성자를 식별하여 징계위원회를 열 수 있습니다.',
+      hideCloseButton: true,
+      buttonScript: '명심할게요',
+      className: 'white',
+    });
+  };
+
+  return { handleShowBlindWriterPromise };
+}

--- a/src/components/feed/common/hooks/useBlindWriterPromise.tsx
+++ b/src/components/feed/common/hooks/useBlindWriterPromise.tsx
@@ -12,6 +12,7 @@ export default function useBlindWriterPromise() {
       buttonText: '명심할게요',
       buttonColor: 'white',
       buttonTextColor: 'black',
+      maxWidth: 320,
     });
   };
 

--- a/src/components/feed/common/hooks/useBlindWriterPromise.tsx
+++ b/src/components/feed/common/hooks/useBlindWriterPromise.tsx
@@ -9,8 +9,9 @@ export default function useBlindWriterPromise() {
       description:
         '타인을 비난하거나 저격하는 글을 작성하는 등 커뮤니티 이용규칙을 위반할 경우, 서비스 이용이 제한될 수 있으며 내부 절차에 따라 익명 작성자를 식별하여 징계위원회를 열 수 있습니다.',
       hideCloseButton: true,
-      buttonScript: '명심할게요',
-      className: 'white',
+      buttonText: '명심할게요',
+      buttonColor: 'white',
+      buttonTextColor: 'black',
     });
   };
 

--- a/src/components/feed/detail/DetailFeedCard.tsx
+++ b/src/components/feed/detail/DetailFeedCard.tsx
@@ -6,6 +6,7 @@ import { forwardRef, PropsWithChildren, ReactNode, useEffect, useRef, useState }
 
 import Checkbox from '@/components/common/Checkbox';
 import Text from '@/components/common/Text';
+import useBlindWriterPromise from '@/components/feed/common/hooks/useBlindWriterPromise';
 import {
   IconChevronLeft,
   IconChevronRight,
@@ -358,6 +359,7 @@ interface InputProps {
 const Input = ({ value, onChange, isBlindChecked, onChangeIsBlindChecked }: InputProps) => {
   const [isFocus, setIsFocus] = useState(false);
   const containerRef = useRef<HTMLDivElement | null>(null);
+  const { handleShowBlindWriterPromise } = useBlindWriterPromise();
 
   const is버튼액티브 = isFocus && value.length > 0;
 
@@ -373,6 +375,11 @@ const Input = ({ value, onChange, isBlindChecked, onChangeIsBlindChecked }: Inpu
     };
   }, []);
 
+  const handleCheckBlindWriter = (isBlindWriter: boolean) => {
+    isBlindWriter && handleShowBlindWriterPromise();
+    onChangeIsBlindChecked(isBlindWriter);
+  };
+
   return (
     <Container ref={containerRef}>
       <InputAnimateArea
@@ -381,7 +388,7 @@ const Input = ({ value, onChange, isBlindChecked, onChangeIsBlindChecked }: Inpu
         transition={{ bounce: 0, stiffness: 1000 }}
       >
         <InputContent>
-          <Checkbox size='small' checked={isBlindChecked} onChange={(e) => onChangeIsBlindChecked(e.target.checked)} />
+          <Checkbox size='small' checked={isBlindChecked} onChange={(e) => handleCheckBlindWriter(e.target.checked)} />
           <Text typography='SUIT_12_M'>익명으로 남기기</Text>
         </InputContent>
       </InputAnimateArea>

--- a/src/components/feed/upload/hooks/useUploadFeedData.ts
+++ b/src/components/feed/upload/hooks/useUploadFeedData.ts
@@ -1,9 +1,11 @@
 import { useState } from 'react';
 
+import useBlindWriterPromise from '@/components/feed/common/hooks/useBlindWriterPromise';
 import { UploadFeedDataType } from '@/components/feed/upload/types';
 
 export default function useUploadFeedData(initialForm: UploadFeedDataType) {
   const [feedData, setFeedData] = useState(initialForm);
+  const { handleShowBlindWriterPromise } = useBlindWriterPromise();
 
   const handleSaveMainCategory = (categoryId: number) => {
     setFeedData((feedData) => ({ ...feedData, mainCategoryId: categoryId }));
@@ -18,6 +20,8 @@ export default function useUploadFeedData(initialForm: UploadFeedDataType) {
   };
 
   const handleSaveIsBlindWriter = (isBlindWriter: boolean) => {
+    isBlindWriter && handleShowBlindWriterPromise();
+
     setFeedData((feedData) => ({ ...feedData, isBlindWriter: isBlindWriter }));
   };
 


### PR DESCRIPTION
### 🤫 쉿, 나한테만 말해줘요. 이슈넘버
- close #1157

### 🧐 어떤 것을 변경했어요~?
<!-- 실제로 변경한 사항을 설명해주세요.-->
- 익명 서약 모달 로직을 구현했어요. 

### 🤔 그렇다면, 어떻게 구현했어요~?
<!-- 실제로 구현한 로직에 대해 설명해주세요.-->
- 기존에 있는 useAlert를 이용했어요, 
- 업로드 부분과, 피드 댓글 부분 두 곳에 적용했습니다.

### ❤️‍🔥 당신이 생각하는 PR포인트, 내겐 매력포인트.
<!-- 해당 PR에서 논의가 필요한 사항을 적어주세요. -->
- 기존 alert에서       
```
      hideCloseButton?: boolean;
      buttonText?: string;
      buttonColor?: string;
      buttonTextColor?: string;
```
를 추가적으로 받도록 수정했어요. 다른 alert로직에 영향이 가지 않도록 설계를 수정하려고 노력했는데, 실제로 다른 로직에 영향이 가지 않을지 확인해주시면 감사하겠습니다! hideCloseButton은, 모달에 따로 확인 버튼이 있다보니까 x버튼이 없어서 내려주어야했고, alert버튼의 text가 확인이 아닐 수 있어서 내려주었고, 확인버튼이 지금은 회색 디폴트 색인데 이 경우는 흰색이라 buttonColor와 textColor를 내려주었습니다. 

### 📸 스크린샷, 없으면 이것 참,, 섭섭한데요?


https://github.com/sopt-makers/sopt-playground-frontend/assets/76681519/402bb330-e524-4f89-af2a-9e66b3bf1020



https://github.com/sopt-makers/sopt-playground-frontend/assets/76681519/3c4899d1-cc36-4d7b-8395-8fc2a0492c89


