### PR TITLE
feat: 로깅 전용 headless 컴포넌트 추가

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "@tanstack/react-query": "^5.4.3",
     "@toss/emotion-utils": "^1.1.10",
     "@toss/error-boundary": "^1.4.6",
+    "@toss/impression-area": "^1.3.1",
     "@toss/use-overlay": "^1.3.6",
     "await-to-js": "^3.0.0",
     "axios": "^0.27.2",

--- a/src/components/eventLogger/components/LoggingClick.tsx
+++ b/src/components/eventLogger/components/LoggingClick.tsx
@@ -1,0 +1,29 @@
+import React, { ReactElement, useCallback } from 'react';
+
+import { ClickEvents } from '@/components/eventLogger/events';
+import useEventLogger from '@/components/eventLogger/hooks/useEventLogger';
+
+interface LoggingClickProps<K extends keyof ClickEvents = keyof ClickEvents> {
+  eventKey: K;
+  params: ClickEvents[K];
+  children: ReactElement;
+}
+
+export const LoggingClick: React.FC<LoggingClickProps> = ({ eventKey, params, children }) => {
+  const { logClickEvent } = useEventLogger();
+
+  const logEvent = useCallback(() => {
+    logClickEvent(eventKey, params);
+  }, [eventKey, params, logClickEvent]);
+
+  const childrenWithLogging = React.cloneElement(children, {
+    onClick: (e: React.MouseEvent) => {
+      logEvent();
+      if (typeof children.props.onClick === 'function') {
+        children.props.onClick(e);
+      }
+    },
+  });
+
+  return childrenWithLogging;
+};

--- a/src/components/eventLogger/components/LoggingClick.tsx
+++ b/src/components/eventLogger/components/LoggingClick.tsx
@@ -2,19 +2,32 @@ import React, { ReactElement, useCallback } from 'react';
 
 import { ClickEvents } from '@/components/eventLogger/events';
 import useEventLogger from '@/components/eventLogger/hooks/useEventLogger';
+import { ParamTuple } from '@/components/eventLogger/types';
 
-interface LoggingClickProps<K extends keyof ClickEvents = keyof ClickEvents> {
-  eventKey: K;
-  params: ClickEvents[K];
+type LoggingClickProps<Key extends keyof ClickEvents> = {
+  eventKey: Key;
   children: ReactElement;
-}
+} & (undefined extends ClickEvents[Key] ? unknown : { param: ClickEvents[Key] });
 
