### PR TITLE
refactor: mainCategoryId 따로 저장하는 로직 걷어내기

### DIFF
--- a/src/components/feed/common/hooks/useCategory.ts
+++ b/src/components/feed/common/hooks/useCategory.ts
@@ -8,36 +8,26 @@ export default function useCategory() {
     queryFn: getCategory.request,
   });
 
-  const findParentCategory = (categoryId: number) => {
+  const findParentCategory = (categoryId: number | null) => {
     const category =
       categoryData &&
-      categoryData.find((category) =>
-        category.children.length > 0
-          ? category.children.some((tag) => tag.id === categoryId)
-          : category.id === categoryId,
+      categoryData.find(
+        (category) =>
+          // MEMO: 피드 업로드에서는 categoryId자체가 부모 카테고리 id일 수 있습니다.
+          category.id === categoryId ||
+          (category.children.length > 0 && category.children.some((tag) => tag.id === categoryId)),
       );
 
     return category;
   };
 
-  const findMainCategory = (categoryId: number | null, mainCategoryId?: number | null) => {
-    const parentCategory =
-      (categoryData &&
-        categoryData.find(
-          (category) => category.id === mainCategoryId || category.children.some((tag) => tag.id === categoryId),
-        )) ??
-      null;
-
-    return parentCategory;
-  };
-
   const findChildrenCategory = (categoryId: number | null) => {
-    const parentCategory = findMainCategory(categoryId);
+    const parentCategory = findParentCategory(categoryId);
 
     const category = (parentCategory && parentCategory.children.find((tag) => tag.id === categoryId)) ?? null;
 
     return category;
   };
 
-  return { findParentCategory, findMainCategory, findChildrenCategory };
+  return { findParentCategory, findChildrenCategory };
 }

--- a/src/components/feed/page/FeedUploadPage.tsx
+++ b/src/components/feed/page/FeedUploadPage.tsx
@@ -21,7 +21,7 @@ import ContentsInput from '@/components/feed/upload/Input/ContentsInput';
 import TitleInput from '@/components/feed/upload/Input/TitleInput';
 import DesktopFeedUploadLayout from '@/components/feed/upload/layout/DesktopFeedUploadLayout';
 import MobileFeedUploadLayout from '@/components/feed/upload/layout/MobileFeedUploadLayout';
-import { FeedDataType, UploadFeedDataType } from '@/components/feed/upload/types';
+import { FeedDataType } from '@/components/feed/upload/types';
 import UsingRules from '@/components/feed/upload/UsingRules';
 import useImageUploader from '@/hooks/useImageUploader';
 import BackArrow from '@/public/icons/icon_chevron_left.svg';
@@ -30,7 +30,7 @@ import { textStyles } from '@/styles/typography';
 
 interface FeedUploadPageProp {
   editingId?: number;
-  defaultValue: UploadFeedDataType;
+  defaultValue: FeedDataType;
   onSubmit: ({ data, id }: { data: FeedDataType; id: number | null }) => void;
 }
 
@@ -42,7 +42,6 @@ export default function FeedUploadPage({ defaultValue, editingId, onSubmit }: Fe
     feedData,
     handleSaveCategory,
     handleSaveIsQuestion,
-    handleSaveMainCategory,
     handleSaveIsBlindWriter,
     saveImageUrls,
     removeImage,
@@ -100,9 +99,9 @@ export default function FeedUploadPage({ defaultValue, editingId, onSubmit }: Fe
     router.back();
   };
 
-  const { findMainCategory } = useCategory();
+  const { findParentCategory } = useCategory();
 
-  const parentCategory = findMainCategory(feedData.categoryId, feedData.mainCategoryId);
+  const parentCategory = findParentCategory(feedData.categoryId);
 
   const quitUploading = () => {
     logClickEvent('quitUploadCommunity', {
@@ -158,7 +157,6 @@ export default function FeedUploadPage({ defaultValue, editingId, onSubmit }: Fe
               <Category
                 feedData={feedData}
                 onSaveCategory={handleSaveCategory}
-                onSaveMainCategory={handleSaveMainCategory}
                 openUsingRules={openUsingRules}
                 closeUsingRules={closeUsingRules}
                 isEdit={isEdit}
@@ -249,7 +247,6 @@ export default function FeedUploadPage({ defaultValue, editingId, onSubmit }: Fe
               <Category
                 feedData={feedData}
                 onSaveCategory={handleSaveCategory}
-                onSaveMainCategory={handleSaveMainCategory}
                 openUsingRules={openUsingRules}
                 closeUsingRules={closeUsingRules}
                 isEdit={isEdit}

--- a/src/components/feed/upload/Category/CategoryHeader/index.tsx
+++ b/src/components/feed/upload/Category/CategoryHeader/index.tsx
@@ -2,7 +2,7 @@ import styled from '@emotion/styled';
 import { colors } from '@sopt-makers/colors';
 
 import useCategory from '@/components/feed/common/hooks/useCategory';
-import { UploadFeedDataType } from '@/components/feed/upload/types';
+import { FeedDataType } from '@/components/feed/upload/types';
 import DetailArrow from '@/public/icons/icon-chevron-right.svg';
 import ExpandMoreArrow from '@/public/icons/icon-expand-more.svg';
 import Arrow from '@/public/icons/icon-select-arrow.svg';
@@ -10,15 +10,15 @@ import { MOBILE_MEDIA_QUERY } from '@/styles/mediaQuery';
 import { textStyles } from '@/styles/typography';
 
 interface CategoryHeaderProp {
-  feedData: UploadFeedDataType;
+  feedData: FeedDataType;
   openCategory: () => void;
   openTag: () => void;
 }
 
 export default function CategoryHeader({ feedData, openCategory, openTag }: CategoryHeaderProp) {
-  const { findMainCategory, findChildrenCategory } = useCategory();
+  const { findParentCategory, findChildrenCategory } = useCategory();
 
-  const parentCategory = findMainCategory(feedData.categoryId, feedData.mainCategoryId);
+  const parentCategory = findParentCategory(feedData.categoryId);
   const childrenCategory = findChildrenCategory(feedData.categoryId);
 
   return (

--- a/src/components/feed/upload/Category/CategorySelector/CategorySelectOptions.tsx
+++ b/src/components/feed/upload/Category/CategorySelector/CategorySelectOptions.tsx
@@ -4,12 +4,12 @@ import { useQuery } from '@tanstack/react-query';
 
 import { getCategory } from '@/api/endpoint/feed/getCategory';
 import { BasicCategory } from '@/components/feed/upload/Category/types';
-import { UploadFeedDataType } from '@/components/feed/upload/types';
+import { FeedDataType } from '@/components/feed/upload/types';
 import { textStyles } from '@/styles/typography';
 
 interface CategorySelectOptionsProp {
   onSave: (categoryId: number) => void;
-  feedData: UploadFeedDataType;
+  feedData: FeedDataType;
 }
 
 export default function CategorySelectOptions({ onSave, feedData }: CategorySelectOptionsProp) {
@@ -31,7 +31,7 @@ export default function CategorySelectOptions({ onSave, feedData }: CategorySele
             <Option
               key={category.id}
               onClick={() => handleSelectCategory(category.id)}
-              isSelected={category.id === feedData.mainCategoryId}
+              isSelected={category.id === feedData.categoryId}
             >
               <OptionTitle>{category.name}</OptionTitle>
               <OptionContents>{category.content}</OptionContents>

--- a/src/components/feed/upload/Category/CategorySelector/index.stories.tsx
+++ b/src/components/feed/upload/Category/CategorySelector/index.stories.tsx
@@ -20,7 +20,6 @@ export const Default = {
           onClose={onClose}
           onSelect={onClose}
           feedData={{
-            mainCategoryId: 0,
             categoryId: 0,
             title: '',
             content: '',

--- a/src/components/feed/upload/Category/CategorySelector/index.tsx
+++ b/src/components/feed/upload/Category/CategorySelector/index.tsx
@@ -4,7 +4,7 @@ import { BottomSheet } from '@/components/common/BottomSheet';
 import Responsive from '@/components/common/Responsive';
 import CategorySelectOptions from '@/components/feed/upload/Category/CategorySelector/CategorySelectOptions';
 import { DropDown } from '@/components/feed/upload/Category/DropDown';
-import { UploadFeedDataType } from '@/components/feed/upload/types';
+import { FeedDataType } from '@/components/feed/upload/types';
 import { MOBILE_MEDIA_QUERY } from '@/styles/mediaQuery';
 import { textStyles } from '@/styles/typography';
 
@@ -12,7 +12,7 @@ interface CategorySelectorProps {
   isOpen?: boolean;
   onClose: () => void;
   onSelect: (categoryId: number) => void;
-  feedData: UploadFeedDataType;
+  feedData: FeedDataType;
 }
 
 export default function CategorySelector({ isOpen = false, onClose, onSelect, feedData }: CategorySelectorProps) {

--- a/src/components/feed/upload/Category/TagSelector/TagSelectOptions.tsx
+++ b/src/components/feed/upload/Category/TagSelector/TagSelectOptions.tsx
@@ -1,18 +1,17 @@
 import styled from '@emotion/styled';
-import { useQuery } from '@tanstack/react-query';
 
-import { getCategory } from '@/api/endpoint/feed/getCategory';
 import Responsive from '@/components/common/Responsive';
 import SquareLink from '@/components/common/SquareLink';
+import useCategory from '@/components/feed/common/hooks/useCategory';
 import { BasicCategory } from '@/components/feed/upload/Category/types';
-import { UploadFeedDataType } from '@/components/feed/upload/types';
+import { FeedDataType } from '@/components/feed/upload/types';
 import CheckIcon from '@/public/icons/icon_check.svg';
 import { MOBILE_MEDIA_QUERY } from '@/styles/mediaQuery';
 
 interface TagSelectOptionsProp {
   onClose: () => void;
   onSave: (categoryId: number) => void;
-  feedData: UploadFeedDataType;
+  feedData: FeedDataType;
 }
 
 export default function TagSelectOptions({ onClose, onSave, feedData }: TagSelectOptionsProp) {
@@ -24,27 +23,9 @@ export default function TagSelectOptions({ onClose, onSave, feedData }: TagSelec
   const handleSelectTagMobile = (id: number) => {
     onSave(id);
   };
-
-  const { data: categories } = useQuery({
-    queryKey: getCategory.cacheKey(),
-    queryFn: getCategory.request,
-  });
-
-  const parentCategory =
-    (categories &&
-      categories.find(
-        (category: BasicCategory) =>
-          category.id === feedData.mainCategoryId || category.children.some((tag) => tag.id === feedData.categoryId),
-      )) ??
-    null;
-
-  const isInitial =
-    (categories &&
-      categories.find(
-        (category: BasicCategory) =>
-          category.id === feedData.mainCategoryId && category.children.some((tag) => tag.id === feedData.categoryId),
-      )) ??
-    null;
+  const { findParentCategory, findChildrenCategory } = useCategory();
+  const parentCategory = findParentCategory(feedData.categoryId);
+  const isInitial = findChildrenCategory(feedData.categoryId);
 
   return (
     <>
@@ -54,12 +35,12 @@ export default function TagSelectOptions({ onClose, onSave, feedData }: TagSelec
             {parentCategory.hasAll && (
               <>
                 <Responsive only='desktop'>
-                  <Option onClick={() => handleSelectTagDesktop(feedData.mainCategoryId ?? 0)}>
+                  <Option onClick={() => handleSelectTagDesktop(feedData.categoryId ?? 0)}>
                     주제 선택 안 함{!isInitial && <CheckIcon />}
                   </Option>
                 </Responsive>
                 <Responsive only='mobile'>
-                  <Option onClick={() => handleSelectTagMobile(feedData.mainCategoryId ?? 0)}>
+                  <Option onClick={() => handleSelectTagMobile(feedData.categoryId ?? 0)}>
                     주제 선택 안 함{!isInitial && <CheckIcon />}
                   </Option>
                 </Responsive>

--- a/src/components/feed/upload/Category/TagSelector/index.stories.tsx
+++ b/src/components/feed/upload/Category/TagSelector/index.stories.tsx
@@ -20,7 +20,6 @@ export const Default = {
           onClose={onClose}
           onBack={onClose}
           feedData={{
-            mainCategoryId: 0,
             categoryId: 0,
             title: '',
             content: '',

--- a/src/components/feed/upload/Category/TagSelector/index.tsx
+++ b/src/components/feed/upload/Category/TagSelector/index.tsx
@@ -1,12 +1,11 @@
 import styled from '@emotion/styled';
-import { useQuery } from '@tanstack/react-query';
 
-import { getCategory } from '@/api/endpoint/feed/getCategory';
 import { BottomSheet } from '@/components/common/BottomSheet';
 import Responsive from '@/components/common/Responsive';
+import useCategory from '@/components/feed/common/hooks/useCategory';
 import { DropDown } from '@/components/feed/upload/Category/DropDown';
 import TagSelectOptions from '@/components/feed/upload/Category/TagSelector/TagSelectOptions';
-import { UploadFeedDataType } from '@/components/feed/upload/types';
+import { FeedDataType } from '@/components/feed/upload/types';
 import BackArrow from '@/public/icons/icon_chevron_left.svg';
 import { MOBILE_MEDIA_QUERY } from '@/styles/mediaQuery';
 import { textStyles } from '@/styles/typography';
@@ -16,21 +15,12 @@ interface TagSelectorProps {
   onBack: () => void;
   onClose: () => void;
   onSave: (categoryId: number) => void;
-  feedData: UploadFeedDataType;
+  feedData: FeedDataType;
 }
 export default function TagSelector({ isOpen = false, onBack, onClose, onSave, feedData }: TagSelectorProps) {
-  const { data: categories } = useQuery({
-    queryKey: getCategory.cacheKey(),
-    queryFn: getCategory.request,
-  });
+  const { findParentCategory } = useCategory();
 
-  const parentCategory =
-    (categories &&
-      categories.find(
-        (category) =>
-          category.id === feedData.mainCategoryId || category.children.some((tag) => tag.id === feedData.categoryId),
-      )) ??
-    null;
+  const parentCategory = findParentCategory(feedData.categoryId);
 
   return (
     <>

--- a/src/components/feed/upload/Category/index.tsx
+++ b/src/components/feed/upload/Category/index.tsx
@@ -7,25 +7,17 @@ import CategoryHeader from '@/components/feed/upload/Category/CategoryHeader';
 import CategorySelector from '@/components/feed/upload/Category/CategorySelector';
 import TagSelector from '@/components/feed/upload/Category/TagSelector';
 import { useCategorySelect } from '@/components/feed/upload/hooks/useCategorySelect';
-import { UploadFeedDataType } from '@/components/feed/upload/types';
+import { FeedDataType } from '@/components/feed/upload/types';
 
 interface CateogryProps {
-  feedData: UploadFeedDataType;
+  feedData: FeedDataType;
   onSaveCategory: (categoryId: number) => void;
-  onSaveMainCategory: (categoryId: number) => void;
   openUsingRules: () => void;
   closeUsingRules: () => void;
   isEdit?: boolean;
 }
 
-export default function Category({
-  feedData,
-  onSaveCategory,
-  onSaveMainCategory,
-  openUsingRules,
-  closeUsingRules,
-  isEdit,
-}: CateogryProps) {
+export default function Category({ feedData, onSaveCategory, openUsingRules, closeUsingRules, isEdit }: CateogryProps) {
   const { isSelectorOpen, closeAll, openCategory, openTag } = useCategorySelect(isEdit ? 'closeAll' : 'openCategory');
 
   const { data: categories } = useQuery({
@@ -55,7 +47,7 @@ export default function Category({
       return;
     }
 
-    onSaveMainCategory(categoryId);
+    onSaveCategory(categoryId);
 
     if (selectedMainCategory.children.length === 0) {
       onSaveCategory(categoryId);

--- a/src/components/feed/upload/hooks/useUploadFeedData.ts
+++ b/src/components/feed/upload/hooks/useUploadFeedData.ts
@@ -2,9 +2,9 @@ import { useState } from 'react';
 
 import useBlindWriterPromise from '@/components/feed/common/hooks/useBlindWriterPromise';
 import useCategory from '@/components/feed/common/hooks/useCategory';
-import { UploadFeedDataType } from '@/components/feed/upload/types';
+import { FeedDataType } from '@/components/feed/upload/types';
 
-export default function useUploadFeedData(defaultValue: UploadFeedDataType) {
+export default function useUploadFeedData(defaultValue: FeedDataType) {
   const [feedData, setFeedData] = useState(defaultValue);
   const { handleShowBlindWriterPromise } = useBlindWriterPromise();
   const { findParentCategory } = useCategory();
@@ -15,10 +15,6 @@ export default function useUploadFeedData(defaultValue: UploadFeedDataType) {
 
   const resetIsQuestion = (categoryId: number) => {
     !findParentCategory(categoryId)?.hasQuestion && setFeedData((feedData) => ({ ...feedData, isQuestion: false }));
-  };
-
-  const handleSaveMainCategory = (categoryId: number) => {
-    setFeedData((feedData) => ({ ...feedData, mainCategoryId: categoryId }));
   };
 
   const handleSaveCategory = (categoryId: number) => {
@@ -68,7 +64,6 @@ export default function useUploadFeedData(defaultValue: UploadFeedDataType) {
     feedData,
     handleSaveCategory,
     handleSaveIsQuestion,
-    handleSaveMainCategory,
     handleSaveIsBlindWriter,
     saveImageUrls,
     removeImage,

--- a/src/components/feed/upload/types.ts
+++ b/src/components/feed/upload/types.ts
@@ -11,10 +11,6 @@ export interface PostedFeedDataType extends FeedDataType {
   id: number;
 }
 
-export interface UploadFeedDataType extends FeedDataType {
-  mainCategoryId: number | null;
-}
-
 export interface EditFeedDataType extends FeedDataType {
   postId: number | null;
 }

--- a/src/pages/feed/edit/[id].tsx
+++ b/src/pages/feed/edit/[id].tsx
@@ -68,7 +68,6 @@ const FeedEdit: FC = () => {
             {data.isMine ? (
               <FeedUploadPage
                 defaultValue={{
-                  mainCategoryId: data.posts.categoryId,
                   categoryId: data.posts.categoryId,
                   title: data.posts.title,
                   content: data.posts.content,

--- a/src/pages/feed/upload.tsx
+++ b/src/pages/feed/upload.tsx
@@ -46,7 +46,6 @@ const FeedUpload: FC = () => {
     <AuthRequired>
       <FeedUploadPage
         defaultValue={{
-          mainCategoryId: null,
           categoryId: null,
           title: '',
           content: '',


### PR DESCRIPTION
### 🤫 쉿, 나한테만 말해줘요. 이슈넘버
- close #1085 

### 🧐 어떤 것을 변경했어요~?
<!-- 실제로 변경한 사항을 설명해주세요.-->
- 피드 업로드에서, mainCategoryId와 categoryId를 두 번 저장하는 로직이 비효율적이라는 생각이 들었어요. categoryId는 실제로 서버에 들어가는 데이터이고, mainCategoryId는 피드 업로드에서 임시로 저장하던 데이터였습니다. categoryId만 저장하고, parentCategory를 찾는 함수를 통해 충분히 부모 카테고리 id를 찾을 수 있기 때문에 이를 따로 저장하는 로직이 불필요하다고 느껴져서 리팩토링하였습니다!

### 🤔 그렇다면, 어떻게 구현했어요~?
<!-- 실제로 구현한 로직에 대해 설명해주세요.-->
- mainCategoryId관련된 내용을 모두 걷어냈습니다. 
- mainCategoryId를 저장하던 곳은 모두 categoryId를 저장하는 로직으로 변경, mainCategoryId를 참조하던 곳은 모두 categoryId를 기반으로 부모 카테고리 id값을 찾는 로직으로 변경했어요. 

### ❤️‍🔥 당신이 생각하는 PR포인트, 내겐 매력포인트.
<!-- 해당 PR에서 논의가 필요한 사항을 적어주세요. -->
- mainCategoryId를 걷어내면서 발생될 이슈가 없을지, 여러번 확인했을 때 이슈는 없었고 원하는대로 잘 동작합니다! 하지만 혹시 모르니, 한 번씩 확인해주시면 좋을 것 같아요~!

### 📸 스크린샷, 없으면 이것 참,, 섭섭한데요?
