### PR TITLE
fix: 클릭 영역 수정, 프로필 이미지 없을때 프로필 연결 안되는 문제 수정

### DIFF
--- a/src/components/feed/list/FeedCard.tsx
+++ b/src/components/feed/list/FeedCard.tsx
@@ -63,17 +63,17 @@ const Base = forwardRef<HTMLDivElement, PropsWithChildren<BaseProps>>(
         }}
         onClick={onClick}
       >
-        {isBlindWriter || profileImage == null ? (
+        {isBlindWriter ? (
           <div css={{ flexShrink: 0 }}>
             <IconMember size={36} />
           </div>
         ) : (
-          <Link href={playgroundLink.memberDetail(memberId)}>
+          <Link href={playgroundLink.memberDetail(memberId)} css={{ height: 'fit-content' }}>
             <ProfileImageBox>
               {profileImage ? (
                 <ProfileImage width={36} height={36} src={profileImage} alt='profileImage' />
               ) : (
-                <EmptyProfileImage />
+                <IconMember size={36} />
               )}
             </ProfileImageBox>
           </Link>
@@ -92,9 +92,11 @@ const Base = forwardRef<HTMLDivElement, PropsWithChildren<BaseProps>>(
                 </Top>
               ) : (
                 <Top align='center'>
-                  <Text typography='SUIT_14_SB' lineHeight={20}>
-                    {name}
-                  </Text>
+                  <Link href={playgroundLink.memberDetail(memberId)}>
+                    <Text typography='SUIT_14_SB' lineHeight={20}>
+                      {name}
+                    </Text>
+                  </Link>
                   <InfoText typography='SUIT_14_M' lineHeight={20} color={colors.gray400}>
                     {info}
                   </InfoText>
@@ -151,13 +153,6 @@ const ProfileImage = styled(ResizedImage)`
   width: 100%;
   height: 100%;
   object-fit: cover;
-`;
-
-const EmptyProfileImage = styled.div`
-  border-radius: 50%;
-  background-color: ${colors.gray700};
-  width: 100%;
-  height: 100%;
 `;
 
 const Top = styled(Flex)`


### PR DESCRIPTION
### 🤫 쉿, 나한테만 말해줘요. 이슈넘버
- close #

### 🧐 어떤 것을 변경했어요~?
<!-- 실제로 변경한 사항을 설명해주세요.-->
- 아래 문제 수정하면서 기명이면서 프로필 이미지 없는 경우엔 링킹이 빠져있어서 그것도 수정했어요
- [관련 쓰레드](https://sopt-makers.slack.com/archives/C042T81PW80/p1702192406593709)
<img width="782" alt="image" src="https://github.com/sopt-makers/sopt-playground-frontend/assets/26808056/a92c0004-e5fd-422f-a19f-752cf3213699">


### 🤔 그렇다면, 어떻게 구현했어요~?
<!-- 실제로 구현한 로직에 대해 설명해주세요.-->

### ❤️‍🔥 당신이 생각하는 PR포인트, 내겐 매력포인트.
<!-- 해당 PR에서 논의가 필요한 사항을 적어주세요. -->

### 📸 스크린샷, 없으면 이것 참,, 섭섭한데요?