-export const LoggingClick: React.FC<LoggingClickProps> = ({ eventKey, params, children }) => {
+/**
+ *
+ * @description: onClick 이벤트가 있는 컴포넌트에 LoggingClick을 감싸주어 로깅을 쉽게 처리할 수 있는 컴포넌트에요.
+ * 커스텀 컴포넌트의 경우 onClick 이벤트를 부착해주세요.
+ */
+export const LoggingClick = <K extends keyof ClickEvents = keyof ClickEvents>({
+  eventKey,
+  children,
+  ...props
+}: LoggingClickProps<K>) => {
   const { logClickEvent } = useEventLogger();
 
   const logEvent = useCallback(() => {
-    logClickEvent(eventKey, params);
-  }, [eventKey, params, logClickEvent]);
+    if ('param' in props) {
+      logClickEvent<K>(eventKey, ...([props.param] as ParamTuple<ClickEvents[K]>));
+    } else {
+      logClickEvent<K>(eventKey, ...([undefined] as ParamTuple<ClickEvents[K]>));
+    }
+  }, [props, eventKey, logClickEvent]);
 
   const childrenWithLogging = React.cloneElement(children, {
     onClick: (e: React.MouseEvent) => {

--- a/src/components/eventLogger/components/LoggingImpression.tsx
+++ b/src/components/eventLogger/components/LoggingImpression.tsx
@@ -1,0 +1,34 @@
+import { ImpressionArea, ImpressionAreaProps } from '@toss/impression-area';
+import { PropsWithChildren, ReactNode } from 'react';
+
+import { ImpressionEvents } from '@/components/eventLogger/events';
+import useEventLogger from '@/components/eventLogger/hooks/useEventLogger';
+import { ParamTuple } from '@/components/eventLogger/types';
+
+type LoggingImpressionProps<Key extends keyof ImpressionEvents> = {
+  eventKey: Key;
+  children: ReactNode;
+} & (undefined extends ImpressionEvents[Key] ? unknown : { param: ImpressionEvents[Key] }) &
+  ImpressionAreaProps;
+
+export const LoggingImpression = <K extends keyof ImpressionEvents = keyof ImpressionEvents>({
+  eventKey,
+  children,
+  ...props
+}: PropsWithChildren<LoggingImpressionProps<K>>) => {
+  const { logImpressionEvent } = useEventLogger();
+
+  const logEvent = () => {
+    if ('param' in props) {
+      logImpressionEvent<K>(eventKey, ...([props.param] as ParamTuple<ImpressionEvents[K]>));
+    } else {
+      logImpressionEvent<K>(eventKey, ...([undefined] as unknown as ParamTuple<ImpressionEvents[K]>));
+    }
+  };
+
+  return (
+    <ImpressionArea onImpressionStart={logEvent} {...props}>
+      {children}
+    </ImpressionArea>
+  );
+};

--- a/src/components/eventLogger/components/LoggingPageView.tsx
+++ b/src/components/eventLogger/components/LoggingPageView.tsx
@@ -1,0 +1,21 @@
+import { ReactNode } from 'react';
+
+import { PageViewEvents } from '@/components/eventLogger/events';
+import useEventLogger from '@/components/eventLogger/hooks/useEventLogger';
+import { useRunOnce } from '@/hooks/useRunOnce';
+
+interface LoggingPageViewProps<K extends keyof PageViewEvents = keyof PageViewEvents> {
+  eventKey: K;
+  params?: PageViewEvents[K];
+  children: ReactNode;
+}
+
+export const LoggingPageView = ({ eventKey, params, children }: LoggingPageViewProps) => {
+  const { logPageViewEvent } = useEventLogger();
+
+  useRunOnce(() => {
+    logPageViewEvent(eventKey, params);
+  }, []);
+
+  return <>{children}</>;
+};

--- a/src/components/eventLogger/components/LoggingPageView.tsx
+++ b/src/components/eventLogger/components/LoggingPageView.tsx
@@ -2,19 +2,27 @@ import { ReactNode } from 'react';
 
 import { PageViewEvents } from '@/components/eventLogger/events';
 import useEventLogger from '@/components/eventLogger/hooks/useEventLogger';
+import { ParamTuple } from '@/components/eventLogger/types';
 import { useRunOnce } from '@/hooks/useRunOnce';
 
-interface LoggingPageViewProps<K extends keyof PageViewEvents = keyof PageViewEvents> {
-  eventKey: K;
-  params?: PageViewEvents[K];
+type LoggingPageViewProps<Key extends keyof PageViewEvents> = {
+  eventKey: Key;
   children: ReactNode;
-}
+} & (undefined extends PageViewEvents[Key] ? unknown : { param: PageViewEvents[Key] });
 
-export const LoggingPageView = ({ eventKey, params, children }: LoggingPageViewProps) => {
+export const LoggingPageView = <K extends keyof PageViewEvents = keyof PageViewEvents>({
+  eventKey,
+  children,
+  ...props
+}: LoggingPageViewProps<K>) => {
   const { logPageViewEvent } = useEventLogger();
 
   useRunOnce(() => {
-    logPageViewEvent(eventKey, params);
+    if ('param' in props) {
+      logPageViewEvent<K>(eventKey, ...([props.param] as ParamTuple<PageViewEvents[K]>));
+    } else {
+      logPageViewEvent<K>(eventKey, ...([undefined] as ParamTuple<PageViewEvents[K]>));
+    }
   }, []);
 
   return <>{children}</>;

--- a/src/components/eventLogger/controllers/amplitude.ts
+++ b/src/components/eventLogger/controllers/amplitude.ts
@@ -22,5 +22,8 @@ export function createAmplitudeController(apiKey: string, userId: string | undef
     pageViewEvent(key, ...params) {
       instance.track(`Pageview-${key}`, ...params);
     },
+    impressionEvent(key, ...params) {
+      instance.track(`Impression-${key}`, ...params);
+    },
   };
 }

--- a/src/components/eventLogger/controllers/consoleLog.ts
+++ b/src/components/eventLogger/controllers/consoleLog.ts
@@ -11,5 +11,8 @@ export function createConsoleLogController(): EventLoggerController {
     pageViewEvent(key, ...params) {
       console.log('[EventLogger.pageviewEvent]', key, ...params);
     },
+    impressionEvent(key, ...params) {
+      console.log('[EventLogger.impressionEvent]', key, ...params);
+    },
   };
 }

--- a/src/components/eventLogger/controllers/storybookAction.ts
+++ b/src/components/eventLogger/controllers/storybookAction.ts
@@ -13,5 +13,8 @@ export function createStorybookActionController(): EventLoggerController {
     pageViewEvent(key, ...params) {
       action('EventLogger.pageviewEvent')(key, ...params);
     },
+    impressionEvent(key, ...params) {
+      action('EventLogger.impressionEvent')(key, ...params);
+    },
   };
 }

--- a/src/components/eventLogger/events.ts
+++ b/src/components/eventLogger/events.ts
@@ -56,6 +56,13 @@ export interface ClickEvents {
   };
   mentorApplicationButton: undefined;
   wordchainEntry: undefined;
+  // 커뮤니티(피드)
+  feedCategory: {
+    category: string;
+  };
+  shareButton: {
+    feedId: string;
+  };
 }
 
 export interface SubmitEvents {
@@ -92,4 +99,17 @@ export interface PageViewEvents {
     mentorId: number;
   };
   wordchain: undefined;
+  // 커뮤니티(피드)
+  feedList: undefined;
+  feedDetail: {
+    feedId: string;
+    category?: string;
+  };
+}
+
+export interface ImpressionEvents {
+  feedCard: {
+    feedId: string;
+    categoryId: string;
+  };
 }

--- a/src/components/eventLogger/hooks/useEventLogger.ts
+++ b/src/components/eventLogger/hooks/useEventLogger.ts
@@ -9,6 +9,7 @@ const useEventLogger = () => {
     logClickEvent: controller.clickEvent,
     logSubmitEvent: controller.submitEvent,
     logPageViewEvent: controller.pageViewEvent,
+    logImpressionEvent: controller.impressionEvent,
   };
 };
 

