### PR TITLE
chore: 모바일에서 토스트 가운데 뜨도록 위치 수정

### DIFF
--- a/src/components/common/Toast/ToastEntry.tsx
+++ b/src/components/common/Toast/ToastEntry.tsx
@@ -13,15 +13,17 @@ export interface ToastEntryProps {
 
 const ToastEntry: FC<ToastEntryProps> = ({ title, message }) => {
   return (
-    <StyledToastEntry>
-      <IconBox>
-        <IconCheck />
-      </IconBox>
-      <HeaderBox>
-        {title && <Title>{title}</Title>}
-        <ContentBox>{message}</ContentBox>
-      </HeaderBox>
-    </StyledToastEntry>
+    <StyledToastWrapper>
+      <StyledToastEntry>
+        <IconBox>
+          <IconCheck />
+        </IconBox>
+        <HeaderBox>
+          {title && <Title>{title}</Title>}
+          <ContentBox>{message}</ContentBox>
+        </HeaderBox>
+      </StyledToastEntry>
+    </StyledToastWrapper>
   );
 };
 
@@ -29,6 +31,13 @@ export default ToastEntry;
 
 const TOAST_CONTAINER_LEFT = 36;
 
+const StyledToastWrapper = styled.div`
+  @media ${MOBILE_MEDIA_QUERY} {
+    display: flex;
+    justify-content: center;
+    width: 100%;
+  }
+`;
 const StyledToastEntry = styled.div`
   display: flex;
   border-radius: 18px;


### PR DESCRIPTION
### 🤫 쉿, 나한테만 말해줘요. 이슈넘버
- close #

### 🧐 어떤 것을 변경했어요~?
<!-- 실제로 변경한 사항을 설명해주세요.-->
- 모바일에서 토스트가 가운데 뜨도록 위치를 수정했어요.

### 🤔 그렇다면, 어떻게 구현했어요~?
<!-- 실제로 구현한 로직에 대해 설명해주세요.-->
- 기존 토스트를 StyledToastWrapper로 감싸서 justify-content:center 해주었습니다. 

### ❤️‍🔥 당신이 생각하는 PR포인트, 내겐 매력포인트.
<!-- 해당 PR에서 논의가 필요한 사항을 적어주세요. -->

### 📸 스크린샷, 없으면 이것 참,, 섭섭한데요?


<img width="454" alt="스크린샷 2023-11-28 오전 2 55 45" src="https://github.com/sopt-makers/sopt-playground-frontend/assets/76681519/6fda6c0f-fde0-47b3-bdda-c241113b65a5">

