### PR TITLE
feat: 커뮤니티 이용규칙 프리뷰 최초 진입시에만 뜨도록 수정

### DIFF
--- a/src/components/feed/page/FeedUploadPage.tsx
+++ b/src/components/feed/page/FeedUploadPage.tsx
@@ -3,7 +3,7 @@ import styled from '@emotion/styled';
 import { colors } from '@sopt-makers/colors';
 import { useQuery } from '@tanstack/react-query';
 import { useRouter } from 'next/router';
-import { FormEvent, useRef } from 'react';
+import { FormEvent, useEffect, useRef } from 'react';
 
 import { getCategory } from '@/api/endpoint/feed/getCategory';
 import { useSaveUploadFeedData } from '@/api/endpoint/feed/uploadFeed';
@@ -109,6 +109,10 @@ export default function FeedUploadPage() {
           category.id === feedData.mainCategoryId || category.children.some((tag) => tag.id === feedData.categoryId),
       )) ??
     null;
+
+  useEffect(() => {
+    localStorage.setItem('isFirst', 'true');
+  }, []);
 
   if (isPending) return <Loading />;
 

--- a/src/components/feed/upload/hooks/useCategorySelect.ts
+++ b/src/components/feed/upload/hooks/useCategorySelect.ts
@@ -22,10 +22,12 @@ export function useCategoryUsingRulesPreview(initialState: boolean) {
   const [isPreviewOpen, setIsPreviewOpen] = useState(initialState);
 
   const openUsingRules = () => {
-    setIsPreviewOpen(true);
+    const isFirst = localStorage.getItem('isFirst') ?? 'true';
+    JSON.parse(isFirst) && setIsPreviewOpen(true);
   };
 
   const closeUsingRules = () => {
+    localStorage.setItem('isFirst', 'false');
     setIsPreviewOpen(false);
   };
 


### PR DESCRIPTION
### 🤫 쉿, 나한테만 말해줘요. 이슈넘버
- close #

### 🧐 어떤 것을 변경했어요~?
<!-- 실제로 변경한 사항을 설명해주세요.-->
- 커뮤니티 이용규칙 프리뷰가, 카테고리를 선택할 때마다 매번 등장했는데요, 최초 진입시에만 뜨도록 수정했습니다. 

### 🤔 그렇다면, 어떻게 구현했어요~?
<!-- 실제로 구현한 로직에 대해 설명해주세요.-->
 - 로컬스토리지에 isFirst라는 값으로 저장해주었어요, 
 - 최초 진입시 
 
```
   useEffect(() => {
    localStorage.setItem('isFirst', 'true');
  }, []);
```

- isFirst가 true인 경우에만 open되고, close될 때는 isFirst값을 false로 변경해주었어요. 

 ```
 const openUsingRules = () => {
    const isFirst = localStorage.getItem('isFirst') ?? 'true';
    JSON.parse(isFirst) && setIsPreviewOpen(true);
  };

  const closeUsingRules = () => {
    localStorage.setItem('isFirst', 'false');
    setIsPreviewOpen(false);
  };
```

### ❤️‍🔥 당신이 생각하는 PR포인트, 내겐 매력포인트.
<!-- 해당 PR에서 논의가 필요한 사항을 적어주세요. -->
 - 페이지에 진입하자마자 isFirst값을 변경해주어야해서 useEffect를 사용했숩니다....

### 📸 스크린샷, 없으면 이것 참,, 섭섭한데요?
