### PR TITLE
feat: 피드 업로드 페이지 로깅 구현

### DIFF
--- a/src/api/endpoint/feed/uploadFeed.ts
+++ b/src/api/endpoint/feed/uploadFeed.ts
@@ -1,10 +1,11 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { useRouter } from 'next/router';
+import { playgroundLink } from 'playground-common/export';
 import { z } from 'zod';
 
 import { useGetPostsInfiniteQuery } from '@/api/endpoint/feed/getPosts';
 import { createEndpoint } from '@/api/typedAxios';
-import { playgroundLink } from '@/constants/links';
+
 interface RequestBody {
   categoryId: number;
   title: string | null;
@@ -24,8 +25,8 @@ export const uploadFeed = createEndpoint({
 });
 
 export const useSaveUploadFeedData = () => {
-  const queryClient = useQueryClient();
   const router = useRouter();
+  const queryClient = useQueryClient();
 
   return useMutation({
     mutationFn: (reqeustBody: RequestBody) => uploadFeed.request(reqeustBody),

--- a/src/api/endpoint/feed/uploadFeed.ts
+++ b/src/api/endpoint/feed/uploadFeed.ts
@@ -5,6 +5,7 @@ import { z } from 'zod';
 
 import { useGetPostsInfiniteQuery } from '@/api/endpoint/feed/getPosts';
 import { createEndpoint } from '@/api/typedAxios';
+import useEventLogger from '@/components/eventLogger/hooks/useEventLogger';
 
 interface RequestBody {
   categoryId: number;
@@ -27,10 +28,12 @@ export const uploadFeed = createEndpoint({
 export const useSaveUploadFeedData = () => {
   const router = useRouter();
   const queryClient = useQueryClient();
+  const { logSubmitEvent } = useEventLogger();
 
   return useMutation({
     mutationFn: (reqeustBody: RequestBody) => uploadFeed.request(reqeustBody),
     onSuccess: async () => {
+      logSubmitEvent('submitCommunity');
       queryClient.invalidateQueries({ queryKey: useGetPostsInfiniteQuery.getKey('') });
       await router.push(playgroundLink.feedList());
     },

--- a/src/components/eventLogger/events.ts
+++ b/src/components/eventLogger/events.ts
@@ -6,6 +6,14 @@ type ProjectCard = {
   id: number;
   name: string;
 };
+type CommunityFeedData = {
+  categoryId: number;
+  title: string | null;
+  content: string;
+  isQuestion: boolean;
+  isBlindWriter: boolean;
+  images: string[];
+};
 
 export interface ClickEvents {
   memberCard: MemberCard;
@@ -56,6 +64,11 @@ export interface ClickEvents {
   };
   mentorApplicationButton: undefined;
   wordchainEntry: undefined;
+  communityRulesClick: undefined;
+  communityUploadCodeButton: undefined;
+  quitUploadCommunity: {
+    feedData: CommunityFeedData;
+  };
 }
 
 export interface SubmitEvents {
@@ -82,6 +95,7 @@ export interface SubmitEvents {
     word: string;
   };
   wordchainNewGame: undefined;
+  submitCommunity: undefined;
 }
 
 export interface PageViewEvents {

--- a/src/components/feed/page/FeedUploadPage.tsx
+++ b/src/components/feed/page/FeedUploadPage.tsx
@@ -10,6 +10,7 @@ import { useSaveUploadFeedData } from '@/api/endpoint/feed/uploadFeed';
 import Checkbox from '@/components/common/Checkbox';
 import Loading from '@/components/common/Loading';
 import Responsive from '@/components/common/Responsive';
+import { LoggingClick } from '@/components/eventLogger/components/LoggingClick';
 import useEventLogger from '@/components/eventLogger/hooks/useEventLogger';
 import Category from '@/components/feed/upload/Category';
 import CheckboxFormItem from '@/components/feed/upload/CheckboxFormItem';
@@ -82,11 +83,10 @@ export default function FeedUploadPage() {
 
   const { mutate: handleUploadFeed, isPending } = useSaveUploadFeedData();
 
-  const { logSubmitEvent, logClickEvent } = useEventLogger();
+  const { logClickEvent } = useEventLogger();
 
   const handleSubmit = (e: FormEvent<HTMLFormElement>) => {
     e.preventDefault();
-    logSubmitEvent('submitCommunity');
     handleUploadFeed({
       categoryId: feedData.categoryId ?? 0,
       title: feedData.title,
@@ -97,9 +97,8 @@ export default function FeedUploadPage() {
     });
   };
 
-  const handleQuitUpload = async () => {
-    quitUploading();
-    await router.push('/community');
+  const handleQuitUpload = () => {
+    router.push('/community');
   };
 
   const { data: categories } = useQuery({
@@ -156,9 +155,23 @@ export default function FeedUploadPage() {
         <DesktopFeedUploadLayout
           header={
             <>
-              <BackArrowWrapper>
-                <BackArrow onClick={handleQuitUpload} />
-              </BackArrowWrapper>
+              <LoggingClick
+                eventKey='quitUploadCommunity'
+                param={{
+                  feedData: {
+                    categoryId: feedData.categoryId ?? 0,
+                    title: feedData.title,
+                    content: feedData.content,
+                    isQuestion: feedData.isQuestion,
+                    isBlindWriter: feedData.isBlindWriter,
+                    images: feedData.images,
+                  },
+                }}
+              >
+                <BackArrowWrapper onClick={handleQuitUpload}>
+                  <BackArrow />
+                </BackArrowWrapper>
+              </LoggingClick>
               <Category
                 feedData={feedData}
                 onSaveCategory={handleSaveCategory}
@@ -228,9 +241,23 @@ export default function FeedUploadPage() {
           header={
             <>
               <TopHeader>
-                <Button type='button' disabled={false} onClick={handleQuitUpload}>
-                  취소
-                </Button>
+                <LoggingClick
+                  eventKey='quitUploadCommunity'
+                  param={{
+                    feedData: {
+                      categoryId: feedData.categoryId ?? 0,
+                      title: feedData.title,
+                      content: feedData.content,
+                      isQuestion: feedData.isQuestion,
+                      isBlindWriter: feedData.isBlindWriter,
+                      images: feedData.images,
+                    },
+                  }}
+                >
+                  <Button type='button' disabled={false} onClick={handleQuitUpload}>
+                    취소
+                  </Button>
+                </LoggingClick>
                 <Button type='submit' disabled={!checkReadyToUpload()}>
                   올리기
                 </Button>

--- a/src/components/feed/upload/CodeUploadButton/index.tsx
+++ b/src/components/feed/upload/CodeUploadButton/index.tsx
@@ -6,7 +6,7 @@ import { BottomSheet } from '@/components/common/BottomSheet';
 import Modal from '@/components/common/Modal';
 import useModalState from '@/components/common/Modal/useModalState';
 import Responsive from '@/components/common/Responsive';
-import useEventLogger from '@/components/eventLogger/hooks/useEventLogger';
+import { LoggingClick } from '@/components/eventLogger/components/LoggingClick';
 import carbonCodeBlockImg from '@/public/icons/img/carbon_code_block.png';
 import { MOBILE_MEDIA_QUERY } from '@/styles/mediaQuery';
 import { textStyles } from '@/styles/typography';
@@ -15,35 +15,31 @@ const CARBON_LINK = 'https://carbon.now.sh/';
 
 export default function CodeUploadButton() {
   const { isOpen, onClose, onOpen } = useModalState();
-  const { logClickEvent } = useEventLogger();
-
-  const handleOpenCode = () => {
-    logClickEvent('communityUploadCodeButton');
-    onOpen();
-  };
 
   return (
-    <>
-      <Button onClick={handleOpenCode} type='button'>
-        {codeSvg}코드
-      </Button>
-      <Responsive only='desktop' asChild>
-        <Modal onClose={onClose} isOpen={isOpen} hideCloseButton>
-          <Modal.Content style={{ width: 'fit-content' }}>
+    <LoggingClick eventKey='communityUploadCodeButton'>
+      <>
+        <Button onClick={onOpen} type='button'>
+          {codeSvg}코드
+        </Button>
+        <Responsive only='desktop' asChild>
+          <Modal onClose={onClose} isOpen={isOpen} hideCloseButton>
+            <Modal.Content style={{ width: 'fit-content' }}>
+              <UnsupportedCodeMessage />
+            </Modal.Content>
+            <StyledModalFooter align='stretch'>
+              <StyledModalButton action='close'>확인</StyledModalButton>
+            </StyledModalFooter>
+          </Modal>
+        </Responsive>
+        <Responsive only='mobile' asChild>
+          <StyledBottomSheet isOpen={isOpen} onClose={onClose}>
             <UnsupportedCodeMessage />
-          </Modal.Content>
-          <StyledModalFooter align='stretch'>
-            <StyledModalButton action='close'>확인</StyledModalButton>
-          </StyledModalFooter>
-        </Modal>
-      </Responsive>
-      <Responsive only='mobile' asChild>
-        <StyledBottomSheet isOpen={isOpen} onClose={onClose}>
-          <UnsupportedCodeMessage />
-          <BottomSheetButton onClick={onClose}>확인</BottomSheetButton>
-        </StyledBottomSheet>
-      </Responsive>
-    </>
+            <BottomSheetButton onClick={onClose}>확인</BottomSheetButton>
+          </StyledBottomSheet>
+        </Responsive>
+      </>
+    </LoggingClick>
   );
 }
 

--- a/src/components/feed/upload/CodeUploadButton/index.tsx
+++ b/src/components/feed/upload/CodeUploadButton/index.tsx
@@ -6,6 +6,7 @@ import { BottomSheet } from '@/components/common/BottomSheet';
 import Modal from '@/components/common/Modal';
 import useModalState from '@/components/common/Modal/useModalState';
 import Responsive from '@/components/common/Responsive';
+import useEventLogger from '@/components/eventLogger/hooks/useEventLogger';
 import carbonCodeBlockImg from '@/public/icons/img/carbon_code_block.png';
 import { MOBILE_MEDIA_QUERY } from '@/styles/mediaQuery';
 import { textStyles } from '@/styles/typography';
@@ -14,9 +15,16 @@ const CARBON_LINK = 'https://carbon.now.sh/';
 
 export default function CodeUploadButton() {
   const { isOpen, onClose, onOpen } = useModalState();
+  const { logClickEvent } = useEventLogger();
+
+  const handleOpenCode = () => {
+    logClickEvent('communityUploadCodeButton');
+    onOpen();
+  };
+
   return (
     <>
-      <Button onClick={onOpen} type='button'>
+      <Button onClick={handleOpenCode} type='button'>
         {codeSvg}코드
       </Button>
       <Responsive only='desktop' asChild>

--- a/src/components/feed/upload/UsingRules/UsingRulesButton/index.tsx
+++ b/src/components/feed/upload/UsingRules/UsingRulesButton/index.tsx
@@ -2,6 +2,7 @@ import styled from '@emotion/styled';
 import { colors } from '@sopt-makers/colors';
 
 import Responsive from '@/components/common/Responsive';
+import useEventLogger from '@/components/eventLogger/hooks/useEventLogger';
 import HelpIc from '@/public/icons/icon_help.svg';
 import ArrowIc from '@/public/icons/icon_more.svg';
 import { MOBILE_MEDIA_QUERY } from '@/styles/mediaQuery';
@@ -12,9 +13,16 @@ interface UsingRulesButtonProp {
 }
 
 export default function UsingRulesButton({ onClick }: UsingRulesButtonProp) {
+  const { logClickEvent } = useEventLogger();
+
+  const handleShowUsingRules = () => {
+    logClickEvent('communityRulesClick');
+    onClick();
+  };
+
   return (
     <>
-      <ShowMoreButton type='button' onClick={onClick}>
+      <ShowMoreButton type='button' onClick={handleShowUsingRules}>
         <Responsive only='desktop'>
           <ButtonWrapper>
             <HelpIc />

--- a/src/components/feed/upload/UsingRules/UsingRulesButton/index.tsx
+++ b/src/components/feed/upload/UsingRules/UsingRulesButton/index.tsx
@@ -2,7 +2,7 @@ import styled from '@emotion/styled';
 import { colors } from '@sopt-makers/colors';
 
 import Responsive from '@/components/common/Responsive';
-import useEventLogger from '@/components/eventLogger/hooks/useEventLogger';
+import { LoggingClick } from '@/components/eventLogger/components/LoggingClick';
 import HelpIc from '@/public/icons/icon_help.svg';
 import ArrowIc from '@/public/icons/icon_more.svg';
 import { MOBILE_MEDIA_QUERY } from '@/styles/mediaQuery';
@@ -13,16 +13,9 @@ interface UsingRulesButtonProp {
 }
 
 export default function UsingRulesButton({ onClick }: UsingRulesButtonProp) {
-  const { logClickEvent } = useEventLogger();
-
-  const handleShowUsingRules = () => {
-    logClickEvent('communityRulesClick');
-    onClick();
-  };
-
   return (
-    <>
-      <ShowMoreButton type='button' onClick={handleShowUsingRules}>
+    <LoggingClick eventKey='communityRulesClick'>
+      <ShowMoreButton type='button' onClick={onClick}>
         <Responsive only='desktop'>
           <ButtonWrapper>
             <HelpIc />
@@ -36,7 +29,7 @@ export default function UsingRulesButton({ onClick }: UsingRulesButtonProp) {
           </ButtonWrapper>
         </Responsive>
       </ShowMoreButton>
-    </>
+    </LoggingClick>
   );
 }
 


### PR DESCRIPTION
### 🤫 쉿, 나한테만 말해줘요. 이슈넘버
- close #1227

### 🧐 어떤 것을 변경했어요~?
<!-- 실제로 변경한 사항을 설명해주세요.-->
- 피드 업로드 페이지에 로그를 추가했어요. 
- 코드 버튼 클릭시, 커뮤니티 이용규칙 버튼 클릭 시, submit, 뒤로가기했을 시, 로그를 추가했어요. 

### 🤔 그렇다면, 어떻게 구현했어요~?
<!-- 실제로 구현한 로직에 대해 설명해주세요.-->
- 코드버튼, 커뮤니티 이용규칙 버튼 클릭 시, submit은 기존 코드를 참고했어요!

### ❤️‍🔥 당신이 생각하는 PR포인트, 내겐 매력포인트.
<!-- 해당 PR에서 논의가 필요한 사항을 적어주세요. -->
- 뒤로가기 시에는 (1) 우리가 구현한 뒤로가기 버튼을 클릭했거나 (2) 브라우저 뒤로가기를 클릭했거나의 경우가 있는데요, (1)은 onclick이벤트에 로그 붙였구, (2)의 경우는 원래 useEffect의 클린업함수로 구현했지만 이 경우는 FeedUploadPage가 언마운트될때마다 실행이 되어서 원하지 않을 때에도 실행이 되었어요. 예를 들면, submit해서 커뮤니티 홈으로 돌아갈 때에도 실행되고, 뒤로가기 했을 때 빈데이터들이 전송되더라구요. 그래서 useEffect의존성배열에 feedData를 넣어주면, 만약 아무 입력없이 업로드 페이지에 접속했다가 뒤로가기를 한 경우는 트래킹이 되지 않는 이슈가 있었습니다. 
    - 그래서 다음과 같이 next의 뒤로가기 감지를 이용했어요.
```
  useEffect(() => {
    // MEMO: 뒤로가기 감지 시, quitUploading 수행
    const handleBack = () => {
      quitUploading();
    };

    window.addEventListener('popstate', handleBack);

    return () => window.removeEventListener('popstate', handleBack);
  }, [feedData]);
```

### 📸 스크린샷, 없으면 이것 참,, 섭섭한데요?