--- a/src/components/eventLogger/types.ts
+++ b/src/components/eventLogger/types.ts
@@ -1,9 +1,10 @@
-import { ClickEvents, PageViewEvents, SubmitEvents } from '@/components/eventLogger/events';
+import { ClickEvents, ImpressionEvents, PageViewEvents, SubmitEvents } from '@/components/eventLogger/events';
 
 export interface EventLoggerController {
   clickEvent<K extends keyof ClickEvents>(key: K, ...params: ParamTuple<ClickEvents[K]>): void;
   submitEvent<K extends keyof SubmitEvents>(key: K, ...params: ParamTuple<SubmitEvents[K]>): void;
   pageViewEvent<K extends keyof PageViewEvents>(key: K, ...params: ParamTuple<PageViewEvents[K]>): void;
+  impressionEvent<K extends keyof ImpressionEvents>(key: K, ...params: ParamTuple<ImpressionEvents[K]>): void;
 }
 
-type ParamTuple<T> = T extends undefined ? [] : [params: T];
+export type ParamTuple<T> = T extends undefined ? [] : [params: T];

--- a/src/components/feed/list/CategorySelect.tsx
+++ b/src/components/feed/list/CategorySelect.tsx
@@ -3,6 +3,7 @@ import { colors } from '@sopt-makers/colors';
 import { FC } from 'react';
 
 import HorizontalScroller from '@/components/common/HorizontalScroller';
