### PR TITLE
feat: 활동 정보 확인 페이지 구현 (1)

### DIFF
--- a/src/api/endpoint_LEGACY/members/type.ts
+++ b/src/api/endpoint_LEGACY/members/type.ts
@@ -55,17 +55,7 @@ export type ProfileDetail = {
   };
   idealType: string;
   selfIntroduction: string;
-  soptActivities: {
-    generation: number;
-    part: string;
-    team: string | null;
-    projects: {
-      id: number;
-      generation: number;
-      name: string;
-      category: ProjectCategory;
-    }[];
-  }[];
+  soptActivities: SoptActivity[];
   links: MemberLink[];
   projects: MemberProject[];
   careers: Career[];
@@ -73,12 +63,16 @@ export type ProfileDetail = {
   isMine: boolean;
 };
 
-export type Activity = {
-  id: number;
+export type SoptActivity = {
   generation: number;
-  team: string;
   part: string;
-  isProject: boolean;
+  team: string | null;
+  projects: {
+    id: number;
+    generation: number;
+    name: string;
+    category: ProjectCategory;
+  }[];
 };
 
 export type MemberLink = {

--- a/src/components/members/CheckSoptActivity.tsx
+++ b/src/components/members/CheckSoptActivity.tsx
@@ -1,0 +1,66 @@
+import React, { useEffect, useState } from 'react';
+import { FormProvider, useForm } from 'react-hook-form';
+
+import { useGetMemberOfMe } from '@/api/endpoint/members/getMemberOfMe';
+import { useGetMemberProfileById } from '@/api/endpoint_LEGACY/hooks';
+import Loading from '@/components/common/Loading';
+import SoptActivitySection from '@/components/members/detail/SoptActivitySection';
+import { UNSELECTED } from '@/components/members/upload/constants';
+import MemberSoptActivityFormSection from '@/components/members/upload/FormSection/SoptActivity';
+import { SoptActivity } from '@/components/members/upload/types';
+
+export default function CheckSoptActivity() {
+  const [isEditMode, setIsEditMode] = useState(false);
+  const { data: me } = useGetMemberOfMe();
+  const { data: profile, isLoading } = useGetMemberProfileById(me?.id);
+
+  const sortedSoptActivities = (() => {
+    if (!profile?.soptActivities) {
+      return [];
+    }
+    const sorted = [...profile.soptActivities];
+    sorted.sort((a, b) => b.generation - a.generation);
+    return sorted;
+  })();
+
+  const formMethods = useForm<{ activities: SoptActivity[] }>({
+    mode: 'onChange',
+  });
+
+  useEffect(() => {
+    if (profile) {
+      formMethods.reset({
+        activities: profile.soptActivities
+          .sort((a, b) => a.generation - b.generation)
+          .map(({ generation, team, part }) => ({
+            generation: `${generation}기`,
+            part,
+            team: team ?? UNSELECTED,
+          })),
+      });
+    }
+  }, [profile, formMethods]);
+
+  if (isLoading) {
+    return <Loading />;
+  }
+
+  return (
+    <FormProvider {...formMethods}>
+      {isEditMode ? (
+        <MemberSoptActivityFormSection isEditable />
+      ) : (
+        <SoptActivitySection soptActivities={sortedSoptActivities} />
+      )}
+      {isEditMode ? (
+        // FIXME: 개발 중 수정 모드 전환을 위한 임시 핸들러
+        <button onClick={() => setIsEditMode(false)}>수정 완료</button>
+      ) : (
+        <div>
+          <button onClick={() => setIsEditMode(true)}>활동 정보 수정하기</button>
+          <button>이대로 등록하기</button>
+        </div>
+      )}
+    </FormProvider>
+  );
+}

--- a/src/components/members/CheckSoptActivity.tsx
+++ b/src/components/members/CheckSoptActivity.tsx
@@ -48,18 +48,19 @@ export default function CheckSoptActivity() {
   return (
     <FormProvider {...formMethods}>
       {isEditMode ? (
-        <MemberSoptActivityFormSection isEditable />
+        <>
+          <MemberSoptActivityFormSection isEditable />
+          {/* FIXME: 개발 중 수정 모드 전환을 위한 임시 핸들러 */}
+          <button onClick={() => setIsEditMode(false)}>수정 완료</button>
+        </>
       ) : (
-        <SoptActivitySection soptActivities={sortedSoptActivities} />
-      )}
-      {isEditMode ? (
-        // FIXME: 개발 중 수정 모드 전환을 위한 임시 핸들러
-        <button onClick={() => setIsEditMode(false)}>수정 완료</button>
-      ) : (
-        <div>
-          <button onClick={() => setIsEditMode(true)}>활동 정보 수정하기</button>
-          <button>이대로 등록하기</button>
-        </div>
+        <>
+          <SoptActivitySection soptActivities={sortedSoptActivities} />
+          <div>
+            <button onClick={() => setIsEditMode(true)}>활동 정보 수정하기</button>
+            <button>이대로 등록하기</button>
+          </div>
+        </>
       )}
     </FormProvider>
   );

--- a/src/components/members/detail/MemberDetail.tsx
+++ b/src/components/members/detail/MemberDetail.tsx
@@ -12,7 +12,6 @@ import { FC, useMemo } from 'react';
 
 import { useGetMemberOfMe } from '@/api/endpoint/members/getMemberOfMe';
 import { useGetMemberProfileById } from '@/api/endpoint_LEGACY/hooks';
-import { isProjectCategory } from '@/api/endpoint_LEGACY/projects/type';
 import Loading from '@/components/common/Loading';
 import Text from '@/components/common/Text';
 import useEventLogger from '@/components/eventLogger/hooks/useEventLogger';
@@ -23,9 +22,8 @@ import InterestSection from '@/components/members/detail/InterestSection';
 import MemberDetailSection from '@/components/members/detail/MemberDetailSection';
 import MemberProjectCard from '@/components/members/detail/MemberProjectCard';
 import MessageSection from '@/components/members/detail/MessageSection';
-import PartItem from '@/components/members/detail/PartItem';
+import SoptActivitySection from '@/components/members/detail/SoptActivitySection';
 import { DEFAULT_DATE } from '@/components/members/upload/constants';
-import { Category } from '@/components/projects/types';
 import { playgroundLink } from '@/constants/links';
 import { useRunOnce } from '@/hooks/useRunOnce';
 import { MOBILE_MEDIA_QUERY } from '@/styles/mediaQuery';
@@ -161,21 +159,7 @@ const MemberDetail: FC<MemberDetailProps> = ({ memberId }) => {
           </MemberDetailSection>
         )}
 
-        <MemberDetailSection style={{ gap: '34px' }}>
-          {sortedSoptActivities.map(({ generation, part, projects, team }, idx) => (
-            <PartItem
-              key={idx}
-              generation={`${generation}`}
-              part={part}
-              activities={projects.map((project) => ({
-                name: project.name,
-                type: convertProjectType(project.category) ?? '',
-                href: playgroundLink.projectDetail(project.id),
-              }))}
-              teams={team !== null ? [team] : []}
-            />
-          ))}
-        </MemberDetailSection>
+        <SoptActivitySection soptActivities={sortedSoptActivities} />
 
         {(profile.sojuCapacity ||
           profile.mbti ||
@@ -257,28 +241,6 @@ const MemberDetail: FC<MemberDetailProps> = ({ memberId }) => {
     </Container>
   );
 };
-
-function convertProjectType(typeCode: Category) {
-  if (!isProjectCategory(typeCode)) throw new Error('project category type error');
-
-  switch (typeCode) {
-    case 'APPJAM':
-      return '앱잼';
-    case 'ETC':
-      return '사이드 프로젝트';
-    case 'JOINTSEMINAR':
-      return '합동 세미나';
-    case 'SOPKATHON':
-      return '솝커톤';
-    case 'SOPTERM':
-      return '솝텀 프로젝트';
-    case 'STUDY':
-      return '스터디';
-    default:
-      const exhaustiveCheck: never = typeCode;
-      throw new Error(`project category ${exhaustiveCheck} type error`);
-  }
-}
 
 const Container = styled.div`
   display: flex;

--- a/src/components/members/detail/SoptActivitySection/index.stories.tsx
+++ b/src/components/members/detail/SoptActivitySection/index.stories.tsx
@@ -1,0 +1,27 @@
+import { Meta } from '@storybook/react';
+
+import SoptActivitySection from '@/components/members/detail/SoptActivitySection';
+
+const meta = {
+  component: SoptActivitySection,
+} satisfies Meta<typeof SoptActivitySection>;
+export default meta;
+
+export const Default = () => {
+  return (
+    <SoptActivitySection
+      soptActivities={[
+        {
+          generation: 29,
+          part: '웹',
+          team: null,
+          projects: [
+            { id: 0, generation: 29, name: '너가소개서', category: 'APPJAM' },
+            { id: 1, generation: 29, name: '산넘어산', category: 'SOPTERM' },
+          ],
+        },
+        { generation: 30, part: '기획', team: '운영팀', projects: [] },
+      ]}
+    />
+  );
+};

--- a/src/components/members/detail/SoptActivitySection/index.tsx
+++ b/src/components/members/detail/SoptActivitySection/index.tsx
@@ -1,0 +1,53 @@
+import { playgroundLink } from 'playground-common/export';
+
+import { SoptActivity } from '@/api/endpoint_LEGACY/members/type';
+import { isProjectCategory } from '@/api/endpoint_LEGACY/projects/type';
+import MemberDetailSection from '@/components/members/detail/MemberDetailSection';
+import PartItem from '@/components/members/detail/PartItem';
+import { Category } from '@/components/projects/types';
+
+interface SoptActivitySectionProps {
+  soptActivities: SoptActivity[];
+}
+
+export default function SoptActivitySection({ soptActivities }: SoptActivitySectionProps) {
+  return (
+    <MemberDetailSection style={{ gap: '34px' }}>
+      {soptActivities.map(({ generation, part, projects, team }, idx) => (
+        <PartItem
+          key={idx}
+          generation={`${generation}`}
+          part={part}
+          activities={projects.map((project) => ({
+            name: project.name,
+            type: convertProjectType(project.category) ?? '',
+            href: playgroundLink.projectDetail(project.id),
+          }))}
+          teams={team !== null ? [team] : []}
+        />
+      ))}
+    </MemberDetailSection>
+  );
+}
+
+function convertProjectType(typeCode: Category) {
+  if (!isProjectCategory(typeCode)) throw new Error('project category type error');
+
+  switch (typeCode) {
+    case 'APPJAM':
+      return '앱잼';
+    case 'ETC':
+      return '사이드 프로젝트';
+    case 'JOINTSEMINAR':
+      return '합동 세미나';
+    case 'SOPKATHON':
+      return '솝커톤';
+    case 'SOPTERM':
+      return '솝텀 프로젝트';
+    case 'STUDY':
+      return '스터디';
+    default:
+      const exhaustiveCheck: never = typeCode;
+      throw new Error(`project category ${exhaustiveCheck} type error`);
+  }
+}

--- a/src/components/members/upload/FormSection/SoptActivity.tsx
+++ b/src/components/members/upload/FormSection/SoptActivity.tsx
@@ -11,15 +11,15 @@ import FormHeader from '@/components/members/upload/forms/FormHeader';
 import { MemberFormSection as FormSection } from '@/components/members/upload/forms/FormSection';
 import SelectOptions from '@/components/members/upload/forms/SelectOptions';
 import { MemberUploadForm } from '@/components/members/upload/types';
-import { GENERATIONS } from '@/constants/generation';
+import { GENERATIONS, LATEST_GENERATION } from '@/constants/generation';
 import { MOBILE_MEDIA_QUERY } from '@/styles/mediaQuery';
 import { textStyles } from '@/styles/typography';
 
-const FILTERED_GENERATIONS = GENERATIONS.filter((generation) => parseInt(generation) <= 30).map(
-  (generation) => generation + '기',
-);
+interface MemberSoptActivityFormSectionProps {
+  isEditable?: boolean;
+}
 
-export default function MemberSoptActivityFormSection() {
+export default function MemberSoptActivityFormSection({ isEditable }: MemberSoptActivityFormSectionProps) {
   const {
     control,
     register,
@@ -49,10 +49,10 @@ export default function MemberSoptActivityFormSection() {
 
   return (
     <StyledFormSection>
-      <FormHeader title='SOPT 활동 정보' required description='31기 이후의 기수와 파트 정보는 수정이 불가능해요.' />
+      <FormHeader title='SOPT 활동 정보' required />
       <StyledAddableWrapper onAppend={onAppend}>
         {fields.map((field, index) =>
-          parseInt(field.generation) <= 30 || !field.generation ? (
+          isEditable ? (
             <AddableItem
               onRemove={() => onRemove(index)}
               key={field.id}
@@ -114,6 +114,10 @@ export default function MemberSoptActivityFormSection() {
     </StyledFormSection>
   );
 }
+
+const FILTERED_GENERATIONS = GENERATIONS.filter((generation) => parseInt(generation) <= LATEST_GENERATION - 1).map(
+  (generation) => generation + '기',
+);
 
 const StyledFormSection = styled(FormSection)`
   @media ${MOBILE_MEDIA_QUERY} {

--- a/src/constants/links.ts
+++ b/src/constants/links.ts
@@ -12,6 +12,7 @@ export const playgroundLink = {
   memberDetail: (id: string | number) => `/members/${id}`,
   memberUpload: () => `/members/upload`,
   memberEdit: () => '/members/edit',
+  memberCheckSoptActivity: () => '/members/checkSoptActivity',
   projectList: () => `/projects`,
   projectDetail: (id: string | number) => `/projects/${id}`,
   projectUpload: () => `/projects/upload`,

--- a/src/pages/auth/callback/apple/register.tsx
+++ b/src/pages/auth/callback/apple/register.tsx
@@ -69,7 +69,7 @@ const AppleRegisterCallbackPage: FC = () => {
   const handleSuccess = () => {
     setLastLoginMethod('apple');
     if (registerToken?.type === 'register') {
-      router.replace(playgroundLink.memberUpload());
+      router.replace(playgroundLink.memberCheckSoptActivity());
     } else if (registerToken?.type === 'reset') {
       router.replace('/');
     }

--- a/src/pages/auth/callback/google/register.tsx
+++ b/src/pages/auth/callback/google/register.tsx
@@ -69,7 +69,7 @@ const GoogleRegisterCallbackPage: FC = () => {
   const handleSuccess = () => {
     setLastLoginMethod('google');
     if (registerToken?.type === 'register') {
-      router.replace(playgroundLink.memberUpload());
+      router.replace(playgroundLink.memberCheckSoptActivity());
     } else if (registerToken?.type === 'reset') {
       router.replace('/');
     }

--- a/src/pages/members/checkSoptActivity.tsx
+++ b/src/pages/members/checkSoptActivity.tsx
@@ -1,0 +1,13 @@
+import CheckSoptActivity from '@/components/members/CheckSoptActivity';
+
+export default function CheckSoptActivityPage() {
+  return (
+    <div>
+      <h1>활동 정보 확인</h1>
+      <div>
+        등록된 활동 정보가 정확한지 확인하고, 이외 활동 정보나 운팀/미팀 활동 내역이 있다면 추가로 등록해주세요.
+      </div>
+      <CheckSoptActivity />
+    </div>
+  );
+}


### PR DESCRIPTION
### 🤫 쉿, 나한테만 말해줘요. 이슈넘버
- #1263

### 🧐 어떤 것을 변경했어요~?
<!-- 실제로 변경한 사항을 설명해주세요.-->

[기능 배경 및 요구 사항 정리한 문서](https://www.notion.so/sopt-makers/839cc91ec6044952a367cbb46afe9220?pvs=4) 

미완이어서 베이스 브랜치 만들어서 거기 타겟으로 올려놨구요
submit 로직, 스타일링, 이대로 수정 누를 시 로직(컨펌 모달 띄우고 프로필 업로드 페이지로 라우팅), 폼 validation 미완입니다!

### 🤔 그렇다면, 어떻게 구현했어요~?
<!-- 실제로 구현한 로직에 대해 설명해주세요.-->


### ❤️‍🔥 당신이 생각하는 PR포인트, 내겐 매력포인트.
<!-- 해당 PR에서 논의가 필요한 사항을 적어주세요. -->

### 📸 스크린샷, 없으면 이것 참,, 섭섭한데요?


https://github.com/sopt-makers/sopt-playground-frontend/assets/73823388/b1a1b757-f885-479d-aba8-b16bc29770fc

