### PR TITLE
fix: post후 데이터가 바로 get되도록

### DIFF
--- a/src/api/endpoint/feed/uploadFeed.ts
+++ b/src/api/endpoint/feed/uploadFeed.ts
@@ -29,9 +29,9 @@ export const useSaveUploadFeedData = () => {
 
   return useMutation({
     mutationFn: (reqeustBody: RequestBody) => uploadFeed.request(reqeustBody),
-    onSuccess: () => {
+    onSuccess: async () => {
       queryClient.invalidateQueries({ queryKey: useGetPostsInfiniteQuery.getKey('') });
-      return router.push(playgroundLink.feedList());
+      await router.push(playgroundLink.feedList());
     },
   });
 };

--- a/src/api/endpoint/feed/uploadFeed.ts
+++ b/src/api/endpoint/feed/uploadFeed.ts
@@ -4,7 +4,7 @@ import { z } from 'zod';
 
 import { useGetPostsInfiniteQuery } from '@/api/endpoint/feed/getPosts';
 import { createEndpoint } from '@/api/typedAxios';
-
+import { playgroundLink } from '@/constants/links';
 interface RequestBody {
   categoryId: number;
   title: string | null;
@@ -31,7 +31,7 @@ export const useSaveUploadFeedData = () => {
     mutationFn: (reqeustBody: RequestBody) => uploadFeed.request(reqeustBody),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: useGetPostsInfiniteQuery.getKey('') });
-      return router.push('/community');
+      return router.push(playgroundLink.feedList());
     },
   });
 };

--- a/src/api/endpoint/feed/uploadFeed.ts
+++ b/src/api/endpoint/feed/uploadFeed.ts
@@ -1,7 +1,8 @@
-import { useMutation } from '@tanstack/react-query';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { useRouter } from 'next/router';
 import { z } from 'zod';
 
+import { useGetPostsInfiniteQuery } from '@/api/endpoint/feed/getPosts';
 import { createEndpoint } from '@/api/typedAxios';
 
 interface RequestBody {
@@ -23,12 +24,14 @@ export const uploadFeed = createEndpoint({
 });
 
 export const useSaveUploadFeedData = () => {
+  const queryClient = useQueryClient();
   const router = useRouter();
 
   return useMutation({
     mutationFn: (reqeustBody: RequestBody) => uploadFeed.request(reqeustBody),
     onSuccess: () => {
-      router.push('/community');
+      queryClient.invalidateQueries({ queryKey: useGetPostsInfiniteQuery.getKey('') });
+      return router.push('/community');
     },
   });
 };


### PR DESCRIPTION
### 🤫 쉿, 나한테만 말해줘요. 이슈넘버
- close #

### 🧐 어떤 것을 변경했어요~?
<!-- 실제로 변경한 사항을 설명해주세요.-->
- post후, 추가된 데이터가 반영되지 않는 문제를 해결했어요. 

### 🤔 그렇다면, 어떻게 구현했어요~?
<!-- 실제로 구현한 로직에 대해 설명해주세요.-->
```
    onSuccess: async () => {
      queryClient.invalidateQueries({ queryKey: useGetPostsInfiniteQuery.getKey('') });
      await router.push(playgroundLink.feedList());
    },
```

### ❤️‍🔥 당신이 생각하는 PR포인트, 내겐 매력포인트.
<!-- 해당 PR에서 논의가 필요한 사항을 적어주세요. -->
- 원래는

```
queryClient.invalidateQueries({ queryKey: useGetPostsInfiniteQuery.getKey('') });
      router.push(playgroundLink.feedList());
```

이렇게만 해주었는데, invalidate가 되지 않고, 바로 커뮤니티 페이지로 이동하는 이슈가 있었어요. 
    - [router.push는 Promise를 리턴하는 비동기 함수](https://stackoverflow.com/questions/76501168/should-i-await-a-router-push-in-nextjs)라고 해요, 그래서, async await을 이용해서 원하는 순서대로 동작하도록 했습니다!
    
<img width="388" alt="스크린샷 2023-11-26 오후 7 50 53" src="https://github.com/sopt-makers/sopt-playground-frontend/assets/76681519/885607eb-325b-48ac-b7ce-0348984b9586">

- 커비 선상님 🚀🚀🚀🚀🚀

### 📸 스크린샷, 없으면 이것 참,, 섭섭한데요?