+import { LoggingClick } from '@/components/eventLogger/components/LoggingClick';
 import { CategoryLink, useCategoryParam } from '@/components/feed/common/queryParam';
 import { textStyles } from '@/styles/typography';
 
@@ -29,17 +30,25 @@ const CategorySelect: FC<CategorySelectProps> = ({ categories }) => {
     <Container>
       <HorizontalScroller>
         <CategoryBox>
-          <Category categoryId={undefined} active={currentCategoryId === ''}>
-            전체
-          </Category>
-          {categories.map((category) => (
-            <Category
-              categoryId={category.hasAllCategory ? category.id : category.tags.at(0)?.id ?? category.id} // 하위에 "전체" 카테고리가 없으면 태그의 첫 카테고리로 보내기
-              key={category.id}
-              active={parentCategory?.id === category.id}
-            >
-              {category.name}
+          <LoggingClick
+            eventKey='feedCategory'
+            param={{
+              category: '전체',
+            }}
+          >
+            <Category categoryId={undefined} active={currentCategoryId === ''}>
+              전체
             </Category>
+          </LoggingClick>
+          {categories.map((category) => (
+            <LoggingClick key={category.id} eventKey='feedCategory' param={{ category: category.name }}>
+              <Category
+                categoryId={category.hasAllCategory ? category.id : category.tags.at(0)?.id ?? category.id} // 하위에 "전체" 카테고리가 없으면 태그의 첫 카테고리로 보내기
+                active={parentCategory?.id === category.id}
+              >
+                {category.name}
+              </Category>
+            </LoggingClick>
           ))}
         </CategoryBox>
       </HorizontalScroller>
@@ -47,14 +56,18 @@ const CategorySelect: FC<CategorySelectProps> = ({ categories }) => {
         <HorizontalScroller css={{ marginBottom: '8px' }}>
           <TagBox>
             {parentCategory.hasAllCategory && (
-              <Chip categoryId={parentCategory.id} active={parentCategory.id === currentCategoryId}>
-                전체
-              </Chip>
+              <LoggingClick eventKey='feedCategory' param={{ category: '전체' }}>
+                <Chip categoryId={parentCategory.id} active={parentCategory.id === currentCategoryId}>
+                  전체
+                </Chip>
+              </LoggingClick>
             )}
             {parentCategory.tags.map((tag) => (
-              <Chip key={tag.id} categoryId={tag.id} active={tag.id === currentCategoryId}>
-                {tag.name}
-              </Chip>
+              <LoggingClick key={tag.id} eventKey='feedCategory' param={{ category: tag.name }}>
+                <Chip key={tag.id} categoryId={tag.id} active={tag.id === currentCategoryId}>
+                  {tag.name}
+                </Chip>
+              </LoggingClick>
             ))}
           </TagBox>
         </HorizontalScroller>

--- a/src/components/feed/list/FeedList.tsx
+++ b/src/components/feed/list/FeedList.tsx
@@ -6,6 +6,7 @@ import Link from 'next/link';
 import { FC, ReactNode } from 'react';
 
 import { getCategory } from '@/api/endpoint/feed/getCategory';
+import { LoggingPageView } from '@/components/eventLogger/components/LoggingPageView';
 import { useCategoryParam } from '@/components/feed/common/queryParam';
 import CategorySelect from '@/components/feed/list/CategorySelect';
 import FeedListItems from '@/components/feed/list/FeedListItems';
@@ -35,24 +36,26 @@ const FeedList: FC<FeedListProps> = ({ renderFeedDetailLink }) => {
   }));
 
   return (
-    <Container>
-      <CategoryArea>{categories && <CategorySelect categories={categories} />}</CategoryArea>
-      <HeightSpacer>
-        <ErrorBoundary
-          renderFallback={(error) => (
-            <div css={{ textAlign: 'center' }}>
-              게시글을 보여주는데 문제가 발생했어요.
-              <br />({error.error.message})
-            </div>
-          )}
-        >
-          <FeedListItems categoryId={categoryId} renderFeedDetailLink={renderFeedDetailLink} />
-        </ErrorBoundary>
-      </HeightSpacer>
-      <UploadLink href={playgroundLink.feedUpload()}>
-        <UploadIcon />
-      </UploadLink>
-    </Container>
+    <LoggingPageView eventKey='feedList'>
+      <Container>
+        <CategoryArea>{categories && <CategorySelect categories={categories} />}</CategoryArea>
+        <HeightSpacer>
+          <ErrorBoundary
+            renderFallback={(error) => (
+              <div css={{ textAlign: 'center' }}>
+                게시글을 보여주는데 문제가 발생했어요.
+                <br />({error.error.message})
+              </div>
+            )}
+          >
+            <FeedListItems categoryId={categoryId} renderFeedDetailLink={renderFeedDetailLink} />
+          </ErrorBoundary>
+        </HeightSpacer>
+        <UploadLink href={playgroundLink.feedUpload()}>
+          <UploadIcon />
+        </UploadLink>
+      </Container>
+    </LoggingPageView>
   );
 };
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -6914,6 +6914,20 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@toss/impression-area@npm:^1.3.1":
+  version: 1.3.1
+  resolution: "@toss/impression-area@npm:1.3.1"
+  dependencies:
+    "@toss/react": ^1.6.1
+    "@toss/utils": ^1.4.6
+    "@types/react": ^18.0.21
+    lodash.debounce: ^4.0.8
+  peerDependencies:
+    react: "*"
+  checksum: bc29c2b4e92586eb0e39518b5c5419514d1bbfc734b305c2d9f4fcc925829f3982a81b4a950d428485144cdde318fd702b076e0099c9c34294e4294a3b55fa77
+  languageName: node
+  linkType: hard
+
 "@toss/react@npm:^1.6.1":
   version: 1.6.1
   resolution: "@toss/react@npm:1.6.1"
@@ -18463,6 +18477,7 @@ __metadata:
     "@testing-library/react": ^14.0.0
     "@toss/emotion-utils": ^1.1.10
     "@toss/error-boundary": ^1.4.6
+    "@toss/impression-area": ^1.3.1
     "@toss/use-overlay": ^1.3.6
     "@types/jest": ^29.4.0
     "@types/jscodeshift": ^0


### PR DESCRIPTION
### 🤫 쉿, 나한테만 말해줘요. 이슈넘버
- close #1224

### 🧐 어떤 것을 변경했어요~?
<!-- 실제로 변경한 사항을 설명해주세요.-->
- pageView, impression, click에 해당하는 headless 로깅 컴포넌트를 만들었어요.
- 이때 LoggingClick의 경우에는 React.cloneElement 를 통해 동작하기 때문에 onClick이 정의되지 않은 커스텀 컴포넌트에는 사용할 수 없어요. 건영이가 LinkWithLog를 말해줬는데요, 요건 생각해보면 얘로 구현 자체를 갈아끼워야 해서 뭔가 취지랑 조곰 맞지 않을수도 있겠다 해서 이렇게 제공해보려고 해요..! 

### 🤔 그렇다면, 어떻게 구현했어요~?
<!-- 실제로 구현한 로직에 대해 설명해주세요.-->

### ❤️‍🔥 당신이 생각하는 PR포인트, 내겐 매력포인트.
<!-- 해당 PR에서 논의가 필요한 사항을 적어주세요. -->

### 📸 스크린샷, 없으면 이것 참,, 섭섭한데요?
