### PR TITLE
chore: 이미지 부분과 커뮤니티 이용규칙 프리뷰 겹치는 문제 해결

### DIFF
--- a/src/components/feed/page/FeedUploadPage.tsx
+++ b/src/components/feed/page/FeedUploadPage.tsx
@@ -249,9 +249,9 @@ export default function FeedUploadPage() {
             </Body>
           }
           footer={
-            <>
+            <Footer isWriting={feedData.content !== null}>
               <UsingRules isPreviewOpen={isPreviewOpen} onClose={closeUsingRules} />
-            </>
+            </Footer>
           }
         />
       </Responsive>
@@ -359,7 +359,7 @@ const TagsWrapper = styled.div`
   gap: 8px;
 
   @media ${MOBILE_MEDIA_QUERY} {
-    margin-top: 16px;
+    margin: 16px 0;
   }
 `;
 
@@ -372,8 +372,18 @@ const CheckBoxesWrapper = styled.div`
   }
 `;
 
-const Footer = styled.div`
+const Footer = styled.div<{ isWriting?: boolean }>`
   width: 100%;
+
+  @media ${MOBILE_MEDIA_QUERY} {
+    ${({ isWriting }) =>
+      !isWriting &&
+      css`
+        position: fixed;
+      `}
+
+    bottom: 8px;
+  }
 `;
 
 const TagAndCheckboxWrapper = styled.div`

--- a/src/components/feed/upload/CheckboxFormItem/BlindWriterWarning/index.tsx
+++ b/src/components/feed/upload/CheckboxFormItem/BlindWriterWarning/index.tsx
@@ -38,4 +38,8 @@ const WarningBoxWrapper = styled.section`
   display: flex;
   justify-content: flex-end;
   width: 100%;
+
+  @media ${MOBILE_MEDIA_QUERY} {
+    justify-content: center;
+  }
 `;

--- a/src/components/feed/upload/layout/MobileFeedUploadLayout.tsx
+++ b/src/components/feed/upload/layout/MobileFeedUploadLayout.tsx
@@ -23,15 +23,15 @@ const HeaderWrapper = styled.header`
 `;
 
 const BodyWrapper = styled.section`
+  margin-top: 10px;
   width: 100%;
 `;
 
 const FooterWrapper = styled.footer`
   display: flex;
-  position: absolute;
-  bottom: 8px;
   flex-direction: column;
   gap: 8px;
+  margin-bottom:10px;
   padding: 0 16px;
   width: 100%;
 `;


### PR DESCRIPTION
### 🤫 쉿, 나한테만 말해줘요. 이슈넘버
- close #1192

### 🧐 어떤 것을 변경했어요~?
<!-- 실제로 변경한 사항을 설명해주세요.-->

![image](https://github.com/sopt-makers/sopt-playground-frontend/assets/76681519/c0c5e196-c7ee-4dfd-a517-fe3938e996be)

- 이미지 부분과 커뮤니티 이용규칙 프리뷰 겹치는 문제를 해결했어요. 

### 🤔 그렇다면, 어떻게 구현했어요~?
<!-- 실제로 구현한 로직에 대해 설명해주세요.-->
- content에 적은 내용이 없을만 footer가 fixed되도록 content가 null인지 아닌지를 isWriting으로 내려주었습니다. 
- 콘텐츠에 적힌 내용이 있으면 footer가 fixed되지 않고, 스크롤되면서 같이 내려가져요. 

### ❤️‍🔥 당신이 생각하는 PR포인트, 내겐 매력포인트.
<!-- 해당 PR에서 논의가 필요한 사항을 적어주세요. -->

### 📸 스크린샷, 없으면 이것 참,, 섭섭한데요?


https://github.com/sopt-makers/sopt-playground-frontend/assets/76681519/c45e80c2-6462-4595-9b28-55c4c5c1ece0



