### PR TITLE
feat: 피드 수정 구현

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -6,8 +6,8 @@
   },
   "stylelint.validate": ["css", "scss", "typescript", "typescriptreact"],
   "editor.codeActionsOnSave": {
-    "source.fixAll.eslint": true,
-    "source.fixAll": true
+    "source.fixAll.eslint": "explicit",
+    "source.fixAll": "explicit"
   },
   "typescript.preferences.importModuleSpecifier": "non-relative",
   "cSpell.words": [

--- a/src/api/endpoint/feed/editFeed.ts
+++ b/src/api/endpoint/feed/editFeed.ts
@@ -16,6 +16,6 @@ export const editFeed = createEndpoint({
 export const useSaveEditFeedData = () => {
   return useMutation({
     mutationFn: (requestBody: { data: FeedDataType; id: number | null }) =>
-      editFeed.request({ postId: requestBody.id ?? 0, ...requestBody.data }),
+      editFeed.request({ postId: requestBody.id, ...requestBody.data }),
   });
 };

--- a/src/api/endpoint/feed/editFeed.ts
+++ b/src/api/endpoint/feed/editFeed.ts
@@ -1,0 +1,44 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { useRouter } from 'next/router';
+import { playgroundLink } from 'playground-common/export';
+import { z } from 'zod';
+
+import { getPost } from '@/api/endpoint/feed/getPost';
+import { useGetPostsInfiniteQuery } from '@/api/endpoint/feed/getPosts';
+import { createEndpoint } from '@/api/typedAxios';
+import useEventLogger from '@/components/eventLogger/hooks/useEventLogger';
+
+interface RequestBody {
+  postId: number;
+  categoryId: number;
+  title: string | null;
+  content: string;
+  isQuestion: boolean;
+  isBlindWriter: boolean;
+  images: string[];
+}
+
+export const editFeed = createEndpoint({
+  request: (reqeustBody: RequestBody) => ({
+    method: 'PUT',
+    url: 'api/v1/community/posts',
+    data: reqeustBody,
+  }),
+  serverResponseScheme: z.unknown(),
+});
+
+export const useSaveEditFeedData = (feedId: string) => {
+  const router = useRouter();
+  const queryClient = useQueryClient();
+  const { logSubmitEvent } = useEventLogger();
+
+  return useMutation({
+    mutationFn: (reqeustBody: RequestBody) => editFeed.request(reqeustBody),
+    onSuccess: async () => {
+      logSubmitEvent('editCommunity');
+      queryClient.invalidateQueries({ queryKey: useGetPostsInfiniteQuery.getKey('') });
+      queryClient.invalidateQueries({ queryKey: getPost.cacheKey(feedId) });
+      await router.push(playgroundLink.feedList());
+    },
+  });
+};

--- a/src/api/endpoint/feed/editFeed.ts
+++ b/src/api/endpoint/feed/editFeed.ts
@@ -1,12 +1,10 @@
-import { useMutation, useQueryClient } from '@tanstack/react-query';
-import { useRouter } from 'next/router';
-import { playgroundLink } from 'playground-common/export';
+import { useMutation } from '@tanstack/react-query';
+// import { playgroundLink } from 'playground-common/export';
 import { z } from 'zod';
 
-import { getPost } from '@/api/endpoint/feed/getPost';
-import { useGetPostsInfiniteQuery } from '@/api/endpoint/feed/getPosts';
+// import { getPost } from '@/api/endpoint/feed/getPost';
+// import { useGetPostsInfiniteQuery } from '@/api/endpoint/feed/getPosts';
 import { createEndpoint } from '@/api/typedAxios';
-import useEventLogger from '@/components/eventLogger/hooks/useEventLogger';
 
 interface RequestBody {
   postId: number;
@@ -27,18 +25,8 @@ export const editFeed = createEndpoint({
   serverResponseScheme: z.unknown(),
 });
 
-export const useSaveEditFeedData = (feedId: string) => {
-  const router = useRouter();
-  const queryClient = useQueryClient();
-  const { logSubmitEvent } = useEventLogger();
-
+export const useSaveEditFeedData = () => {
   return useMutation({
     mutationFn: (reqeustBody: RequestBody) => editFeed.request(reqeustBody),
-    onSuccess: async () => {
-      logSubmitEvent('editCommunity');
-      queryClient.invalidateQueries({ queryKey: useGetPostsInfiniteQuery.getKey('') });
-      queryClient.invalidateQueries({ queryKey: getPost.cacheKey(feedId) });
-      await router.push(playgroundLink.feedList());
-    },
   });
 };

--- a/src/api/endpoint/feed/editFeed.ts
+++ b/src/api/endpoint/feed/editFeed.ts
@@ -1,32 +1,21 @@
 import { useMutation } from '@tanstack/react-query';
-// import { playgroundLink } from 'playground-common/export';
 import { z } from 'zod';
 
-// import { getPost } from '@/api/endpoint/feed/getPost';
-// import { useGetPostsInfiniteQuery } from '@/api/endpoint/feed/getPosts';
 import { createEndpoint } from '@/api/typedAxios';
-
-interface RequestBody {
-  postId: number;
-  categoryId: number;
-  title: string | null;
-  content: string;
-  isQuestion: boolean;
-  isBlindWriter: boolean;
-  images: string[];
-}
+import { EditFeedDataType, FeedDataType } from '@/components/feed/upload/types';
 
 export const editFeed = createEndpoint({
-  request: (reqeustBody: RequestBody) => ({
+  request: (requestBody: EditFeedDataType) => ({
     method: 'PUT',
     url: 'api/v1/community/posts',
-    data: reqeustBody,
+    data: requestBody,
   }),
   serverResponseScheme: z.unknown(),
 });
 
 export const useSaveEditFeedData = () => {
   return useMutation({
-    mutationFn: (reqeustBody: RequestBody) => editFeed.request(reqeustBody),
+    mutationFn: (requestBody: { data: FeedDataType; id: number | null }) =>
+      editFeed.request({ postId: requestBody.id ?? 0, ...requestBody.data }),
   });
 };

--- a/src/api/endpoint/feed/editFeed.ts
+++ b/src/api/endpoint/feed/editFeed.ts
@@ -1,8 +1,7 @@
-import { useMutation } from '@tanstack/react-query';
 import { z } from 'zod';
 
 import { createEndpoint } from '@/api/typedAxios';
-import { EditFeedDataType, FeedDataType } from '@/components/feed/upload/types';
+import { EditFeedDataType } from '@/components/feed/upload/types';
 
 export const editFeed = createEndpoint({
   request: (requestBody: EditFeedDataType) => ({
@@ -12,10 +11,3 @@ export const editFeed = createEndpoint({
   }),
   serverResponseScheme: z.unknown(),
 });
-
-export const useSaveEditFeedData = () => {
-  return useMutation({
-    mutationFn: (requestBody: { data: FeedDataType; id: number | null }) =>
-      editFeed.request({ postId: requestBody.id, ...requestBody.data }),
-  });
-};

--- a/src/api/endpoint/feed/getPost.ts
+++ b/src/api/endpoint/feed/getPost.ts
@@ -55,10 +55,12 @@ export const getPost = createEndpoint({
   }),
 });
 
-export const useGetPostQuery = (postId: string) => {
+export const useGetPostQuery = (postId: string | undefined) => {
+  const id = postId ?? '';
+
   return useQuery({
-    queryKey: getPost.cacheKey(postId),
-    queryFn: () => getPost.request(postId),
+    queryKey: getPost.cacheKey(id),
+    queryFn: () => getPost.request(id),
     enabled: !!postId,
   });
 };

--- a/src/api/endpoint/feed/getPost.ts
+++ b/src/api/endpoint/feed/getPost.ts
@@ -59,5 +59,6 @@ export const useGetPostQuery = (postId: string) => {
   return useQuery({
     queryKey: getPost.cacheKey(postId),
     queryFn: () => getPost.request(postId),
+    enabled: !!postId,
   });
 };

--- a/src/api/endpoint/feed/uploadFeed.ts
+++ b/src/api/endpoint/feed/uploadFeed.ts
@@ -1,4 +1,3 @@
-import { useMutation } from '@tanstack/react-query';
 import { z } from 'zod';
 
 import { createEndpoint } from '@/api/typedAxios';
@@ -12,9 +11,3 @@ export const uploadFeed = createEndpoint({
   }),
   serverResponseScheme: z.unknown(),
 });
-
-export const useSaveUploadFeedData = () => {
-  return useMutation({
-    mutationFn: (reqeustBody: { data: FeedDataType; id: number | null }) => uploadFeed.request({ ...reqeustBody.data }),
-  });
-};

--- a/src/api/endpoint/feed/uploadFeed.ts
+++ b/src/api/endpoint/feed/uploadFeed.ts
@@ -1,23 +1,11 @@
-import { useMutation, useQueryClient } from '@tanstack/react-query';
-import { useRouter } from 'next/router';
-import { playgroundLink } from 'playground-common/export';
+import { useMutation } from '@tanstack/react-query';
 import { z } from 'zod';
 
-import { useGetPostsInfiniteQuery } from '@/api/endpoint/feed/getPosts';
 import { createEndpoint } from '@/api/typedAxios';
-import useEventLogger from '@/components/eventLogger/hooks/useEventLogger';
-
-interface RequestBody {
-  categoryId: number;
-  title: string | null;
-  content: string;
-  isQuestion: boolean;
-  isBlindWriter: boolean;
-  images: string[];
-}
+import { FeedDataType } from '@/components/feed/upload/types';
 
 export const uploadFeed = createEndpoint({
-  request: (reqeustBody: RequestBody) => ({
+  request: (reqeustBody: FeedDataType) => ({
     method: 'POST',
     url: 'api/v1/community/posts',
     data: reqeustBody,
@@ -26,16 +14,7 @@ export const uploadFeed = createEndpoint({
 });
 
 export const useSaveUploadFeedData = () => {
-  const router = useRouter();
-  const queryClient = useQueryClient();
-  const { logSubmitEvent } = useEventLogger();
-
   return useMutation({
-    mutationFn: (reqeustBody: RequestBody) => uploadFeed.request(reqeustBody),
-    onSuccess: async () => {
-      logSubmitEvent('submitCommunity');
-      queryClient.invalidateQueries({ queryKey: useGetPostsInfiniteQuery.getKey('') });
-      await router.push(playgroundLink.feedList());
-    },
+    mutationFn: (reqeustBody: { data: FeedDataType; id: number | null }) => uploadFeed.request({ ...reqeustBody.data }),
   });
 };

--- a/src/components/eventLogger/events.ts
+++ b/src/components/eventLogger/events.ts
@@ -115,6 +115,7 @@ export interface SubmitEvents {
   };
   wordchainNewGame: undefined;
   submitCommunity: undefined;
+  editCommunity: undefined;
   // 커뮤니티(피드)
   postComment: {
     feedId: string;

--- a/src/components/feed/common/hooks/useCategory.ts
+++ b/src/components/feed/common/hooks/useCategory.ts
@@ -20,5 +20,24 @@ export default function useCategory() {
     return category;
   };
 
-  return { findParentCategory };
+  const findMainCategory = (categoryId: number | null, mainCategoryId?: number | null) => {
+    const parentCategory =
+      (categoryData &&
+        categoryData.find(
+          (category) => category.id === mainCategoryId || category.children.some((tag) => tag.id === categoryId),
+        )) ??
+      null;
+
+    return parentCategory;
+  };
+
+  const findChildrenCategory = (categoryId: number | null) => {
+    const parentCategory = findMainCategory(categoryId);
+
+    const category = (parentCategory && parentCategory.children.find((tag) => tag.id === categoryId)) ?? null;
+
+    return category;
+  };
+
+  return { findParentCategory, findMainCategory, findChildrenCategory };
 }

--- a/src/components/feed/detail/FeedDetail.tsx
+++ b/src/components/feed/detail/FeedDetail.tsx
@@ -1,5 +1,7 @@
 import { useQueryClient } from '@tanstack/react-query';
 import { ErrorBoundary } from '@toss/error-boundary';
+import Link from 'next/link';
+import { playgroundLink } from 'playground-common/export';
 import { ReactNode, useRef } from 'react';
 
 import { useGetCommentQuery } from '@/api/endpoint/feed/getComment';
@@ -72,14 +74,9 @@ const FeedDetail = ({ postId, renderCategoryLink, renderBackLink }: FeedDetailPr
               }
             >
               {postData.isMine ? (
-                <FeedDropdown.Item
-                  onClick={(e) => {
-                    e.stopPropagation();
-                    toast.show({ message: '아직 지원하지 않는 기능이에요.' });
-                  }}
-                >
-                  수정
-                </FeedDropdown.Item>
+                <Link href={playgroundLink.feedEdit(postId)}>
+                  <FeedDropdown.Item>수정</FeedDropdown.Item>
+                </Link>
               ) : null}
               {postData.isMine ? (
                 <FeedDropdown.Item

--- a/src/components/feed/edit/EditImpossibleModal.tsx
+++ b/src/components/feed/edit/EditImpossibleModal.tsx
@@ -1,0 +1,41 @@
+import styled from '@emotion/styled';
+import { colors } from '@sopt-makers/colors';
+import { useRouter } from 'next/router';
+
+import Modal from '@/components/common/Modal';
+
+interface ModalProp {
+  isOpen: boolean;
+  onClose: () => void;
+}
+
+export default function EditImpossibleModal({ isOpen, onClose }: ModalProp) {
+  const router = useRouter();
+
+  return (
+    <Modal
+      isOpen={isOpen}
+      onClose={() => {
+        router.back();
+        onClose();
+      }}
+      hideCloseButton={true}
+    >
+      <Modal.Content>
+        <StyledDescription>다른 사람의 글은 수정할 수 없어요.</StyledDescription>
+        <Modal.Footer align='stretch'>
+          <StyledButton action='close'>확인</StyledButton>
+        </Modal.Footer>
+      </Modal.Content>
+    </Modal>
+  );
+}
+
+const StyledDescription = styled(Modal.Title)`
+  padding: 35px 20px 0;
+`;
+
+const StyledButton = styled(Modal.Button)`
+  background-color: ${colors.white};
+  color: ${colors.black};
+`;

--- a/src/components/feed/list/FeedListItems.tsx
+++ b/src/components/feed/list/FeedListItems.tsx
@@ -2,6 +2,8 @@ import styled from '@emotion/styled';
 import { colors } from '@sopt-makers/colors';
 import { useQuery } from '@tanstack/react-query';
 import { Flex } from '@toss/emotion-utils';
+import Link from 'next/link';
+import { playgroundLink } from 'playground-common/export';
 import { FC, ReactNode, useRef } from 'react';
 import { Virtuoso, VirtuosoHandle } from 'react-virtuoso';
 import { atom, useRecoilState } from 'recoil';
@@ -156,14 +158,9 @@ const FeedListItems: FC<FeedListItemsProps> = ({ categoryId, renderFeedDetailLin
                     }
                   >
                     {post.isMine ? (
-                      <FeedDropdown.Item
-                        onClick={(e) => {
-                          e.stopPropagation();
-                          toast.show({ message: '아직 지원하지 않는 기능이에요.' });
-                        }}
-                      >
-                        수정
-                      </FeedDropdown.Item>
+                      <Link href={playgroundLink.feedEdit(post.id)}>
+                        <FeedDropdown.Item>수정</FeedDropdown.Item>
+                      </Link>
                     ) : null}
                     <LoggingClick eventKey='feedShareButton' param={{ feedId: String(post.id), referral: 'list' }}>
                       <FeedDropdown.Item

--- a/src/components/feed/page/FeedUploadPage.tsx
+++ b/src/components/feed/page/FeedUploadPage.tsx
@@ -1,13 +1,9 @@
 import { css } from '@emotion/react';
 import styled from '@emotion/styled';
 import { colors } from '@sopt-makers/colors';
-import { UseMutateFunction, useQueryClient } from '@tanstack/react-query';
 import { useRouter } from 'next/router';
-import { playgroundLink } from 'playground-common/export';
 import { FormEvent, useEffect, useRef } from 'react';
 
-import { getPost } from '@/api/endpoint/feed/getPost';
-import { useGetPostsInfiniteQuery } from '@/api/endpoint/feed/getPosts';
 import Checkbox from '@/components/common/Checkbox';
 import Responsive from '@/components/common/Responsive';
 import { LoggingClick } from '@/components/eventLogger/components/LoggingClick';
@@ -35,7 +31,7 @@ import { textStyles } from '@/styles/typography';
 interface FeedUploadPageProp {
   editingId?: number;
   defaultValue: UploadFeedDataType;
-  onSubmit: UseMutateFunction<unknown, Error, { data: FeedDataType; id: number | null }, unknown>;
+  onSubmit: ({ data, id }: { data: FeedDataType; id: number | null }) => void;
 }
 
 export default function FeedUploadPage({ defaultValue, editingId, onSubmit }: FeedUploadPageProp) {
@@ -82,33 +78,22 @@ export default function FeedUploadPage({ defaultValue, editingId, onSubmit }: Fe
   });
 
   const { isPreviewOpen, openUsingRules, closeUsingRules } = useCategoryUsingRulesPreview(false);
-  const { logClickEvent, logSubmitEvent } = useEventLogger();
-  const queryClient = useQueryClient();
+  const { logClickEvent } = useEventLogger();
 
   const handleSubmit = (e: FormEvent<HTMLFormElement>) => {
     e.preventDefault();
 
-    onSubmit(
-      {
-        data: {
-          categoryId: feedData.categoryId,
-          title: feedData.title,
-          content: feedData.content,
-          isQuestion: feedData.isQuestion,
-          isBlindWriter: feedData.isBlindWriter,
-          images: feedData.images,
-        },
-        id: editingId ?? null,
+    onSubmit({
+      data: {
+        categoryId: feedData.categoryId,
+        title: feedData.title,
+        content: feedData.content,
+        isQuestion: feedData.isQuestion,
+        isBlindWriter: feedData.isBlindWriter,
+        images: feedData.images,
       },
-      {
-        onSuccess: async () => {
-          logSubmitEvent(editingId ? 'editCommunity' : 'submitCommunity');
-          queryClient.invalidateQueries({ queryKey: useGetPostsInfiniteQuery.getKey('') });
-          editingId && queryClient.invalidateQueries({ queryKey: getPost.cacheKey(`${editingId}`) });
-          await router.push(playgroundLink.feedList());
-        },
-      },
-    );
+      id: editingId ?? null,
+    });
   };
 
   const handleQuitUpload = () => {

--- a/src/components/feed/page/FeedUploadPage.tsx
+++ b/src/components/feed/page/FeedUploadPage.tsx
@@ -56,10 +56,6 @@ export default function FeedUploadPage({ initialForm, editingId, onSubmit }: Fee
     checkReadyToUpload,
   } = useUploadFeedData(initialForm);
 
-  console.log(feedData);
-  console.log('asdfsafdsa');
-  console.log('isEdit' + isEdit);
-
   const mobileContentsRef = useRef<HTMLTextAreaElement>(null);
   const handleMobileKeyPressToContents = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
     if (e.key === 'Enter' && !e.nativeEvent.isComposing) {

--- a/src/components/feed/page/FeedUploadPage.tsx
+++ b/src/components/feed/page/FeedUploadPage.tsx
@@ -33,14 +33,14 @@ import { MOBILE_MEDIA_QUERY } from '@/styles/mediaQuery';
 import { textStyles } from '@/styles/typography';
 
 interface FeedUploadPageProp {
-  editingId?: number | null;
+  editingId?: number;
   initialForm: UploadFeedDataType;
   onSubmit: UseMutateFunction<unknown, Error, { data: FeedDataType; id: number | null }, unknown>;
 }
 
 export default function FeedUploadPage({ initialForm, editingId, onSubmit }: FeedUploadPageProp) {
   const router = useRouter();
-  const isEdit = editingId !== null;
+  const isEdit = editingId !== undefined;
 
   const {
     feedData,
@@ -55,6 +55,10 @@ export default function FeedUploadPage({ initialForm, editingId, onSubmit }: Fee
     resetFeedData,
     checkReadyToUpload,
   } = useUploadFeedData(initialForm);
+
+  console.log(feedData);
+  console.log('asdfsafdsa');
+  console.log('isEdit' + isEdit);
 
   const mobileContentsRef = useRef<HTMLTextAreaElement>(null);
   const handleMobileKeyPressToContents = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {

--- a/src/components/feed/page/FeedUploadPage.tsx
+++ b/src/components/feed/page/FeedUploadPage.tsx
@@ -34,11 +34,11 @@ import { textStyles } from '@/styles/typography';
 
 interface FeedUploadPageProp {
   editingId?: number;
-  initialForm: UploadFeedDataType;
+  defaultValue: UploadFeedDataType;
   onSubmit: UseMutateFunction<unknown, Error, { data: FeedDataType; id: number | null }, unknown>;
 }
 
-export default function FeedUploadPage({ initialForm, editingId, onSubmit }: FeedUploadPageProp) {
+export default function FeedUploadPage({ defaultValue, editingId, onSubmit }: FeedUploadPageProp) {
   const router = useRouter();
   const isEdit = editingId !== undefined;
 
@@ -54,7 +54,7 @@ export default function FeedUploadPage({ initialForm, editingId, onSubmit }: Fee
     handleSaveContent,
     resetFeedData,
     checkReadyToUpload,
-  } = useUploadFeedData(initialForm);
+  } = useUploadFeedData(defaultValue);
 
   const mobileContentsRef = useRef<HTMLTextAreaElement>(null);
   const handleMobileKeyPressToContents = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {

--- a/src/components/feed/upload/Category/CategoryHeader/index.tsx
+++ b/src/components/feed/upload/Category/CategoryHeader/index.tsx
@@ -1,8 +1,7 @@
 import styled from '@emotion/styled';
 import { colors } from '@sopt-makers/colors';
-import { useQuery } from '@tanstack/react-query';
 
-import { getCategory } from '@/api/endpoint/feed/getCategory';
+import useCategory from '@/components/feed/common/hooks/useCategory';
 import { UploadFeedDataType } from '@/components/feed/upload/types';
 import DetailArrow from '@/public/icons/icon-chevron-right.svg';
 import ExpandMoreArrow from '@/public/icons/icon-expand-more.svg';
@@ -17,21 +16,10 @@ interface CategoryHeaderProp {
 }
 
 export default function CategoryHeader({ feedData, openCategory, openTag }: CategoryHeaderProp) {
-  const { data: categories } = useQuery({
-    queryKey: getCategory.cacheKey(),
-    queryFn: getCategory.request,
-  });
+  const { findMainCategory, findChildrenCategory } = useCategory();
 
-  const parentCategory =
-    (categories &&
-      categories.find(
-        (category) =>
-          category.id === feedData.mainCategoryId || category.children.some((tag) => tag.id === feedData.categoryId),
-      )) ??
-    null;
-
-  const childrenCategory =
-    (parentCategory && parentCategory.children.find((tag) => tag.id === feedData.categoryId)) ?? null;
+  const parentCategory = findMainCategory(feedData.categoryId, feedData.mainCategoryId);
+  const childrenCategory = findChildrenCategory(feedData.categoryId);
 
   return (
     <>

--- a/src/components/feed/upload/Category/index.tsx
+++ b/src/components/feed/upload/Category/index.tsx
@@ -15,6 +15,7 @@ interface CateogryProps {
   onSaveMainCategory: (categoryId: number) => void;
   openUsingRules: () => void;
   closeUsingRules: () => void;
+  isEdit?: boolean;
 }
 
 export default function Category({
@@ -23,8 +24,9 @@ export default function Category({
   onSaveMainCategory,
   openUsingRules,
   closeUsingRules,
+  isEdit,
 }: CateogryProps) {
-  const { isSelectorOpen, closeAll, openCategory, openTag } = useCategorySelect('openCategory');
+  const { isSelectorOpen, closeAll, openCategory, openTag } = useCategorySelect(isEdit ? 'closeAll' : 'openCategory');
 
   const { data: categories } = useQuery({
     queryKey: getCategory.cacheKey(),

--- a/src/components/feed/upload/Category/index.tsx
+++ b/src/components/feed/upload/Category/index.tsx
@@ -48,7 +48,7 @@ export default function Category({
     }, myProfile.soptActivities[0]).part;
   }, [myProfile?.soptActivities]);
 
-  const handleSaveMainCategory = (categoryId: number) => {
+  const handleSaveParentCategory = (categoryId: number) => {
     const selectedMainCategory = categories?.find((category) => category.id === categoryId);
 
     if (selectedMainCategory == null) {
@@ -97,7 +97,7 @@ export default function Category({
       <CategorySelector
         isOpen={isSelectorOpen === 'openCategory'}
         onClose={closeAll}
-        onSelect={handleSaveMainCategory}
+        onSelect={handleSaveParentCategory}
         feedData={feedData}
       />
       <TagSelector

--- a/src/components/feed/upload/Input/ContentsInput/index.tsx
+++ b/src/components/feed/upload/Input/ContentsInput/index.tsx
@@ -8,13 +8,23 @@ import { textStyles } from '@/styles/typography';
 
 interface ContentsInputProp {
   onChange: (e: ChangeEvent<HTMLInputElement> | ChangeEvent<HTMLTextAreaElement>) => void;
+  value: string | null;
 }
 
-const ContentsInput = forwardRef(({ onChange }: ContentsInputProp, ref: Ref<HTMLTextAreaElement> | undefined) => {
-  return (
-    <Contents placeholder='내용을 입력해주세요' maxLength={20000} spellCheck='false' onChange={onChange} ref={ref} />
-  );
-});
+const ContentsInput = forwardRef(
+  ({ onChange, value }: ContentsInputProp, ref: Ref<HTMLTextAreaElement> | undefined) => {
+    return (
+      <Contents
+        placeholder='내용을 입력해주세요'
+        maxLength={20000}
+        spellCheck='false'
+        onChange={onChange}
+        ref={ref}
+        value={value ?? ''}
+      />
+    );
+  },
+);
 
 export default ContentsInput;
 

--- a/src/components/feed/upload/hooks/useUploadFeedData.ts
+++ b/src/components/feed/upload/hooks/useUploadFeedData.ts
@@ -4,8 +4,8 @@ import useBlindWriterPromise from '@/components/feed/common/hooks/useBlindWriter
 import useCategory from '@/components/feed/common/hooks/useCategory';
 import { UploadFeedDataType } from '@/components/feed/upload/types';
 
-export default function useUploadFeedData(initialForm: UploadFeedDataType) {
-  const [feedData, setFeedData] = useState(initialForm);
+export default function useUploadFeedData(defaultValue: UploadFeedDataType) {
+  const [feedData, setFeedData] = useState(defaultValue);
   const { handleShowBlindWriterPromise } = useBlindWriterPromise();
   const { findParentCategory } = useCategory();
 
@@ -61,7 +61,7 @@ export default function useUploadFeedData(initialForm: UploadFeedDataType) {
   };
 
   const resetFeedData = () => {
-    setFeedData(initialForm);
+    setFeedData(defaultValue);
   };
 
   return {

--- a/src/components/feed/upload/hooks/useUploadFeedData.ts
+++ b/src/components/feed/upload/hooks/useUploadFeedData.ts
@@ -1,30 +1,17 @@
-import { useQuery } from '@tanstack/react-query';
 import { useState } from 'react';
 
-import { getCategory } from '@/api/endpoint/feed/getCategory';
 import useBlindWriterPromise from '@/components/feed/common/hooks/useBlindWriterPromise';
+import useCategory from '@/components/feed/common/hooks/useCategory';
 import { UploadFeedDataType } from '@/components/feed/upload/types';
 
 export default function useUploadFeedData(initialForm: UploadFeedDataType) {
   const [feedData, setFeedData] = useState(initialForm);
   const { handleShowBlindWriterPromise } = useBlindWriterPromise();
+  const { findParentCategory } = useCategory();
 
-  const { data: categoryData } = useQuery({
-    queryKey: getCategory.cacheKey(),
-    queryFn: getCategory.request,
-  });
-
-  const findParentCategory = (categoryId: number) => {
-    const category =
-      categoryData &&
-      categoryData.find((category) =>
-        category.children.length > 0
-          ? category.children.some((tag) => tag.id === categoryId)
-          : category.id === categoryId,
-      );
-
-    return category;
-  };
+  // useEffect(() => {
+  //   setFeedData(initialForm);
+  // }, [initialForm]);
 
   const resetIsBlindWriter = (categoryId: number) => {
     !findParentCategory(categoryId)?.hasBlind && setFeedData((feedData) => ({ ...feedData, isBlindWriter: false }));

--- a/src/components/feed/upload/hooks/useUploadFeedData.ts
+++ b/src/components/feed/upload/hooks/useUploadFeedData.ts
@@ -9,10 +9,6 @@ export default function useUploadFeedData(initialForm: UploadFeedDataType) {
   const { handleShowBlindWriterPromise } = useBlindWriterPromise();
   const { findParentCategory } = useCategory();
 
-  // useEffect(() => {
-  //   setFeedData(initialForm);
-  // }, [initialForm]);
-
   const resetIsBlindWriter = (categoryId: number) => {
     !findParentCategory(categoryId)?.hasBlind && setFeedData((feedData) => ({ ...feedData, isBlindWriter: false }));
   };

--- a/src/components/feed/upload/types.ts
+++ b/src/components/feed/upload/types.ts
@@ -16,5 +16,5 @@ export interface UploadFeedDataType extends FeedDataType {
 }
 
 export interface EditFeedDataType extends FeedDataType {
-  postId: number;
+  postId: number | null;
 }

--- a/src/components/feed/upload/types.ts
+++ b/src/components/feed/upload/types.ts
@@ -1,9 +1,20 @@
-export interface UploadFeedDataType {
-  mainCategoryId: number | null;
+export interface FeedDataType {
   categoryId: number | null;
   title: string | null;
   content: string;
   isQuestion: boolean;
   isBlindWriter: boolean;
   images: string[];
+}
+
+export interface PostedFeedDataType extends FeedDataType {
+  id: number;
+}
+
+export interface UploadFeedDataType extends FeedDataType {
+  mainCategoryId: number | null;
+}
+
+export interface EditFeedDataType extends FeedDataType {
+  postId: number;
 }

--- a/src/constants/links.ts
+++ b/src/constants/links.ts
@@ -31,4 +31,5 @@ export const playgroundLink = {
   feedList: () => `/`,
   feedDetail: (id: string | number) => `/feed/${id}`,
   feedUpload: () => `/feed/upload`,
+  feedEdit: (id: string | number) => `/feed/edit/${id}`,
 };

--- a/src/pages/feed/edit/[id].tsx
+++ b/src/pages/feed/edit/[id].tsx
@@ -8,7 +8,9 @@ import { getPost, useGetPostQuery } from '@/api/endpoint/feed/getPost';
 import { useGetPostsInfiniteQuery } from '@/api/endpoint/feed/getPosts';
 import AuthRequired from '@/components/auth/AuthRequired';
 import Loading from '@/components/common/Loading';
+import useModalState from '@/components/common/Modal/useModalState';
 import useEventLogger from '@/components/eventLogger/hooks/useEventLogger';
+import EditImpossibleModal from '@/components/feed/edit/EditImpossibleModal';
 import FeedUploadPage, { LoadingWrapper } from '@/components/feed/page/FeedUploadPage';
 import { FeedDataType } from '@/components/feed/upload/types';
 import useStringRouterQuery from '@/hooks/useStringRouterQuery';
@@ -21,6 +23,7 @@ const FeedEdit: FC = () => {
   const router = useRouter();
   const { logSubmitEvent } = useEventLogger();
   const queryClient = useQueryClient();
+  const { isOpen, onOpen, onClose } = useModalState(true);
 
   const { mutate, isPending } = useMutation({
     mutationFn: (requestBody: { data: FeedDataType; id: number | null }) =>
@@ -62,19 +65,23 @@ const FeedEdit: FC = () => {
       <>
         {data != null && (
           <AuthRequired>
-            <FeedUploadPage
-              defaultValue={{
-                mainCategoryId: data.posts.categoryId,
-                categoryId: data.posts.categoryId,
-                title: data.posts.title,
-                content: data.posts.content,
-                isQuestion: data.posts.isQuestion,
-                isBlindWriter: data.posts.isBlindWriter,
-                images: data.posts.images,
-              }}
-              onSubmit={handleEditSubmit}
-              editingId={data.posts.id}
-            />
+            {data.isMine ? (
+              <FeedUploadPage
+                defaultValue={{
+                  mainCategoryId: data.posts.categoryId,
+                  categoryId: data.posts.categoryId,
+                  title: data.posts.title,
+                  content: data.posts.content,
+                  isQuestion: data.posts.isQuestion,
+                  isBlindWriter: data.posts.isBlindWriter,
+                  images: data.posts.images,
+                }}
+                onSubmit={handleEditSubmit}
+                editingId={data.posts.id}
+              />
+            ) : (
+              <EditImpossibleModal isOpen={isOpen} onClose={onClose} />
+            )}
           </AuthRequired>
         )}
       </>

--- a/src/pages/feed/edit/[id].tsx
+++ b/src/pages/feed/edit/[id].tsx
@@ -41,7 +41,7 @@ const FeedEdit: FC = () => {
         {data != null && (
           <AuthRequired>
             <FeedUploadPage
-              initialForm={{
+              defaultValue={{
                 mainCategoryId: data.posts.categoryId,
                 categoryId: data.posts.categoryId,
                 title: data.posts.title,

--- a/src/pages/feed/edit/[id].tsx
+++ b/src/pages/feed/edit/[id].tsx
@@ -1,0 +1,32 @@
+import { FC } from 'react';
+
+import AuthRequired from '@/components/auth/AuthRequired';
+import FeedUploadPage from '@/components/feed/page/FeedUploadPage';
+import useStringRouterQuery from '@/hooks/useStringRouterQuery';
+import { setLayout } from '@/utils/layout';
+
+const FeedEdit: FC = () => {
+  const { status, query } = useStringRouterQuery(['id'] as const);
+
+  if (status === 'loading') {
+    return null;
+  }
+
+  if (status === 'error') {
+    return null;
+  }
+
+  if (status === 'success') {
+    return (
+      <AuthRequired>
+        <FeedUploadPage isEdit feedId={query.id} />
+      </AuthRequired>
+    );
+  }
+
+  return null;
+};
+
+setLayout(FeedEdit, 'empty');
+
+export default FeedEdit;

--- a/src/pages/feed/edit/[id].tsx
+++ b/src/pages/feed/edit/[id].tsx
@@ -1,10 +1,12 @@
+import { useMutation } from '@tanstack/react-query';
 import { FC } from 'react';
 
-import { useSaveEditFeedData } from '@/api/endpoint/feed/editFeed';
+import { editFeed } from '@/api/endpoint/feed/editFeed';
 import { useGetPostQuery } from '@/api/endpoint/feed/getPost';
 import AuthRequired from '@/components/auth/AuthRequired';
 import Loading from '@/components/common/Loading';
 import FeedUploadPage, { LoadingWrapper } from '@/components/feed/page/FeedUploadPage';
+import { FeedDataType } from '@/components/feed/upload/types';
 import useStringRouterQuery from '@/hooks/useStringRouterQuery';
 import { setLayout } from '@/utils/layout';
 
@@ -13,7 +15,10 @@ const FeedEdit: FC = () => {
   const feedId = query ? query.id : '';
   const { data } = useGetPostQuery(feedId);
 
-  const { mutate: handleEditFeed, isPending } = useSaveEditFeedData();
+  const { mutate, isPending } = useMutation({
+    mutationFn: (requestBody: { data: FeedDataType; id: number | null }) =>
+      editFeed.request({ postId: requestBody.id, ...requestBody.data }),
+  });
 
   if (isPending) {
     return (
@@ -46,7 +51,7 @@ const FeedEdit: FC = () => {
                 isBlindWriter: data.posts.isBlindWriter,
                 images: data.posts.images,
               }}
-              onSubmit={handleEditFeed}
+              onSubmit={mutate}
               editingId={data.posts.id}
             />
           </AuthRequired>

--- a/src/pages/feed/edit/[id].tsx
+++ b/src/pages/feed/edit/[id].tsx
@@ -12,8 +12,7 @@ import { setLayout } from '@/utils/layout';
 
 const FeedEdit: FC = () => {
   const { status, query } = useStringRouterQuery(['id'] as const);
-  const feedId = query ? query.id : '';
-  const { data } = useGetPostQuery(feedId);
+  const { data } = useGetPostQuery(query?.id);
 
   const { mutate, isPending } = useMutation({
     mutationFn: (requestBody: { data: FeedDataType; id: number | null }) =>

--- a/src/pages/feed/edit/[id].tsx
+++ b/src/pages/feed/edit/[id].tsx
@@ -47,7 +47,7 @@ const FeedEdit: FC = () => {
                 images: data.posts.images,
               }}
               onSubmit={handleEditFeed}
-              editingId={data.posts.categoryId}
+              editingId={data.posts.id}
             />
           </AuthRequired>
         )}

--- a/src/pages/feed/edit/[id].tsx
+++ b/src/pages/feed/edit/[id].tsx
@@ -1,12 +1,27 @@
 import { FC } from 'react';
 
+import { useSaveEditFeedData } from '@/api/endpoint/feed/editFeed';
+import { useGetPostQuery } from '@/api/endpoint/feed/getPost';
 import AuthRequired from '@/components/auth/AuthRequired';
-import FeedUploadPage from '@/components/feed/page/FeedUploadPage';
+import Loading from '@/components/common/Loading';
+import FeedUploadPage, { LoadingWrapper } from '@/components/feed/page/FeedUploadPage';
 import useStringRouterQuery from '@/hooks/useStringRouterQuery';
 import { setLayout } from '@/utils/layout';
 
 const FeedEdit: FC = () => {
   const { status, query } = useStringRouterQuery(['id'] as const);
+  const feedId = query ? query.id : '';
+  const { data } = useGetPostQuery(feedId);
+
+  const { mutate: handleEditFeed, isPending } = useSaveEditFeedData();
+
+  if (isPending) {
+    return (
+      <LoadingWrapper>
+        <Loading />
+      </LoadingWrapper>
+    );
+  }
 
   if (status === 'loading') {
     return null;
@@ -18,9 +33,25 @@ const FeedEdit: FC = () => {
 
   if (status === 'success') {
     return (
-      <AuthRequired>
-        <FeedUploadPage isEdit feedId={query.id} />
-      </AuthRequired>
+      <>
+        {data != null && (
+          <AuthRequired>
+            <FeedUploadPage
+              initialForm={{
+                mainCategoryId: data.posts.categoryId,
+                categoryId: data.posts.categoryId,
+                title: data.posts.title,
+                content: data.posts.content,
+                isQuestion: data.posts.isQuestion,
+                isBlindWriter: data.posts.isBlindWriter,
+                images: data.posts.images,
+              }}
+              onSubmit={handleEditFeed}
+              editingId={data.posts.categoryId}
+            />
+          </AuthRequired>
+        )}
+      </>
     );
   }
 

--- a/src/pages/feed/edit/[id].tsx
+++ b/src/pages/feed/edit/[id].tsx
@@ -1,10 +1,14 @@
-import { useMutation } from '@tanstack/react-query';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { useRouter } from 'next/router';
+import { playgroundLink } from 'playground-common/export';
 import { FC } from 'react';
 
 import { editFeed } from '@/api/endpoint/feed/editFeed';
-import { useGetPostQuery } from '@/api/endpoint/feed/getPost';
+import { getPost, useGetPostQuery } from '@/api/endpoint/feed/getPost';
+import { useGetPostsInfiniteQuery } from '@/api/endpoint/feed/getPosts';
 import AuthRequired from '@/components/auth/AuthRequired';
 import Loading from '@/components/common/Loading';
+import useEventLogger from '@/components/eventLogger/hooks/useEventLogger';
 import FeedUploadPage, { LoadingWrapper } from '@/components/feed/page/FeedUploadPage';
 import { FeedDataType } from '@/components/feed/upload/types';
 import useStringRouterQuery from '@/hooks/useStringRouterQuery';
@@ -13,11 +17,29 @@ import { setLayout } from '@/utils/layout';
 const FeedEdit: FC = () => {
   const { status, query } = useStringRouterQuery(['id'] as const);
   const { data } = useGetPostQuery(query?.id);
+  const editingId = data?.posts.id;
+  const router = useRouter();
+  const { logSubmitEvent } = useEventLogger();
+  const queryClient = useQueryClient();
 
   const { mutate, isPending } = useMutation({
     mutationFn: (requestBody: { data: FeedDataType; id: number | null }) =>
       editFeed.request({ postId: requestBody.id, ...requestBody.data }),
   });
+
+  const handleEditSubmit = ({ data, id }: { data: FeedDataType; id: number | null }) => {
+    mutate(
+      { data: data, id: id },
+      {
+        onSuccess: async () => {
+          logSubmitEvent('editCommunity');
+          queryClient.invalidateQueries({ queryKey: useGetPostsInfiniteQuery.getKey('') });
+          editingId && queryClient.invalidateQueries({ queryKey: getPost.cacheKey(`${editingId}`) });
+          await router.push(playgroundLink.feedList());
+        },
+      },
+    );
+  };
 
   if (isPending) {
     return (
@@ -50,7 +72,7 @@ const FeedEdit: FC = () => {
                 isBlindWriter: data.posts.isBlindWriter,
                 images: data.posts.images,
               }}
-              onSubmit={mutate}
+              onSubmit={handleEditSubmit}
               editingId={data.posts.id}
             />
           </AuthRequired>

--- a/src/pages/feed/upload.tsx
+++ b/src/pages/feed/upload.tsx
@@ -1,13 +1,36 @@
 import { FC } from 'react';
 
+import { useSaveUploadFeedData } from '@/api/endpoint/feed/uploadFeed';
 import AuthRequired from '@/components/auth/AuthRequired';
-import FeedUploadPage from '@/components/feed/page/FeedUploadPage';
+import Loading from '@/components/common/Loading';
+import FeedUploadPage, { LoadingWrapper } from '@/components/feed/page/FeedUploadPage';
 import { setLayout } from '@/utils/layout';
 
 const FeedUpload: FC = () => {
+  const { mutate: handleUploadFeed, isPending } = useSaveUploadFeedData();
+
+  if (isPending) {
+    return (
+      <LoadingWrapper>
+        <Loading />
+      </LoadingWrapper>
+    );
+  }
+
   return (
     <AuthRequired>
-      <FeedUploadPage />
+      <FeedUploadPage
+        initialForm={{
+          mainCategoryId: null,
+          categoryId: null,
+          title: '',
+          content: '',
+          isQuestion: false,
+          isBlindWriter: false,
+          images: [],
+        }}
+        onSubmit={handleUploadFeed}
+      />
     </AuthRequired>
   );
 };

--- a/src/pages/feed/upload.tsx
+++ b/src/pages/feed/upload.tsx
@@ -1,13 +1,17 @@
+import { useMutation } from '@tanstack/react-query';
 import { FC } from 'react';
 
-import { useSaveUploadFeedData } from '@/api/endpoint/feed/uploadFeed';
+import { uploadFeed } from '@/api/endpoint/feed/uploadFeed';
 import AuthRequired from '@/components/auth/AuthRequired';
 import Loading from '@/components/common/Loading';
 import FeedUploadPage, { LoadingWrapper } from '@/components/feed/page/FeedUploadPage';
+import { FeedDataType } from '@/components/feed/upload/types';
 import { setLayout } from '@/utils/layout';
 
 const FeedUpload: FC = () => {
-  const { mutate: handleUploadFeed, isPending } = useSaveUploadFeedData();
+  const { mutate, isPending } = useMutation({
+    mutationFn: (reqeustBody: { data: FeedDataType; id: number | null }) => uploadFeed.request({ ...reqeustBody.data }),
+  });
 
   if (isPending) {
     return (
@@ -29,7 +33,7 @@ const FeedUpload: FC = () => {
           isBlindWriter: false,
           images: [],
         }}
-        onSubmit={handleUploadFeed}
+        onSubmit={mutate}
       />
     </AuthRequired>
   );

--- a/src/pages/feed/upload.tsx
+++ b/src/pages/feed/upload.tsx
@@ -24,7 +24,7 @@ const FeedUpload: FC = () => {
   return (
     <AuthRequired>
       <FeedUploadPage
-        initialForm={{
+        defaultValue={{
           mainCategoryId: null,
           categoryId: null,
           title: '',


### PR DESCRIPTION
### 🤫 쉿, 나한테만 말해줘요. 이슈넘버
- close #1262 

### 🧐 어떤 것을 변경했어요~?
<!-- 실제로 변경한 사항을 설명해주세요.-->
- 피드 수정을 구현했어요. 

### 🤔 그렇다면, 어떻게 구현했어요~?
<!-- 실제로 구현한 로직에 대해 설명해주세요.-->
- 기존의 FeedUploadPage를 재활용하려고 했어요, 그래서 isEdit을 prop으로 내려받도록 했습니다.(isEdit true이면 PUT, 아니면 POST가 되도록이요!) 
- 또한 feed/edit/[id]로 라우팅해서 query.id를 prop으로 내려주었어요. 그 값을 이용해 `const { data: postData } = useGetPostQuery(feedId);` 로 데이터를 가져왔어요. 만일 postData가 없으면(1.실제로 값이 없거나 2. 수정이 아닌 업로드인 경우) null이나 빈값이 되도록 다음과 같이 initialData를 선언해주었어요. 
```
  const initialData = {
    mainCategoryId: postData?.posts.categoryId ?? null,
    categoryId: postData?.posts.categoryId ?? null,
    title: postData?.posts.title ?? '',
    content: postData?.posts.content ?? '',
    isQuestion: postData?.posts.isQuestion ?? false,
    isBlindWriter: postData?.posts.isBlindWriter ?? false,
    images: postData?.posts.images ?? [],
  };
```

### ❤️‍🔥 당신이 생각하는 PR포인트, 내겐 매력포인트.
<!-- 해당 PR에서 논의가 필요한 사항을 적어주세요. -->
### useUploadFeedData
`const [feedData, setFeedData] = useState(initialForm);`
- 만일, 수정을 눌러서 수정페이지로 들어오면 feedData의 초기값이 initialForm으로 잘 들어오는데요! 새로고침을 하게 되면, feedData가 initialForm이 아닌 null, false, []로 초기화가 되더라고요.. (간혹 처음에도 initialForm으로 초기화가 안 될 때가 있습니다ㅜ)
- props로 받는 initialForm(부모컴포넌트에서는 initialData)을 변수가 아닌 state로 변경해보아도 동일한 이슈가 생기더라구요, useEffect를 사용해서 setFeedData해주면 무한리렌더링이 발생해서 좋은 방법이 없을지 논의하고 싶습니다!


# 코드리뷰 반영하면서 리팩토링한 결과
### 🤔 그렇다면, 어떻게 구현했어요~?
- 원래 FeedUploadPage 안에서 handleEditFeed, handleUpdateFeed를 불러왔는데, FeedUploadPage 바깥에서 불러오고 props으로 내려주었어요. 
- FeedUploadPage 컴포넌트에, initialForm, onSubmit, editingId을 prop으로 내려주었어요.
- 수정의 경우, 데이터를 읽어온 뒤 data != null인 경우에만 FeedUploadPage컴포넌트가 보여지도록 해서, 새로고침을 해도 수정 데이터가 바로 잘 들어와요!!


### 📸 스크린샷, 없으면 이것 참,, 섭섭한데요?

<img width="1440" alt="스크린샷 2024-01-09 오후 7 21 58" src="https://github.com/sopt-makers/sopt-playground-frontend/assets/76681519/a0896ab7-12c3-4a4a-a559-20fa461b0a56">

