### PR TITLE
feat: 댓글 수정, 삭제 시 invalidate되는 onSuccess 로직 추가

### DIFF
--- a/src/api/endpoint/feed/postComment.ts
+++ b/src/api/endpoint/feed/postComment.ts
@@ -1,6 +1,7 @@
-import { useMutation } from '@tanstack/react-query';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { z } from 'zod';
 
+import { useGetPostsInfiniteQuery } from '@/api/endpoint/feed/getPosts';
 import { createEndpoint } from '@/api/typedAxios';
 
 interface RequestBody {
@@ -22,7 +23,12 @@ export const postComment = createEndpoint({
 });
 
 export const usePostCommentMutation = (postId: string) => {
+  const queryClient = useQueryClient();
+
   return useMutation({
     mutationFn: (reqeustBody: RequestBody) => postComment.request(postId, reqeustBody),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: useGetPostsInfiniteQuery.getKey('') });
+    },
   });
 };

--- a/src/components/feed/common/hooks/useDeleteComment.ts
+++ b/src/components/feed/common/hooks/useDeleteComment.ts
@@ -1,7 +1,9 @@
 import { colors } from '@sopt-makers/colors';
+import { useQueryClient } from '@tanstack/react-query';
 import { useCallback } from 'react';
 
 import { useDeleteCommentMutation } from '@/api/endpoint/feed/deleteComment';
+import { useGetPostsInfiniteQuery } from '@/api/endpoint/feed/getPosts';
 import useConfirm from '@/components/common/Modal/useConfirm';
 import { zIndex } from '@/styles/zIndex';
 
@@ -13,6 +15,7 @@ interface Options {
 export const useDeleteComment = () => {
   const { mutate } = useDeleteCommentMutation();
   const { confirm } = useConfirm();
+  const queryClient = useQueryClient();
 
   const handleDeleteComment = useCallback(
     async (options: Options) => {
@@ -29,6 +32,7 @@ export const useDeleteComment = () => {
       if (result) {
         mutate(options.commentId, {
           onSuccess: () => {
+            queryClient.invalidateQueries({ queryKey: useGetPostsInfiniteQuery.getKey('') });
             options.onSuccess?.();
           },
         });


### PR DESCRIPTION
### 🤫 쉿, 나한테만 말해줘요. 이슈넘버
- close #

### 🧐 어떤 것을 변경했어요~?
<!-- 실제로 변경한 사항을 설명해주세요.-->

### 🤔 그렇다면, 어떻게 구현했어요~?
<!-- 실제로 구현한 로직에 대해 설명해주세요.-->
- 댓글 수정, 삭제 시 invalidate되는 onSuccess 로직을 추가했어요. 

### ❤️‍🔥 당신이 생각하는 PR포인트, 내겐 매력포인트.
<!-- 해당 PR에서 논의가 필요한 사항을 적어주세요. -->
```
    onSuccess: () => {
      queryClient.invalidateQueries({ queryKey: useGetPostsInfiniteQuery.getKey('') });
    },
```

### 📸 스크린샷, 없으면 이것 참,, 섭섭한데요?
