### PR TITLE
fix: 최근 끝말잇기 limit 조정

### DIFF
--- a/src/api/endpoint/wordchain/getWordchain.ts
+++ b/src/api/endpoint/wordchain/getWordchain.ts
@@ -101,7 +101,7 @@ const useGetRecentWordchain: UseGetRecentWordchain = <TData>(
 
     queryFn: async () => {
       const data = await getWordchain.request({
-        limit: 0,
+        limit: 1,
         cursor: 0,
       });
       return data;


### PR DESCRIPTION
### 🤫 쉿, 나한테만 말해줘요. 이슈넘버
- close #1302

### 🧐 어떤 것을 변경했어요~?
<!-- 실제로 변경한 사항을 설명해주세요.-->         
- 끝말잇기 가장 최근 데이터가 불러와지지 않는 이슈가 있었어요. 
- limit이 0으로 설정되어서 0개의 데이터가 왔고, 이에, limit을 1로 수정해주었습니다.                                  

### 🤔 그렇다면, 어떻게 구현했어요~?
<!-- 실제로 구현한 로직에 대해 설명해주세요.-->

<img width="348" alt="스크린샷 2024-03-03 오후 8 25 18" src="https://github.com/sopt-makers/sopt-playground-frontend/assets/76681519/e2270e29-30bd-40a6-8046-b909dedc1423">


### ❤️‍🔥 당신이 생각하는 PR포인트, 내겐 매력포인트.
<!-- 해당 PR에서 논의가 필요한 사항을 적어주세요. -->

### 📸 스크린샷, 없으면 이것 참,, 섭섭한데요?
