### PR TITLE
feat: 신고 후 확인 모달 구현

### DIFF
--- a/public/icons/check_box_field.svg
+++ b/public/icons/check_box_field.svg
@@ -1,0 +1,4 @@
+<svg width="32" height="32" viewBox="0 0 32 32" fill="none" xmlns="http://www.w3.org/2000/svg">
+<rect width="32" height="32" rx="16" fill="#16BF81"/>
+<path d="M8 15.7333L13.3333 21.3333L24 12" stroke="#FCFCFC" stroke-width="1.2" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/src/components/common/Modal/usePopup.tsx
+++ b/src/components/common/Modal/usePopup.tsx
@@ -42,6 +42,7 @@ const StyledContentWrapper = styled.div`
   display: flex;
   flex-direction: column;
   align-items: center;
+  text-align: center;
 `;
 
 const StyledIcon = styled.div<{ icon: string }>`

--- a/src/components/common/Modal/usePopup.tsx
+++ b/src/components/common/Modal/usePopup.tsx
@@ -1,0 +1,62 @@
+import styled from '@emotion/styled';
+import { useOverlay } from '@toss/use-overlay';
+import { ReactNode, useCallback } from 'react';
+
+import Modal from '@/components/common/Modal';
+
+const usePopup = () => {
+  const { open, close } = useOverlay();
+
+  const popup = useCallback(
+    (options: { icon: string; title: ReactNode; description: ReactNode; maxWidth?: number; zIndex?: number }) =>
+      new Promise<boolean>((resolve) => {
+        open(({ isOpen, close }) => (
+          <Modal
+            isOpen={isOpen}
+            onClose={() => {
+              resolve(false);
+              close();
+            }}
+            hideCloseButton
+            zIndex={options.zIndex}
+          >
+            <StyledPopupContent maxWidth={options.maxWidth}>
+              <StyledIcon icon={options.icon} />
+              <StyledContentWrapper>
+                <Modal.Title>{options.title}</Modal.Title>
+                <StylePopupDescription>{options.description}</StylePopupDescription>
+              </StyledContentWrapper>
+            </StyledPopupContent>
+          </Modal>
+        ));
+      }),
+    [open],
+  );
+
+  return { popup, close };
+};
+
+export default usePopup;
+
+const StyledContentWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+`;
+
+const StyledIcon = styled.div<{ icon: string }>`
+  content: url(${({ icon }) => icon});
+`;
+
+const StyledPopupContent = styled(Modal.Content)<{ maxWidth?: number }>`
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  align-items: center;
+  min-width: 320px;
+  max-width: ${({ maxWidth }) => maxWidth}px;
+`;
+
+const StylePopupDescription = styled.div`
+  width: 100%;
+`;

--- a/src/components/feed/common/hooks/useReportFeed.ts
+++ b/src/components/feed/common/hooks/useReportFeed.ts
@@ -3,6 +3,7 @@ import { useCallback } from 'react';
 import { usePostReportPostMutation } from '@/api/endpoint/feed/postReportPost';
 import useAlert from '@/components/common/Modal/useAlert';
 import useConfirm from '@/components/common/Modal/useConfirm';
+import usePopup from '@/components/common/Modal/usePopup';
 
 interface Options {
   postId: string;
@@ -13,6 +14,7 @@ export const useReportFeed = () => {
   const { confirm } = useConfirm();
   const { alert } = useAlert();
   const { mutate } = usePostReportPostMutation();
+  const { popup } = usePopup();
 
   const handleReport = useCallback(
     async (options: Options) => {
@@ -26,10 +28,12 @@ export const useReportFeed = () => {
       if (result) {
         mutate(options.postId, {
           onSuccess: () => {
-            alert({
+            popup({
+              icon: '/icons/check_box_field.svg',
               title: '신고해주셔서 감사해요',
               description:
                 '메이커스에서 빠르게 검토 후 적절한 조치를 취할게요 :) 건전한 커뮤니티를 만드는데 기여해주셔서 감사해요!',
+              maxWidth: 324,
             });
             options.onSuccess?.();
           },


### PR DESCRIPTION
### 🤫 쉿, 나한테만 말해줘요. 이슈넘버
- close #1207

### 🧐 어떤 것을 변경했어요~?
<!-- 실제로 변경한 사항을 설명해주세요.-->
- 신고 후 확인 모달이 피그마 디자인과 달라서 변경해주었어요. 

### 🤔 그렇다면, 어떻게 구현했어요~?
<!-- 실제로 구현한 로직에 대해 설명해주세요.-->
- 기존 alert를 이용하기에는,,, 확인 버튼도 없고, 체크 아이콘이 있으며, 콘텐츠들이 가운데 정렬이에요. 

- 특히 확인 버튼이 없다는 점에서, 모달과는 다른 로직이라고 생각했고, useAlert코드를 참고하여 usePopup을 만들었어요. usePopup에서는 확인버튼에 대한 정보를 내려받지 않는 대신, 아이콘을 내려받는 로직입니다. 

### ❤️‍🔥 당신이 생각하는 PR포인트, 내겐 매력포인트.
<!-- 해당 PR에서 논의가 필요한 사항을 적어주세요. -->
- 아이콘을 svg자체로 내려주고 싶었는데, 잘 적용되지 않아서... 이렇게 링크를 직접 내려주고, usePopup에서는 css의 content 속성을 이용해 보여주었어요..!

```
            popup({
              icon: '/icons/check_box_field.svg',
              title: '신고해주셔서 감사해요',
              description:
                '메이커스에서 빠르게 검토 후 적절한 조치를 취할게요 :) 건전한 커뮤니티를 만드는데 기여해주셔서 감사해요!',
              maxWidth: 324,
            });
```

### 📸 스크린샷, 없으면 이것 참,, 섭섭한데요?


<img width="389" alt="스크린샷 2023-11-28 오후 6 45 58" src="https://github.com/sopt-makers/sopt-playground-frontend/assets/76681519/156de2d8-119a-4a11-b6c8-9b2f68b38ea0">