### PR TITLE
feat: 데스크톱 레이아웃 구분선 추가

### DIFF
--- a/src/components/feed/detail/DetailFeedCard.tsx
+++ b/src/components/feed/detail/DetailFeedCard.tsx
@@ -27,8 +27,6 @@ const Base = ({ children }: PropsWithChildren<unknown>) => {
 };
 
 const StyledBase = styled(Flex)`
-  border-right: 1px solid ${colors.gray800};
-  border-left: 1px solid ${colors.gray800};
   height: 100%;
 `;
 

--- a/src/components/feed/list/CategorySelect.tsx
+++ b/src/components/feed/list/CategorySelect.tsx
@@ -60,7 +60,9 @@ const CategorySelect: FC<CategorySelectProps> = ({ categories }) => {
 
 export default CategorySelect;
 
-export const Container = styled.div``;
+export const Container = styled.div`
+  border-bottom: 1px solid ${colors.gray800};
+`;
 
 export const CategoryBox = styled.div`
   display: flex;

--- a/src/components/feed/page/layout/DesktopCommunityLayout.tsx
+++ b/src/components/feed/page/layout/DesktopCommunityLayout.tsx
@@ -1,4 +1,5 @@
 import styled from '@emotion/styled';
+import { colors } from '@sopt-makers/colors';
 import { m } from 'framer-motion';
 import { FC, ReactNode } from 'react';
 
@@ -40,6 +41,8 @@ const Container = styled.div`
 
 const ListSlot = styled.div`
   flex: 1 1 0;
+  border-right: 1px solid ${colors.gray800};
+  border-left: 1px solid ${colors.gray800};
   max-width: 560px;
 `;
 
@@ -62,6 +65,7 @@ const DetailSlotInner = styled.div`
   top: 0;
   right: 0;
   bottom: 0;
+  border-right: 1px solid ${colors.gray800};
   width: ${DETAIL_SLOT_WIDTH}px;
   min-width: ${DETAIL_SLOT_WIDTH}px;
 `;


### PR DESCRIPTION
### 🤫 쉿, 나한테만 말해줘요. 이슈넘버
- close #

### 🧐 어떤 것을 변경했어요~?
<!-- 실제로 변경한 사항을 설명해주세요.-->

리스트 왼쪽과 카테고리 아래 구분선을 추가하고, 리스트의 구분선 렌더링을 밖으로 뺍니다.

### 🤔 그렇다면, 어떻게 구현했어요~?
<!-- 실제로 구현한 로직에 대해 설명해주세요.-->

### ❤️‍🔥 당신이 생각하는 PR포인트, 내겐 매력포인트.
<!-- 해당 PR에서 논의가 필요한 사항을 적어주세요. -->

### 📸 스크린샷, 없으면 이것 참,, 섭섭한데요?
