### PR TITLE
fix: 레이아웃 zIndex로 인해 Modal이 뜨지 않는 이슈 수정

### DIFF
--- a/src/components/common/Modal/index.tsx
+++ b/src/components/common/Modal/index.tsx
@@ -1,3 +1,4 @@
+import { css } from '@emotion/react';
 import styled from '@emotion/styled';
 import * as Dialog from '@radix-ui/react-dialog';
 import { colors } from '@sopt-makers/colors';
@@ -18,6 +19,7 @@ export interface ModalProps extends PropsWithChildren<HTMLAttributes<HTMLDivElem
   isOpen?: boolean;
   onClose: () => void;
   hideCloseButton?: boolean;
+  zIndex?: number;
 }
 
 const ModalComponent: FC<ModalProps> = (props) => {
@@ -30,7 +32,7 @@ const ModalComponent: FC<ModalProps> = (props) => {
   return (
     <Dialog.Root open={isOpen} onOpenChange={onClose}>
       <DialogPortal>
-        <StyledBackground asChild>
+        <StyledBackground zIndex={props.zIndex} asChild>
           <m.div initial={{ opacity: 0 }} animate={{ opacity: 1 }} transition={{ duration: 0.2 }}>
             <StyledModalContainer asChild {...restProps}>
               <m.div initial={{ scale: 0.9 }} animate={{ scale: 1 }} transition={{ duration: 0.2 }}>
@@ -59,13 +61,19 @@ const Modal = Object.assign(ModalComponent, {
 
 export default Modal;
 
-const StyledBackground = styled(Dialog.Overlay)`
+const StyledBackground = styled(Dialog.Overlay)<{ zIndex?: number }>`
   display: flex;
   position: fixed;
   inset: 0;
   align-items: center;
   justify-content: center;
   background-color: rgb(0 0 0 / 30%);
+
+  ${({ zIndex }) =>
+    zIndex &&
+    css`
+      z-index: ${zIndex};
+    `}
 `;
 
 const StyledModalContainer = styled(Dialog.Content)`

--- a/src/components/common/Modal/useAlert.tsx
+++ b/src/components/common/Modal/useAlert.tsx
@@ -17,6 +17,7 @@ const useAlert = () => {
       buttonColor?: string;
       buttonTextColor?: string;
       maxWidth?: number;
+      zIndex?: number;
     }) =>
       new Promise<boolean>((resolve) => {
         open(({ isOpen, close }) => (
@@ -27,6 +28,7 @@ const useAlert = () => {
               close();
             }}
             hideCloseButton={options.hideCloseButton ?? false}
+            zIndex={options.zIndex}
           >
             <StyledModalContent maxWidth={options.maxWidth}>
               <Modal.Title>{options.title}</Modal.Title>

--- a/src/components/common/Modal/useConfirm.tsx
+++ b/src/components/common/Modal/useConfirm.tsx
@@ -16,6 +16,7 @@ const useConfirm = () => {
       okButtonText: string;
       okButtonColor?: string;
       okButtonTextColor?: string;
+      zIndex?: number;
     }) =>
       new Promise<boolean>((resolve) => {
         open(({ isOpen, close }) => (
@@ -25,6 +26,7 @@ const useConfirm = () => {
               resolve(false);
               close();
             }}
+            zIndex={options.zIndex}
           >
             <StyledModalContent>
               <Modal.Title>{options.title}</Modal.Title>

--- a/src/components/feed/common/hooks/useDeleteComment.ts
+++ b/src/components/feed/common/hooks/useDeleteComment.ts
@@ -3,6 +3,7 @@ import { useCallback } from 'react';
 
 import { useDeleteCommentMutation } from '@/api/endpoint/feed/deleteComment';
 import useConfirm from '@/components/common/Modal/useConfirm';
+import { zIndex } from '@/styles/zIndex';
 
 interface Options {
   commentId: string;
@@ -22,6 +23,7 @@ export const useDeleteComment = () => {
         okButtonTextColor: colors.white,
         okButtonText: '삭제하기',
         cancelButtonText: '취소',
+        zIndex: zIndex.헤더,
       });
 
       if (result) {

--- a/src/components/feed/common/hooks/useReportComment.ts
+++ b/src/components/feed/common/hooks/useReportComment.ts
@@ -3,6 +3,7 @@ import { useCallback } from 'react';
 import { usePostReportCommentMutation } from '@/api/endpoint/feed/postReportComment';
 import useAlert from '@/components/common/Modal/useAlert';
 import useConfirm from '@/components/common/Modal/useConfirm';
+import { zIndex } from '@/styles/zIndex';
 
 interface Options {
   commentId: string;
@@ -21,6 +22,7 @@ export const useReportComment = () => {
         description: '댓글을 신고할 경우, 메이커스에서 검토를 거쳐 적절한 조치 및 게시자 제재를 취해요.',
         okButtonText: '신고하기',
         cancelButtonText: '취소',
+        zIndex: zIndex.헤더,
       });
 
       if (result) {

--- a/src/components/feed/page/layout/MobileCommunityLayout.tsx
+++ b/src/components/feed/page/layout/MobileCommunityLayout.tsx
@@ -3,6 +3,8 @@ import { colors } from '@sopt-makers/colors';
 import { FC, ReactNode } from 'react';
 import { RemoveScroll } from 'react-remove-scroll';
 
+import { zIndex } from '@/styles/zIndex';
+
 interface MobileCommunityLayoutProps {
   isDetailOpen: boolean;
   listSlot: ReactNode;
@@ -37,7 +39,7 @@ const ListSlotBox = styled.div`
 const Overlay = styled.div`
   position: fixed;
   inset: 0;
-  z-index: 100;
+  z-index: ${zIndex.헤더};
   overflow: hidden;
 `;
 

--- a/src/styles/zIndex.ts
+++ b/src/styles/zIndex.ts
@@ -1,0 +1,3 @@
+export const zIndex = {
+  헤더: 100,
+};


### PR DESCRIPTION
### 🤫 쉿, 나한테만 말해줘요. 이슈넘버
- close #

### 🧐 어떤 것을 변경했어요~?
<!-- 실제로 변경한 사항을 설명해주세요.-->
- 썩 맘에드는 방법은 아니지만.. 레이아웃의 zIndex를 제거할 순 없고, 모달에 zIndex를 부여하면 또 다른 사이드 이펙트가 일어날까봐 prop으로 받도록 대응했어요.

### 🤔 그렇다면, 어떻게 구현했어요~?
<!-- 실제로 구현한 로직에 대해 설명해주세요.-->

### ❤️‍🔥 당신이 생각하는 PR포인트, 내겐 매력포인트.
<!-- 해당 PR에서 논의가 필요한 사항을 적어주세요. -->

### 📸 스크린샷, 없으면 이것 참,, 섭섭한데요?
