### PR TITLE
feat: 커뮤니티 스크롤 복원 구현

### DIFF
--- a/src/components/feed/list/FeedCard.tsx
+++ b/src/components/feed/list/FeedCard.tsx
@@ -28,6 +28,7 @@ interface BaseProps {
   rightIcon?: ReactNode;
   memberId: number;
   isShowInfo: boolean;
+  onClick?: () => void;
 }
 
 const Base = forwardRef<HTMLDivElement, PropsWithChildren<BaseProps>>(
@@ -47,6 +48,7 @@ const Base = forwardRef<HTMLDivElement, PropsWithChildren<BaseProps>>(
       rightIcon,
       memberId,
       isShowInfo,
+      onClick,
     },
     ref,
   ) => {
@@ -59,6 +61,7 @@ const Base = forwardRef<HTMLDivElement, PropsWithChildren<BaseProps>>(
           gap: 8,
           borderBottom: `1px solid ${colors.gray800}`,
         }}
+        onClick={onClick}
       >
         {isBlindWriter || profileImage == null ? (
           <div css={{ flexShrink: 0 }}>

--- a/src/components/feed/page/FeedHomePage.tsx
+++ b/src/components/feed/page/FeedHomePage.tsx
@@ -1,4 +1,5 @@
 import { ImpressionArea } from '@toss/impression-area';
+import Link from 'next/link';
 import { FC } from 'react';
 
 import Responsive from '@/components/common/Responsive';
@@ -10,6 +11,7 @@ import FeedDetail from '@/components/feed/detail/FeedDetail';
 import FeedList from '@/components/feed/list/FeedList';
 import DesktopCommunityLayout from '@/components/feed/page/layout/DesktopCommunityLayout';
 import MobileCommunityLayout from '@/components/feed/page/layout/MobileCommunityLayout';
+import { playgroundLink } from '@/constants/links';
 
 const CommunityPage: FC = () => {
   const [postId] = useFeedDetailParam();
@@ -61,7 +63,13 @@ const CommunityPage: FC = () => {
                 <ImpressionArea onImpressionStart={() => queueHit(feedId)}>
                   <LoggingImpression areaThreshold={0.5} eventKey='feedCard' param={{ feedId }}>
                     <LoggingClick eventKey='feedCard' param={{ feedId }}>
-                      <FeedDetailLink feedId={feedId}>{children}</FeedDetailLink>
+                      <Link
+                        href={{
+                          pathname: playgroundLink.feedDetail(feedId),
+                        }}
+                      >
+                        {children}
+                      </Link>
                     </LoggingClick>
                   </LoggingImpression>
                 </ImpressionArea>

--- a/src/components/layout/HeaderOnlyDesktopLayout.tsx
+++ b/src/components/layout/HeaderOnlyDesktopLayout.tsx
@@ -1,0 +1,47 @@
+import styled from '@emotion/styled';
+import { FC, ReactNode } from 'react';
+import { RemoveScroll } from 'react-remove-scroll';
+
+import Header from '@/components/common/Header';
+import Responsive from '@/components/common/Responsive';
+import { createLayoutCSSVariable } from '@/components/layout/utils';
+import { MOBILE_MEDIA_QUERY } from '@/styles/mediaQuery';
+
+interface HeaderLayoutProps {
+  children: ReactNode;
+}
+
+const HeaderOnlyDesktopLayout: FC<HeaderLayoutProps> = ({ children }) => {
+  return (
+    <>
+      <Responsive only='desktop'>
+        <FixedSlot className={RemoveScroll.classNames.zeroRight}>
+          <Header />
+        </FixedSlot>
+      </Responsive>
+      <StyledContainer>{children}</StyledContainer>
+    </>
+  );
+};
+
+export default HeaderOnlyDesktopLayout;
+
+const StyledContainer = styled.div`
+  padding-top: 80px;
+
+  ${createLayoutCSSVariable({ headerHeight: 80 })}
+
+  @media ${MOBILE_MEDIA_QUERY} {
+    padding-top: 0;
+
+    ${createLayoutCSSVariable({ headerHeight: 0 })}
+  }
+`;
+
+const FixedSlot = styled.div`
+  position: fixed;
+  top: 0;
+  right: 0;
+  left: 0;
+  z-index: 100;
+`;

--- a/src/components/layout/index.tsx
+++ b/src/components/layout/index.tsx
@@ -2,10 +2,12 @@ import EmptyLayout from '@/components/layout/EmptyLayout';
 import FullScreenLayout from '@/components/layout/FullScreenLayout';
 import HeaderFooterLayout from '@/components/layout/HeaderFooterLayout';
 import HeaderLayout from '@/components/layout/HeaderLayout';
+import HeaderOnlyDesktopLayout from '@/components/layout/HeaderOnlyDesktopLayout';
 
 export const preDefinedLayouts = {
   header: HeaderLayout,
   empty: EmptyLayout,
   headerFooter: HeaderFooterLayout,
+  headerOnlyDesktop: HeaderOnlyDesktopLayout,
   fullScreen: FullScreenLayout,
 };

--- a/src/components/navigation/NavigationProvider.tsx
+++ b/src/components/navigation/NavigationProvider.tsx
@@ -1,0 +1,64 @@
+import { useRouter } from 'next/router';
+import { FC, ReactNode, useEffect, useRef } from 'react';
+
+import { NavigationContext } from '@/components/navigation/navigationContext';
+
+interface ScrollProviderProps {
+  children: ReactNode;
+}
+
+const NavigationProvider: FC<ScrollProviderProps> = ({ children }) => {
+  const router = useRouter();
+  const lastRouteStateRef = useRef<{
+    fromPath: string;
+    type: 'back' | 'move';
+  } | null>(null);
+
+  useEffect(() => {
+    const handleBack = () => {
+      if (lastRouteStateRef.current?.fromPath !== router.asPath) {
+        lastRouteStateRef.current = {
+          fromPath: router.asPath,
+          type: 'back',
+        };
+      }
+    };
+
+    const handleStart = () => {
+      if (lastRouteStateRef.current == null || lastRouteStateRef.current.fromPath !== router.asPath) {
+        lastRouteStateRef.current = {
+          fromPath: router.asPath,
+          type: 'move',
+        };
+      }
+    };
+
+    router.beforePopState(() => {
+      handleBack();
+      return true;
+    });
+
+    router.events.on('routeChangeStart', handleStart);
+
+    return () => {
+      router.beforePopState(() => {
+        return true;
+      });
+      router.events.off('routeChangeStart', handleStart);
+    };
+  }, [router]);
+
+  return (
+    <NavigationContext.Provider
+      value={{
+        getLastRouteState: () => {
+          return lastRouteStateRef.current ?? null;
+        },
+      }}
+    >
+      {children}
+    </NavigationContext.Provider>
+  );
+};
+
+export default NavigationProvider;

--- a/src/components/navigation/navigationContext.ts
+++ b/src/components/navigation/navigationContext.ts
@@ -1,0 +1,9 @@
+import { createContext } from 'react';
+
+interface ContextValue {
+  getLastRouteState: () => { type: 'move' | 'back'; fromPath: string } | null;
+}
+
+export const NavigationContext = createContext<ContextValue>({
+  getLastRouteState: () => null,
+});

--- a/src/components/navigation/useNavigateBack.ts
+++ b/src/components/navigation/useNavigateBack.ts
@@ -1,0 +1,28 @@
+import { useRouter } from 'next/router';
+import { useContext, useEffect, useRef } from 'react';
+
+import { NavigationContext } from '@/components/navigation/navigationContext';
+
+export const useNavigateBack = (callback: () => void) => {
+  const { getLastRouteState } = useContext(NavigationContext);
+  const router = useRouter();
+  const callbackRef = useRef(callback);
+
+  useEffect(() => {
+    callbackRef.current = callback;
+  }, [callback]);
+
+  useEffect(() => {
+    const fn = () => {
+      if (getLastRouteState()?.type === 'back') {
+        callbackRef.current?.();
+      }
+    };
+
+    router.events.on('routeChangeComplete', fn);
+
+    return () => {
+      router.events.off('routeChangeComplete', fn);
+    };
+  }, [router, getLastRouteState]);
+};

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -19,6 +19,7 @@ import ToastProvider from '@/components/common/Toast/providers/ToastProvider';
 import AmplitudeProvider from '@/components/eventLogger/providers/AmplitudeProvider';
 import * as gtm from '@/components/googleTagManager/gtm';
 import GoogleTagManagerScript from '@/components/googleTagManager/Script';
+import NavigationProvider from '@/components/navigation/NavigationProvider';
 import { AMPLITUDE_API_KEY, DEBUG, ORIGIN } from '@/constants/env';
 import GlobalStyle from '@/styles/GlobalStyle';
 import { getLayout } from '@/utils/layout';
@@ -89,9 +90,11 @@ function MyApp({ Component, pageProps }: AppProps) {
                 <GlobalStyle />
                 <ResponsiveProvider>
                   <OverlayProvider>
-                    <Layout>
-                      <Component {...pageProps} />
-                    </Layout>
+                    <NavigationProvider>
+                      <Layout>
+                        <Component {...pageProps} />
+                      </Layout>
+                    </NavigationProvider>
                   </OverlayProvider>
                 </ResponsiveProvider>
                 {DEBUG && <Debugger />}

--- a/src/pages/feed/[id].tsx
+++ b/src/pages/feed/[id].tsx
@@ -51,7 +51,7 @@ const FeedDetailPage = () => {
   );
 };
 
-setLayout(FeedDetailPage, 'header');
+setLayout(FeedDetailPage, 'headerOnlyDesktop');
 
 export default FeedDetailPage;
 


### PR DESCRIPTION
### 🤫 쉿, 나한테만 말해줘요. 이슈넘버
- close #

### 🧐 어떤 것을 변경했어요~?
<!-- 실제로 변경한 사항을 설명해주세요.-->

뒤로가기를 할 때 커뮤니티 리스트의 스크롤이 복원되도록 만들었어요.

뒤로가기로 접근할 시 호출되는 훅인 `useNavigationBack` 을 만들고, 거기에서 [virtuoso의 scrollToIndex 기능](https://virtuoso.dev/scroll-to-index/)을 활용해 스크롤 복원을 구현했어요.

### 🤔 그렇다면, 어떻게 구현했어요~?
<!-- 실제로 구현한 로직에 대해 설명해주세요.-->

### ❤️‍🔥 당신이 생각하는 PR포인트, 내겐 매력포인트.
<!-- 해당 PR에서 논의가 필요한 사항을 적어주세요. -->

### 📸 스크린샷, 없으면 이것 참,, 섭섭한데요?
