### PR TITLE
feat: 프로필 내 카드 구현

### DIFF
--- a/src/components/common/ContentsCard/index.stories.tsx
+++ b/src/components/common/ContentsCard/index.stories.tsx
@@ -13,7 +13,6 @@ export const Default = {
     title: '프로젝트 제목제목제목 제목입니다.',
     top: '프로젝트 유형 카테고리',
     bottom: '프로젝트 날짜 설명 이 프로젝트는 프로젝트입니다.',
-    isCurrent: true,
   },
 
   name: 'Default',

--- a/src/components/common/ContentsCard/index.stories.tsx
+++ b/src/components/common/ContentsCard/index.stories.tsx
@@ -1,0 +1,20 @@
+import { Meta } from '@storybook/react';
+
+import ContentsCard from '@/components/common/ContentsCard';
+
+export default {
+  component: ContentsCard,
+} as Meta<typeof ContentsCard>;
+
+export const Default = {
+  args: {
+    thumbnail:
+      'https://makers-web-img.s3.ap-northeast-2.amazonaws.com/meeting/2024/01/08/213a1b06-35fd-4227-9029-3843f66622a3.png',
+    title: '프로젝트 제목제목제목 제목입니다.',
+    top: '프로젝트 유형 카테고리',
+    bottom: '프로젝트 날짜 설명 이 프로젝트는 프로젝트입니다.',
+    isCurrent: true,
+  },
+
+  name: 'Default',
+};

--- a/src/components/common/ContentsCard/index.tsx
+++ b/src/components/common/ContentsCard/index.tsx
@@ -10,7 +10,7 @@ interface ContentsCardProps {
   isCurrent?: boolean;
 }
 
-export default function ContentsCars({ thumbnail, title, top, bottom, isCurrent }: ContentsCardProps) {
+export default function ContentsCard({ thumbnail, title, top, bottom, isCurrent }: ContentsCardProps) {
   return (
     <Card>
       <Thumbnail src={thumbnail} alt={`${title} 이미지`} />

--- a/src/components/common/ContentsCard/index.tsx
+++ b/src/components/common/ContentsCard/index.tsx
@@ -7,20 +7,16 @@ interface ContentsCardProps {
   title: string;
   top: string;
   bottom: string;
-  isCurrent?: boolean;
 }
 
-export default function ContentsCard({ thumbnail, title, top, bottom, isCurrent }: ContentsCardProps) {
+export default function ContentsCard({ thumbnail, title, top, bottom }: ContentsCardProps) {
   return (
     <Card>
       <Thumbnail src={thumbnail} alt={`${title} 이미지`} />
       <Contents>
         <Description>{top}</Description>
         <Title>{title}</Title>
-        <Bottom>
-          {isCurrent !== undefined && <Circle isCurrent={isCurrent} />}
-          <Description>{bottom}</Description>
-        </Bottom>
+        <Description>{bottom}</Description>
       </Contents>
     </Card>
   );
@@ -55,13 +51,6 @@ const Description = styled.p`
   ${fonts.LABEL_14_SB};
 `;
 
-const Circle = styled.div<{ isCurrent: boolean }>`
-  border-radius: 50%;
-  background-color: ${({ isCurrent }) => (isCurrent ? '#CDF47C' : colors.gray300)};
-  width: 6px;
-  height: 6px;
-`;
-
 const Title = styled.h1`
   max-width: 227px;
   overflow: hidden;
@@ -77,10 +66,4 @@ const Contents = styled.div`
   display: flex;
   flex-direction: column;
   gap: 4px;
-`;
-
-const Bottom = styled.footer`
-  display: flex;
-  gap: 8px;
-  align-items: center;
 `;

--- a/src/components/common/ContentsCard/index.tsx
+++ b/src/components/common/ContentsCard/index.tsx
@@ -1,0 +1,86 @@
+import styled from '@emotion/styled';
+import { colors } from '@sopt-makers/colors';
+import { fonts } from '@sopt-makers/fonts';
+
+interface ContentsCardProps {
+  thumbnail: string;
+  title: string;
+  top: string;
+  bottom: string;
+  isCurrent?: boolean;
+}
+
+export default function ContentsCars({ thumbnail, title, top, bottom, isCurrent }: ContentsCardProps) {
+  return (
+    <Card>
+      <Thumbnail src={thumbnail} alt={`${title} 이미지`} />
+      <Contents>
+        <Description>{top}</Description>
+        <Title>{title}</Title>
+        <Bottom>
+          {isCurrent !== undefined && <Circle isCurrent={isCurrent} />}
+          <Description>{bottom}</Description>
+        </Bottom>
+      </Contents>
+    </Card>
+  );
+}
+
+const Card = styled.article`
+  display: center;
+  gap: 16px;
+  align-items: center;
+  border-radius: 20px;
+  background: ${colors.gray900};
+  padding: 16px;
+  width: 100%;
+  height: 116px;
+`;
+
+const Thumbnail = styled.img`
+  border-radius: 14px;
+  width: 84px;
+  height: 84px;
+  object-fit: cover;
+`;
+
+const Description = styled.p`
+  max-width: 220px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  word-break: break-all;
+  color: ${colors.gray200};
+
+  ${fonts.LABEL_14_SB};
+`;
+
+const Circle = styled.div<{ isCurrent: boolean }>`
+  border-radius: 50%;
+  background-color: ${({ isCurrent }) => (isCurrent ? '#CDF47C' : colors.gray300)};
+  width: 6px;
+  height: 6px;
+`;
+
+const Title = styled.h1`
+  max-width: 227px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  word-break: break-all;
+  color: ${colors.white};
+
+  ${fonts.HEADING_18_B};
+`;
+
+const Contents = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+`;
+
+const Bottom = styled.footer`
+  display: flex;
+  gap: 8px;
+  align-items: center;
+`;


### PR DESCRIPTION
### 🤫 쉿, 나한테만 말해줘요. 이슈넘버
- close #1271

### 🧐 어떤 것을 변경했어요~?
<!-- 실제로 변경한 사항을 설명해주세요.-->
- 프로필 내에서 프로젝트/모임에 사용되는 콘텐츠 카드를 구현했어요. 

### 🤔 그렇다면, 어떻게 구현했어요~?
<!-- 실제로 구현한 로직에 대해 설명해주세요.-->
- ContentsCard로 네이밍하고, thumbnail, title, top, bottom을 prop으로 받아왔어요.
- title은 제목, top은 제목 위에 들어가는 내용, bottom은 제목 아래에 들어가는 내용이에요. 

### ❤️‍🔥 당신이 생각하는 PR포인트, 내겐 매력포인트.
<!-- 해당 PR에서 논의가 필요한 사항을 적어주세요. -->
- MemberProjectCard, MemberGroupCard컴포넌트를 따로 만든 뒤, 지금 만든 ContentsCard를 사용하려고 해요.

### 📸 스크린샷, 없으면 이것 참,, 섭섭한데요?

<img width="487" alt="스크린샷 2024-01-24 오전 1 01 33" src="https://github.com/sopt-makers/sopt-playground-frontend/assets/76681519/a9818a3b-99f1-4028-86de-7b8dbc9eab70">

