### PR TITLE
chore: 소소한 css 수정 (댓글 resize none, 인포 ellipsis 처리)

### DIFF
--- a/src/components/feed/detail/DetailFeedCard.tsx
+++ b/src/components/feed/detail/DetailFeedCard.tsx
@@ -545,6 +545,7 @@ const StyledTextArea = styled(TextareaAutosize)`
   background-color: ${colors.background};
   padding-bottom: 7px;
   max-height: 180px;
+  resize: none;
   line-height: 22px;
   line-height: 26px;
   white-space: pre-wrap;

--- a/src/components/feed/list/FeedCard.tsx
+++ b/src/components/feed/list/FeedCard.tsx
@@ -71,9 +71,9 @@ const Base = ({
                 <Text typography='SUIT_14_SB' lineHeight={20}>
                   익명
                 </Text>
-                <Text typography='SUIT_14_R' lineHeight={20} color={colors.gray400}>
+                <InfoText typography='SUIT_14_R' lineHeight={20} color={colors.gray400}>
                   {isShowInfo && info}
-                </Text>
+                </InfoText>
               </Top>
             ) : (
               <Link href={playgroundLink.memberDetail(memberId)}>
@@ -81,9 +81,9 @@ const Base = ({
                   <Text typography='SUIT_14_SB' lineHeight={20}>
                     {name}
                   </Text>
-                  <Text typography='SUIT_14_R' lineHeight={20} color={colors.gray400}>
+                  <InfoText typography='SUIT_14_R' lineHeight={20} color={colors.gray400}>
                     {info}
-                  </Text>
+                  </InfoText>
                 </Top>
               </Link>
             )}
@@ -134,6 +134,17 @@ const Top = styled(Flex)`
 
   @media ${MOBILE_MEDIA_QUERY} {
     gap: 2px;
+  }
+`;
+
+const InfoText = styled(Text)`
+  white-space: nowrap;
+
+  @media screen and (max-width: 460px) {
+    max-width: 220px;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    -webkit-box-orient: vertical;
   }
 `;
 


### PR DESCRIPTION
### 🤫 쉿, 나한테만 말해줘요. 이슈넘버
- close #

### 🧐 어떤 것을 변경했어요~?
<!-- 실제로 변경한 사항을 설명해주세요.-->
- 818c7b5a4ad5ab021d8b774edcfb0d7f47621881 인포 길어지면 ellipsis 처리 리스트의 카드에서도 적용
- [21f1655](https://github.com/sopt-makers/sopt-playground-frontend/pull/1215/commits/21f1655746cde3aee00eb840242fe4c5d1909743) 댓글 textArea resize none 추가

### 🤔 그렇다면, 어떻게 구현했어요~?
<!-- 실제로 구현한 로직에 대해 설명해주세요.-->

### ❤️‍🔥 당신이 생각하는 PR포인트, 내겐 매력포인트.
<!-- 해당 PR에서 논의가 필요한 사항을 적어주세요. -->

### 📸 스크린샷, 없으면 이것 참,, 섭섭한데요?
