### PR TITLE
fix: 피드 이미지 슬라이더 > 이미지 닫기 버튼이 사진보다 위로 올라오도록

### DIFF
--- a/src/components/feed/detail/slider/FeedImageSlider.tsx
+++ b/src/components/feed/detail/slider/FeedImageSlider.tsx
@@ -38,9 +38,6 @@ const FeedImageSlider = ({ images, opened, onClose }: FeedImageSliderProps) => {
           <RemoveScroll>
             <Background initial={{ opacity: 0 }} animate={{ opacity: 1 }} exit={{ opacity: 0 }}>
               {images.length > 1 ? <StyledIndex>{`${activeIndex + 1}/${images.length}`}</StyledIndex> : null}
-              <CloseButton onClick={onClose}>
-                <IconClose />
-              </CloseButton>
               <Responsive only='desktop' asChild>
                 <StyledSwiper
                   modules={[Navigation]}
@@ -63,6 +60,9 @@ const FeedImageSlider = ({ images, opened, onClose }: FeedImageSliderProps) => {
                   ))}
                 </StyledSwiper>
               </Responsive>
+              <CloseButton onClick={onClose}>
+                <IconClose />
+              </CloseButton>
             </Background>
           </RemoveScroll>
         </Portal>
@@ -93,6 +93,7 @@ const CloseButton = styled.button`
   bottom: 48px;
   flex-shrink: 0;
   transition: background-color 0.2s ease-in-out;
+  z-index: 1;
   border-radius: 50%;
   background-color: ${colors.gray10};
   padding: 12px;

--- a/src/components/feed/detail/slider/FeedImageSlider.tsx
+++ b/src/components/feed/detail/slider/FeedImageSlider.tsx
@@ -38,6 +38,9 @@ const FeedImageSlider = ({ images, opened, onClose }: FeedImageSliderProps) => {
           <RemoveScroll>
             <Background initial={{ opacity: 0 }} animate={{ opacity: 1 }} exit={{ opacity: 0 }}>
               {images.length > 1 ? <StyledIndex>{`${activeIndex + 1}/${images.length}`}</StyledIndex> : null}
+              <CloseButton onClick={onClose}>
+                <IconClose />
+              </CloseButton>
               <Responsive only='desktop' asChild>
                 <StyledSwiper
                   modules={[Navigation]}
@@ -60,9 +63,6 @@ const FeedImageSlider = ({ images, opened, onClose }: FeedImageSliderProps) => {
                   ))}
                 </StyledSwiper>
               </Responsive>
-              <CloseButton onClick={onClose}>
-                <IconClose />
-              </CloseButton>
             </Background>
           </RemoveScroll>
         </Portal>


### PR DESCRIPTION
### 🤫 쉿, 나한테만 말해줘요. 이슈넘버
- close #

### 🧐 어떤 것을 변경했어요~?
<!-- 실제로 변경한 사항을 설명해주세요.-->
이미지가 길 경우 버튼이 가려져 닫을 수 없는 문제를 z-index로 해결했어요
z-index 잘못 쓰면 이리저리 관리하기 어렵지만 포탈 내부라 크게 고민 안 하고 갈겼습니다

### 🤔 그렇다면, 어떻게 구현했어요~?
<!-- 실제로 구현한 로직에 대해 설명해주세요.-->

### ❤️‍🔥 당신이 생각하는 PR포인트, 내겐 매력포인트.
<!-- 해당 PR에서 논의가 필요한 사항을 적어주세요. -->

### 📸 스크린샷, 없으면 이것 참,, 섭섭한데요?

as-is

<img width="419" alt="image" src="https://github.com/sopt-makers/sopt-playground-frontend/assets/73823388/30db0a97-21db-4015-9c66-99c7b954b8d4">


to-be
<img width="451" alt="image" src="https://github.com/sopt-makers/sopt-playground-frontend/assets/73823388/a0b55dd4-9680-450b-8cd8-42d69a40eec9">

