### PR TITLE
feat: 본문 줄바꿈 안됨으로 스크롤 생기는 이슈 수정, info ellipsis 되도록 수정

### DIFF
--- a/src/components/feed/detail/DetailFeedCard.tsx
+++ b/src/components/feed/detail/DetailFeedCard.tsx
@@ -292,6 +292,7 @@ const ImageScrollContainer = styled(Flex)`
 const StyledContent = styled(Text)`
   line-height: 26px;
   white-space: pre-wrap;
+  word-break: break-all;
   color: ${colors.gray30};
   ${textStyles.SUIT_16_R};
 

--- a/src/components/feed/detail/DetailFeedCard.tsx
+++ b/src/components/feed/detail/DetailFeedCard.tsx
@@ -398,11 +398,9 @@ const Comment = ({
                 </Text>
               )}
               {!isBlindWriter && (
-                <Link href={playgroundLink.memberDetail(memberId)}>
-                  <InfoText typography='SUIT_14_M' color={colors.gray400}>
-                    {`∙ ${info}`}
-                  </InfoText>
-                </Link>
+                <InfoText typography='SUIT_14_M' color={colors.gray400}>
+                  {`∙ ${info}`}
+                </InfoText>
               )}
             </Stack.Horizontal>
             <Flex>
@@ -454,7 +452,7 @@ const InfoText = styled(Text)`
   white-space: nowrap;
 
   @media ${'screen and (max-width: 460px)'} {
-    max-width: 178px;
+    max-width: 230px;
     overflow: hidden;
     text-overflow: ellipsis;
     -webkit-box-orient: vertical;

--- a/src/components/feed/list/FeedCard.tsx
+++ b/src/components/feed/list/FeedCard.tsx
@@ -91,16 +91,14 @@ const Base = forwardRef<HTMLDivElement, PropsWithChildren<BaseProps>>(
                   </InfoText>
                 </Top>
               ) : (
-                <Link href={playgroundLink.memberDetail(memberId)}>
-                  <Top align='center'>
-                    <Text typography='SUIT_14_SB' lineHeight={20}>
-                      {name}
-                    </Text>
-                    <InfoText typography='SUIT_14_M' lineHeight={20} color={colors.gray400}>
-                      {info}
-                    </InfoText>
-                  </Top>
-                </Link>
+                <Top align='center'>
+                  <Text typography='SUIT_14_SB' lineHeight={20}>
+                    {name}
+                  </Text>
+                  <InfoText typography='SUIT_14_M' lineHeight={20} color={colors.gray400}>
+                    {info}
+                  </InfoText>
+                </Top>
               )}
               <Stack.Horizontal gutter={4} align='center'>
                 <Text typography='SUIT_14_M' lineHeight={20} color={colors.gray400}>
@@ -173,8 +171,8 @@ const Top = styled(Flex)`
 const InfoText = styled(Text)`
   white-space: nowrap;
 
-  @media screen and (max-width: 460px) {
-    max-width: 220px;
+  @media ${'screen and (max-width: 460px)'} {
+    max-width: 230px;
     overflow: hidden;
     text-overflow: ellipsis;
     -webkit-box-orient: vertical;

--- a/src/components/feed/list/FeedCard.tsx
+++ b/src/components/feed/list/FeedCard.tsx
@@ -122,6 +122,7 @@ const Base = forwardRef<HTMLDivElement, PropsWithChildren<BaseProps>>(
                 lineHeight={22}
                 css={{
                   whiteSpace: 'pre-wrap',
+                  wordBreak: 'break-all',
                 }}
               >
                 {renderContent(content)}


### PR DESCRIPTION
### 🤫 쉿, 나한테만 말해줘요. 이슈넘버
- close #1252

### 🧐 어떤 것을 변경했어요~?
<!-- 실제로 변경한 사항을 설명해주세요.-->
제곧내
#### as-is
<img width="352" alt="image" src="https://github.com/sopt-makers/sopt-playground-frontend/assets/26808056/04ed57b9-6da7-46d5-a36a-108e1b11f834">

#### to-be
<img width="353" alt="image" src="https://github.com/sopt-makers/sopt-playground-frontend/assets/26808056/68dbe4f8-8d78-4239-96e0-584da0a0f889">

- 수정했었는데, Link 태그 감싸면서 스타일 깨짐. 굳이 정보 클릭했을때 멤버로 넘어갈 필요는 없어보여서 제거


### 🤔 그렇다면, 어떻게 구현했어요~?
<!-- 실제로 구현한 로직에 대해 설명해주세요.-->

### ❤️‍🔥 당신이 생각하는 PR포인트, 내겐 매력포인트.
<!-- 해당 PR에서 논의가 필요한 사항을 적어주세요. -->

### 📸 스크린샷, 없으면 이것 참,, 섭섭한데요?
