### PR TITLE
feat: 카테고리 변경시 캐시 리셋

### DIFF
--- a/src/components/feed/list/CategorySelect.tsx
+++ b/src/components/feed/list/CategorySelect.tsx
@@ -1,7 +1,9 @@
 import styled from '@emotion/styled';
 import { colors } from '@sopt-makers/colors';
+import { useQueryClient } from '@tanstack/react-query';
 import { FC } from 'react';
 
+import { useGetPostsInfiniteQuery } from '@/api/endpoint/feed/getPosts';
 import HorizontalScroller from '@/components/common/HorizontalScroller';
 import { LoggingClick } from '@/components/eventLogger/components/LoggingClick';
 import { CategoryLink, useCategoryParam } from '@/components/feed/common/queryParam';
@@ -20,6 +22,7 @@ interface CategorySelectProps {
 }
 
 const CategorySelect: FC<CategorySelectProps> = ({ categories }) => {
+  const queryClient = useQueryClient();
   const [currentCategoryId] = useCategoryParam({ defaultValue: '' });
   const parentCategory =
     categories.find(
@@ -43,6 +46,9 @@ const CategorySelect: FC<CategorySelectProps> = ({ categories }) => {
           {categories.map((category) => (
             <LoggingClick key={category.id} eventKey='feedListCategoryFilter' param={{ category: category.name }}>
               <Category
+                onClick={() => {
+                  queryClient.invalidateQueries({ queryKey: useGetPostsInfiniteQuery.getKey(category.id) });
+                }}
                 categoryId={category.hasAllCategory ? category.id : category.tags.at(0)?.id ?? category.id} // 하위에 "전체" 카테고리가 없으면 태그의 첫 카테고리로 보내기
                 active={parentCategory?.id === category.id}
               >
@@ -64,7 +70,14 @@ const CategorySelect: FC<CategorySelectProps> = ({ categories }) => {
             )}
             {parentCategory.tags.map((tag) => (
               <LoggingClick key={tag.id} eventKey='feedListCategoryFilter' param={{ category: tag.name }}>
-                <Chip key={tag.id} categoryId={tag.id} active={tag.id === currentCategoryId}>
+                <Chip
+                  key={tag.id}
+                  categoryId={tag.id}
+                  active={tag.id === currentCategoryId}
+                  onClick={() => {
+                    queryClient.invalidateQueries({ queryKey: useGetPostsInfiniteQuery.getKey(tag.id) });
+                  }}
+                >
                   {tag.name}
                 </Chip>
               </LoggingClick>


### PR DESCRIPTION
### 🤫 쉿, 나한테만 말해줘요. 이슈넘버
- close #

### 🧐 어떤 것을 변경했어요~?
<!-- 실제로 변경한 사항을 설명해주세요.-->

유저가 카테고리 버튼을 직접 눌러 카테고리를 변경할 때, 리액트 쿼리에 저장된 캐시를 Invalidate 합니다. 유저가 카테고리를 이동하며 최신글을 볼 수 있게 만듭니다.

### 🤔 그렇다면, 어떻게 구현했어요~?
<!-- 실제로 구현한 로직에 대해 설명해주세요.-->

### ❤️‍🔥 당신이 생각하는 PR포인트, 내겐 매력포인트.
<!-- 해당 PR에서 논의가 필요한 사항을 적어주세요. -->

### 📸 스크린샷, 없으면 이것 참,, 섭섭한데요?
