### PR TITLE
fix: 콘텐츠 input과 푸터 겹치는 문제 해결

### DIFF
--- a/src/components/feed/page/FeedUploadPage.tsx
+++ b/src/components/feed/page/FeedUploadPage.tsx
@@ -314,7 +314,7 @@ export default function FeedUploadPage() {
             </Body>
           }
           footer={
-            <Footer isWriting={feedData.content !== null}>
+            <Footer>
               <UsingRules isPreviewOpen={isPreviewOpen} onClose={closeUsingRules} />
             </Footer>
           }
@@ -351,7 +351,7 @@ const InputWrapper = styled.section`
   min-width: 608px;
 
   @media ${MOBILE_MEDIA_QUERY} {
-    margin-top: 8px;
+    margin: 8px 0;
     min-width: 100%;
   }
 `;
@@ -437,18 +437,8 @@ const CheckBoxesWrapper = styled.div`
   }
 `;
 
-const Footer = styled.div<{ isWriting?: boolean }>`
+const Footer = styled.div`
   width: 100%;
-
-  @media ${MOBILE_MEDIA_QUERY} {
-    ${({ isWriting }) =>
-      !isWriting &&
-      css`
-        position: fixed;
-      `}
-
-    bottom: 8px;
-  }
 `;
 
 const TagAndCheckboxWrapper = styled.div`

--- a/src/components/feed/upload/Category/DropDown/index.tsx
+++ b/src/components/feed/upload/Category/DropDown/index.tsx
@@ -66,7 +66,7 @@ const ModalWrapper = styled.div`
 
 const StyledBackground = styled.div`
   display: flex;
-  position: fixed;
+  position: absolute;
   top: 0;
   left: 0;
   justify-content: center;

--- a/src/components/feed/upload/Input/ContentsInput/index.tsx
+++ b/src/components/feed/upload/Input/ContentsInput/index.tsx
@@ -19,12 +19,9 @@ const ContentsInput = forwardRef(({ onChange }: ContentsInputProp, ref: Ref<HTML
 export default ContentsInput;
 
 const Contents = styled(TextareaAutosize)`
-  margin-bottom: 80px;
   outline: none;
   background-color: transparent;
   width: 100%;
-
-  /* min-height: 100vw; */
   resize: none;
   line-height: 26px;
   white-space: pre-wrap;

--- a/src/components/feed/upload/Input/ContentsInput/index.tsx
+++ b/src/components/feed/upload/Input/ContentsInput/index.tsx
@@ -19,10 +19,12 @@ const ContentsInput = forwardRef(({ onChange }: ContentsInputProp, ref: Ref<HTML
 export default ContentsInput;
 
 const Contents = styled(TextareaAutosize)`
+  margin-bottom: 80px;
   outline: none;
   background-color: transparent;
   width: 100%;
-  min-height: 100vw;
+
+  /* min-height: 100vw; */
   resize: none;
   line-height: 26px;
   white-space: pre-wrap;

--- a/src/components/feed/upload/layout/DesktopFeedUploadLayout.tsx
+++ b/src/components/feed/upload/layout/DesktopFeedUploadLayout.tsx
@@ -29,7 +29,8 @@ const Layout = styled.div`
   flex-flow: row wrap;
   align-items: stretch;
   justify-content: space-around;
-  height: 100dvh;
+  height: 100vh;
+
   @supports (height: 100dvh) {
     max-height: 100dvh;
   }

--- a/src/components/feed/upload/layout/DesktopFeedUploadLayout.tsx
+++ b/src/components/feed/upload/layout/DesktopFeedUploadLayout.tsx
@@ -10,17 +10,32 @@ interface DesktopFeedUploadLayoutProps {
 
 export default function DesktopFeedUploadLayout({ header, body, footer }: DesktopFeedUploadLayoutProps) {
   return (
-    <>
-      <HeaderWrapper>{header}</HeaderWrapper>
-      <BodyContainer>
-        <BodyWrapper>{body}</BodyWrapper>
-      </BodyContainer>
+    <Layout>
+      <TopLayout>
+        <HeaderWrapper>{header}</HeaderWrapper>
+        <BodyContainer>
+          <BodyWrapper>{body}</BodyWrapper>
+        </BodyContainer>
+      </TopLayout>
       <FooterContainer>
         <FooterWrapper>{footer}</FooterWrapper>
       </FooterContainer>
-    </>
+    </Layout>
   );
 }
+
+const Layout = styled.div`
+  display: flex;
+  flex-flow: row wrap;
+  align-items: stretch;
+  justify-content: space-around;
+  height: 100dvh;
+  @supports (height: 100dvh) {
+    max-height: 100dvh;
+  }
+`;
+
+const TopLayout = styled.div``;
 
 const HeaderWrapper = styled.header`
   display: flex;
@@ -54,8 +69,7 @@ const FooterWrapper = styled.div`
 
 const FooterContainer = styled.footer`
   display: flex;
-  position: fixed;
-  bottom: 0;
+  align-items: flex-end;
   justify-content: center;
   width: 100%;
 `;

--- a/src/components/feed/upload/layout/MobileFeedUploadLayout.tsx
+++ b/src/components/feed/upload/layout/MobileFeedUploadLayout.tsx
@@ -31,7 +31,7 @@ const FooterWrapper = styled.footer`
   display: flex;
   flex-direction: column;
   gap: 8px;
-  margin-bottom:10px;
+  margin-bottom: 10px;
   padding: 0 16px;
   width: 100%;
 `;


### PR DESCRIPTION
### 🤫 쉿, 나한테만 말해줘요. 이슈넘버
- close #1258

### 🧐 어떤 것을 변경했어요~?
<!-- 실제로 변경한 사항을 설명해주세요.-->
- 콘텐츠 input과 푸터 겹치는 문제 해결했어요. 

### 🤔 그렇다면, 어떻게 구현했어요~?
<!-- 실제로 구현한 로직에 대해 설명해주세요.-->
- height:dvh를 주고, align-items: flex-end; 로 해결했어요!

### ❤️‍🔥 당신이 생각하는 PR포인트, 내겐 매력포인트.
<!-- 해당 PR에서 논의가 필요한 사항을 적어주세요. -->

- 처음에는 flex-grow를 이용하려고 했으나, flex-grow는 사파리와 사파리 ios에서 적용이 안된다고 체크되어있더라구요,,!([flex-grow 문서](https://developer.mozilla.org/ko/docs/Web/CSS/flex-grow)) => 확인해보니 아니네요ㅎㅎ 제가 잘 못 읽엇숩니다..ㅎㅎ flex-grow를 사용했을 때 원하는 구현이 잘 안 되었는데 아래의 방법으로 해결이 되어서 이렇게 최종 수정했습니다!
- `align-items: flex-end;` 로도 충분히 해결가능해서 align-items: flex-end; 를 사용했고, height:dvh를 주었습니다! 

### 📸 스크린샷, 없으면 이것 참,, 섭섭한데요?


https://github.com/sopt-makers/sopt-playground-frontend/assets/76681519/fefab4c9-d25a-4bda-98a7-19f8e782a660


