### PR TITLE
feat: tag가 없는 카테고리인 경우, 표시하지 않기

### DIFF
--- a/src/components/feed/common/hooks/useCategory.ts
+++ b/src/components/feed/common/hooks/useCategory.ts
@@ -1,0 +1,24 @@
+import { useQuery } from '@tanstack/react-query';
+
+import { getCategory } from '@/api/endpoint/feed/getCategory';
+
+export default function useCategory() {
+  const { data: categoryData } = useQuery({
+    queryKey: getCategory.cacheKey(),
+    queryFn: getCategory.request,
+  });
+
+  const findParentCategory = (categoryId: number) => {
+    const category =
+      categoryData &&
+      categoryData.find((category) =>
+        category.children.length > 0
+          ? category.children.some((tag) => tag.id === categoryId)
+          : category.id === categoryId,
+      );
+
+    return category;
+  };
+
+  return { findParentCategory };
+}

--- a/src/components/feed/detail/DetailFeedCard.tsx
+++ b/src/components/feed/detail/DetailFeedCard.tsx
@@ -43,6 +43,7 @@ interface HeaderProps {
   left?: ReactNode;
   right?: ReactNode;
   renderCategoryLink?: (props: { children: ReactNode; categoryId: string }) => ReactNode;
+  hasChildren?: boolean;
 }
 
 const Header = ({
@@ -52,6 +53,7 @@ const Header = ({
   left,
   right,
   renderCategoryLink = (props) => props.children,
+  hasChildren,
 }: HeaderProps) => {
   return (
     <StyledHeader align='center' justify='space-between' as='header'>
@@ -62,8 +64,12 @@ const Header = ({
           children: (
             <Chip align='center' as='div'>
               <Text typography='SUIT_13_M'>{category}</Text>
-              <IconChevronRight />
-              <Text typography='SUIT_13_M'>{tag}</Text>
+              {hasChildren && (
+                <>
+                  <IconChevronRight />
+                  <Text typography='SUIT_13_M'>{tag}</Text>
+                </>
+              )}
             </Chip>
           ),
           categoryId,

--- a/src/components/feed/detail/FeedDetail.tsx
+++ b/src/components/feed/detail/FeedDetail.tsx
@@ -1,12 +1,13 @@
 import { useQueryClient } from '@tanstack/react-query';
 import { ErrorBoundary } from '@toss/error-boundary';
-import React, { ReactNode, useRef } from 'react';
+import { ReactNode, useRef } from 'react';
 
 import { useGetCommentQuery } from '@/api/endpoint/feed/getComment';
 import { useGetPostQuery } from '@/api/endpoint/feed/getPost';
 import { useGetPostsInfiniteQuery } from '@/api/endpoint/feed/getPosts';
 import useToast from '@/components/common/Toast/useToast';
 import FeedDropdown from '@/components/feed/common/FeedDropdown';
+import useCategory from '@/components/feed/common/hooks/useCategory';
 import { useCategoryInfo } from '@/components/feed/common/hooks/useCurrentCategory';
 import { useDeleteFeed } from '@/components/feed/common/hooks/useDeleteFeed';
 import { useReportFeed } from '@/components/feed/common/hooks/useReportFeed';
@@ -34,16 +35,20 @@ const FeedDetail = ({ postId, renderCategoryLink, renderBackLink }: FeedDetailPr
   const currentCategory = useCategoryInfo(postData?.posts.categoryId.toString());
   const containerRef = useRef<HTMLDivElement>(null);
   const [categoryId] = useCategoryParam();
+  const { findParentCategory } = useCategory();
 
   if (postData == null || commentData == null) {
     return null;
   }
+
+  const children = findParentCategory(postData.posts.categoryId)?.children ?? [];
 
   return (
     <DetailFeedCard>
       <DetailFeedCard.Header
         category={currentCategory?.category?.name ?? ''}
         tag={currentCategory?.tag?.name ?? '전체'}
+        hasChildren={children.length > 0}
         categoryId={postData.posts.categoryId.toString()}
         renderCategoryLink={renderCategoryLink}
         left={renderBackLink({


### PR DESCRIPTION
### 🤫 쉿, 나한테만 말해줘요. 이슈넘버
- close #

### 🧐 어떤 것을 변경했어요~?
<!-- 실제로 변경한 사항을 설명해주세요.-->
- tag가 없는 카테고리(ex.자유)인 경우, detail feed에서 표기되지 않도록 구현했어요. 

### 🤔 그렇다면, 어떻게 구현했어요~?
<!-- 실제로 구현한 로직에 대해 설명해주세요.-->
- boolean값인 hasChildren을 내려주었어요, 
```
const children = findParentCategory(postData.posts.categoryId)?.children ?? [];

<DetailFeedCard.Header
        ...
        hasChildren={children.length > 0} 
```

```
              {hasChildren && (
                <>
                  <IconChevronRight />
                  <Text typography='SUIT_13_M'>{tag}</Text>
                </>
              )}
```
- hasChildren이 true일 때에만 `>tag` 가 보이게 했어요. 


### ❤️‍🔥 당신이 생각하는 PR포인트, 내겐 매력포인트.
<!-- 해당 PR에서 논의가 필요한 사항을 적어주세요. -->
- 여기서 쓰인 findParentCategory를 훅으로 뺐는데요, 카테고리 아이디 하나로 부모 카테고리를 찾는 로직이 꽤 반복적으로 사용되어서, 훅으로 뺐고, 기존에 쓰인 코드는 후에 리팩토링하겠씁니다!(근데 슬랙보니까, 이제 부모 카테고리아이디&네임/현재 카테고리아이디&네임 둘 다 내려주는 방식으로 변경하기로 된 것 같기도 하네요...)

### 📸 스크린샷, 없으면 이것 참,, 섭섭한데요?
<img width="541" alt="스크린샷 2023-11-28 오후 5 10 17" src="https://github.com/sopt-makers/sopt-playground-frontend/assets/76681519/f432e955-f34c-431c-a9e0-f44f5be9bdd9">
