### PR TITLE
feat: 전체 뷰에서 게시글 카테고리 표기하기

### DIFF
--- a/src/components/feed/common/utils.ts
+++ b/src/components/feed/common/utils.ts
@@ -35,6 +35,14 @@ export enum Category {
   꿀팁,
 }
 
+export const CategoryList = {
+  자유: '자유',
+  파트: '파트',
+  SOPT활동: 'SOPT활동',
+  홍보: '홍보',
+  취업_진로: '취업/진로',
+};
+
 const 특수임원List = [
   '메이커스 리드',
   '기획 파트장',

--- a/src/components/feed/common/utils.ts
+++ b/src/components/feed/common/utils.ts
@@ -71,3 +71,9 @@ export function getMemberInfo(post: Post) {
 
   return defaultInfo;
 }
+
+export function getUploadedCategoryInfo(category: string, part: string) {
+  const uploadedCategory = category === '파트' ? category + part : category;
+
+  return `님이 ${uploadedCategory}에 남김`;
+}

--- a/src/components/feed/common/utils.ts
+++ b/src/components/feed/common/utils.ts
@@ -71,9 +71,3 @@ export function getMemberInfo(post: Post) {
 
   return defaultInfo;
 }
-
-export function getUploadedCategoryInfo(category: string, part: string) {
-  const uploadedCategory = category === '파트' ? category + part : category;
-
-  return `님이 ${uploadedCategory}에 남김`;
-}

--- a/src/components/feed/list/FeedCard.stories.tsx
+++ b/src/components/feed/list/FeedCard.stories.tsx
@@ -43,6 +43,7 @@ const defaultProps: ComponentProps<typeof FeedCard> = {
     '처음해봐도 괜찮으니까 편하게 오세요! 장소는 클라이밍파크 신논현점 생각하고 있어요. 2시쯤 만나서 하고, 끝나고 같이 고기 먹어요~',
   hits: 23,
   commentLength: COMMENTS.length,
+  isShowInfo: true,
 };
 
 export const 기본 = () => {

--- a/src/components/feed/list/FeedCard.tsx
+++ b/src/components/feed/list/FeedCard.tsx
@@ -6,6 +6,7 @@ import { PropsWithChildren, ReactNode } from 'react';
 
 import Text from '@/components/common/Text';
 import { IconMember, IconMoreHoriz } from '@/components/feed/common/Icon';
+import { useCategoryParam } from '@/components/feed/common/queryParam';
 import { getRelativeTime } from '@/components/feed/common/utils';
 import { MOBILE_MEDIA_QUERY } from '@/styles/mediaQuery';
 import { horizontalScroll, scrollOverMargin } from '@/styles/mixin';
@@ -39,6 +40,8 @@ const Base = ({
   children,
   rightIcon,
 }: PropsWithChildren<BaseProps>) => {
+  const [categoryId] = useCategoryParam({ defaultValue: '' });
+
   return (
     <Flex
       css={{
@@ -58,20 +61,14 @@ const Base = ({
       <Flex direction='column' css={{ minWidth: 0, gap: '8px', width: '100%' }}>
         <Stack gutter={title ? 8 : 4}>
           <Flex justify='space-between'>
-            {isBlindWriter ? (
+            <Top align='center'>
               <Text typography='SUIT_14_SB' lineHeight={20}>
-                익명
+                {isBlindWriter ? '익명' : name}
               </Text>
-            ) : (
-              <Top align='center'>
-                <Text typography='SUIT_14_SB' lineHeight={20}>
-                  {name}
-                </Text>
-                <Text typography='SUIT_14_R' lineHeight={20} color={colors.gray400}>
-                  {info}
-                </Text>
-              </Top>
-            )}
+              <Text typography='SUIT_14_R' lineHeight={20} color={colors.gray400}>
+                {isBlindWriter ? (categoryId ? '' : info) : info}
+              </Text>
+            </Top>
             <Stack.Horizontal gutter={4} align='center'>
               <Text typography='SUIT_14_R' lineHeight={20} color={colors.gray400}>
                 {getRelativeTime(createdAt)}

--- a/src/components/feed/list/FeedCard.tsx
+++ b/src/components/feed/list/FeedCard.tsx
@@ -68,9 +68,6 @@ const Base = ({
                   {name}
                 </Text>
                 <Text typography='SUIT_14_R' lineHeight={20} color={colors.gray400}>
-                  ∙
-                </Text>
-                <Text typography='SUIT_14_R' lineHeight={20} color={colors.gray400}>
                   {info}
                 </Text>
               </Top>

--- a/src/components/feed/list/FeedCard.tsx
+++ b/src/components/feed/list/FeedCard.tsx
@@ -6,7 +6,6 @@ import { PropsWithChildren, ReactNode } from 'react';
 
 import Text from '@/components/common/Text';
 import { IconMember, IconMoreHoriz } from '@/components/feed/common/Icon';
-import { useCategoryParam } from '@/components/feed/common/queryParam';
 import { getRelativeTime } from '@/components/feed/common/utils';
 import { MOBILE_MEDIA_QUERY } from '@/styles/mediaQuery';
 import { horizontalScroll, scrollOverMargin } from '@/styles/mixin';
@@ -24,6 +23,7 @@ interface BaseProps {
   commentLength: number;
   hits: number;
   rightIcon?: ReactNode;
+  isShowInfo: boolean;
 }
 
 const Base = ({
@@ -39,9 +39,8 @@ const Base = ({
   hits,
   children,
   rightIcon,
+  isShowInfo,
 }: PropsWithChildren<BaseProps>) => {
-  const [categoryId] = useCategoryParam({ defaultValue: '' });
-
   return (
     <Flex
       css={{
@@ -66,7 +65,7 @@ const Base = ({
                 {isBlindWriter ? '익명' : name}
               </Text>
               <Text typography='SUIT_14_R' lineHeight={20} color={colors.gray400}>
-                {isBlindWriter ? (categoryId ? '' : info) : info}
+                {isBlindWriter ? (isShowInfo ? info : '') : info}
               </Text>
             </Top>
             <Stack.Horizontal gutter={4} align='center'>

--- a/src/components/feed/list/FeedListItems.tsx
+++ b/src/components/feed/list/FeedListItems.tsx
@@ -87,6 +87,7 @@ const FeedListItems: FC<FeedListItemsProps> = ({ categoryId, renderFeedDetailLin
                 hits={post.hits}
                 isBlindWriter={post.isBlindWriter}
                 isQuestion={post.isQuestion}
+                isShowInfo={categoryId === ''}
                 info={
                   categoryId ? (
                     <>

--- a/src/components/feed/list/FeedListItems.tsx
+++ b/src/components/feed/list/FeedListItems.tsx
@@ -13,7 +13,7 @@ import FeedDropdown from '@/components/feed/common/FeedDropdown';
 import { useDeleteFeed } from '@/components/feed/common/hooks/useDeleteFeed';
 import { useReportFeed } from '@/components/feed/common/hooks/useReportFeed';
 import { useShareFeed } from '@/components/feed/common/hooks/useShareFeed';
-import { getMemberInfo } from '@/components/feed/common/utils';
+import { CategoryList, getMemberInfo } from '@/components/feed/common/utils';
 import FeedCard from '@/components/feed/list/FeedCard';
 interface FeedListItemsProps {
   categoryId: string | undefined;
@@ -36,13 +36,33 @@ const FeedListItems: FC<FeedListItemsProps> = ({ categoryId, renderFeedDetailLin
     queryFn: getCategory.request,
   });
 
-  const parentCategory = (categoryId: number, part: string) => {
+  const parentCategory = (categoryId: number, tag: string) => {
     const category =
-      categoryData && categoryData.find((category) => category.children.some((tag) => tag.id === categoryId))?.name;
+      categoryData &&
+      categoryData.find((category) =>
+        category.children.length > 0
+          ? category.children.some((tag) => tag.id === categoryId)
+          : category.id === categoryId,
+      )?.name;
 
-    const uploadedCategory = category === '파트' ? part + category : category;
+    return uploadedCategory(category, tag);
+  };
 
-    return uploadedCategory;
+  const uploadedCategory = (category: string | undefined, tag: string) => {
+    switch (category) {
+      case tag:
+        return category;
+      case CategoryList.파트:
+        return tag + category;
+      case CategoryList.SOPT활동:
+        return tag;
+      case CategoryList.취업_진로:
+        return '취업 ' + tag;
+      case CategoryList.홍보:
+        return tag === '채용' ? tag : tag + ' ' + category;
+      default:
+        return category;
+    }
   };
 
   return (


### PR DESCRIPTION
### 🤫 쉿, 나한테만 말해줘요. 이슈넘버
- close #1195

### 🧐 어떤 것을 변경했어요~?
<!-- 실제로 변경한 사항을 설명해주세요.-->
- 전체 뷰에서 업로드된 게시글 카테고리가 표기되도록 했어요. 

### 🤔 그렇다면, 어떻게 구현했어요~?
<!-- 실제로 구현한 로직에 대해 설명해주세요.-->
- FeedCard에 prop으로 info를 내려주신 것으로 보아,,, 이름 옆에 들어가는 내용을 추상적으로 내려주려고 하신 것 같아서, prop으로 내려주는 info값을 수정했습니다. 

![image](https://github.com/sopt-makers/sopt-playground-frontend/assets/76681519/41ebc6f3-c409-4d9b-874c-b43317ce02fc)

- 이렇게 categoryId가 빈값인 경우=전체를 보고 있는 경우이기 때문에, categoryId가 있으면 기존의 getMemberInfo로 가고, 없으면 ~님이 ~에 남김 이 뜨도록 했어요. 

![image](https://github.com/sopt-makers/sopt-playground-frontend/assets/76681519/6df7f3df-b0f3-423d-af9a-ee1042fc2d31)

- 이렇게 받아진 categoryId로 부모카테고리를 찾아서 반환해주었습니다. 파트 카테고리의 경우는 어느 파트인지까지 보내줘야해서 다음과 같이 짰습니다!

![image](https://github.com/sopt-makers/sopt-playground-frontend/assets/76681519/2c1c5acf-0ee3-4d49-a876-d6dd2e45135c)

- 생각보다........복잡하게 있어가지고, switch-case 문으로 모든 경우의 수를 대응해주었습니다........

### ❤️‍🔥 당신이 생각하는 PR포인트, 내겐 매력포인트.
<!-- 해당 PR에서 논의가 필요한 사항을 적어주세요. -->

### 📸 스크린샷, 없으면 이것 참,, 섭섭한데요?
<img width="697" alt="스크린샷 2023-11-28 오전 1 47 03" src="https://github.com/sopt-makers/sopt-playground-frontend/assets/76681519/b04d67f0-7bd0-4cc8-b01d-983b64baa9f5">

