### PR TITLE
fix: feed edit 페이지 라우팅 이슈 해결

### DIFF
--- a/functions/feed/edit/[id].ts
+++ b/functions/feed/edit/[id].ts
@@ -1,0 +1,10 @@
+// /feed/edit/[id] 주소로 직접 접근 시 /feed/edit/[id].html 로 보내기
+export const onRequest: PagesFunction = async (context) => {
+  const { next, params } = context;
+
+  if (/\d+/.test(`${params.id}`)) {
+    return next('/feed/edit/[id]');
+  }
+
+  return next();
+};


### PR DESCRIPTION
### 🤫 쉿, 나한테만 말해줘요. 이슈넘버
- close #1282 

### 🧐 어떤 것을 변경했어요~?
<!-- 실제로 변경한 사항을 설명해주세요.-->
- 수정 페이지에서 새로고침을 하면 404페이지가 뜨는 이슈를 해결했어요. 
<img width="382" alt="스크린샷 2024-01-27 오후 7 41 40" src="https://github.com/sopt-makers/sopt-playground-frontend/assets/76681519/832cb858-3bc3-4676-bd48-a7f8f9d578fa">

### 🤔 그렇다면, 어떻게 구현했어요~?
<!-- 실제로 구현한 로직에 대해 설명해주세요.-->
https://github.com/sopt-makers/sopt-playground-frontend/pull/456 이 PR을 참고했어요!!!

### ❤️‍🔥 당신이 생각하는 PR포인트, 내겐 매력포인트.
<!-- 해당 PR에서 논의가 필요한 사항을 적어주세요. -->
- 멘토링이나 프로젝트 수정 url과의 통일성을 위해 feed/edit/[id] 라우팅은 유지하고, PR을 참고하여 function을 추가해주었어요.

### 📸 스크린샷, 없으면 이것 참,, 섭섭한데요?
