### PR TITLE
feat: 프로필 내 모임 기능 구현 완료

### DIFF
--- a/src/api/endpoint/members/getMemberCrew.ts
+++ b/src/api/endpoint/members/getMemberCrew.ts
@@ -38,12 +38,12 @@ export const getMemberCrew = createEndpoint({
   }),
 });
 
-export const useGetMemberCrewInfiniteQuery = (id?: number) => {
+export const useGetMemberCrewInfiniteQuery = (limit: number, id?: number) => {
   if (typeof id === 'undefined') throw new Error('Invalid id');
   return useInfiniteQuery({
     queryKey: useGetMemberCrewInfiniteQuery.getKey(id),
     queryFn: async ({ pageParam }) => {
-      return await getMemberCrew.request({ id: id, params: { page: pageParam, take: 20 } });
+      return await getMemberCrew.request({ id: id, params: { page: pageParam, take: limit } });
     },
     initialPageParam: 1,
     getNextPageParam: (lastPage) => {

--- a/src/api/endpoint/members/getMemberCrew.ts
+++ b/src/api/endpoint/members/getMemberCrew.ts
@@ -43,7 +43,7 @@ export const useGetMemberCrewInfiniteQuery = (id?: number) => {
   return useInfiniteQuery({
     queryKey: useGetMemberCrewInfiniteQuery.getKey(id),
     queryFn: async ({ pageParam }) => {
-      return await getMemberCrew.request({ id: id, params: { page: pageParam, take: 3 } });
+      return await getMemberCrew.request({ id: id, params: { page: pageParam, take: 20 } });
     },
     initialPageParam: 1,
     getNextPageParam: (lastPage) => {

--- a/src/api/endpoint_LEGACY/hooks/members.ts
+++ b/src/api/endpoint_LEGACY/hooks/members.ts
@@ -2,11 +2,7 @@ import { useMutation, useQuery, UseQueryOptions } from '@tanstack/react-query';
 import { AxiosError } from 'axios';
 
 import { getMembersSearchByName } from '@/api/endpoint/members/getMembersSearchByName';
-import {
-  getMemberProfileById,
-  getMemberProfileOfMe,
-  postMemberMessage as postMemberMessage,
-} from '@/api/endpoint_LEGACY/members';
+import { getMemberProfileById, getMemberProfileOfMe, postMemberMessage } from '@/api/endpoint_LEGACY/members';
 import { PostMemberMessageVariables, ProfileDetail } from '@/api/endpoint_LEGACY/members/type';
 
 // 멤버 프로필 조회

--- a/src/components/members/detail/ActivitySection/MemberDetail.tsx
+++ b/src/components/members/detail/ActivitySection/MemberDetail.tsx
@@ -54,8 +54,16 @@ const MemberDetail: FC<MemberDetailProps> = ({ memberId }) => {
   const { logClickEvent, logPageViewEvent } = useEventLogger();
   const router = useRouter();
   const { ref, isVisible } = useIntersectionObserver();
-  const { data: profile, isLoading, error } = useGetMemberProfileById(safeParseInt(memberId) ?? undefined);
-  const { data: memberCrewData, fetchNextPage } = useGetMemberCrewInfiniteQuery(safeParseInt(memberId) ?? undefined);
+  const {
+    data: profile,
+    isLoading,
+    error: profileError,
+  } = useGetMemberProfileById(safeParseInt(memberId) ?? undefined);
+  const {
+    data: memberCrewData,
+    fetchNextPage,
+    error: crewError,
+  } = useGetMemberCrewInfiniteQuery(safeParseInt(memberId) ?? undefined);
   const { data: me } = useGetMemberOfMe();
   const meetingList = memberCrewData?.pages.map((page) => page.meetings).flat() ?? [];
 
@@ -83,7 +91,7 @@ const MemberDetail: FC<MemberDetailProps> = ({ memberId }) => {
     }
   }, [isVisible, fetchNextPage]);
 
-  if (error?.response?.status === 400) {
+  if (profileError?.response?.status === 400 || crewError?.response?.status === 400) {
     return <EmptyProfile />;
   }
 

--- a/src/components/members/detail/ActivitySection/MemberDetail.tsx
+++ b/src/components/members/detail/ActivitySection/MemberDetail.tsx
@@ -36,74 +36,6 @@ import { MOBILE_MEDIA_QUERY } from '@/styles/mediaQuery';
 import { textStyles } from '@/styles/typography';
 import { safeParseInt } from '@/utils';
 
-const DUMMY = {
-  meetings: [
-    {
-      id: 91,
-      isMeetingLeader: false,
-      title: '네네네네네네네네네네네네네네네네네네네네ㅔ네네네네네네네네네',
-      imageUrl:
-        'https://makers-web-img.s3.ap-northeast-2.amazonaws.com/meeting/2023/12/09/127b44eb-cc90-4b3a-a01c-6d202b781d58.jpeg',
-      category: '스터디',
-      isActiveMeeting: false,
-      mstartDate: '2023-04-11T00:00:00',
-      mendDate: '2023-05-27T00:00:00',
-    },
-    {
-      id: 90,
-      isMeetingLeader: false,
-      title: '\b커피 한잔 할래요 ?',
-      imageUrl:
-        'https://makers-web-img.s3.ap-northeast-2.amazonaws.com/meeting/2023/10/17/9c185091-7575-48e2-95f2-67f06aea0335.jpeg',
-      category: '스터디',
-      isActiveMeeting: true,
-      mstartDate: '2023-12-10T00:00:00',
-      mendDate: '2024-05-10T00:00:00',
-    },
-    {
-      id: 85,
-      isMeetingLeader: false,
-      title: '주술사되는법',
-      imageUrl:
-        'https://makers-web-img.s3.ap-northeast-2.amazonaws.com/meeting/2023/10/01/21c6ea54-8965-4ed7-a691-bb0a1e11382c.png',
-      category: '스터디',
-      isActiveMeeting: true,
-      mstartDate: '2023-10-04T00:00:00',
-      mendDate: '2024-10-04T00:00:00',
-    },
-    {
-      id: 83,
-      isMeetingLeader: false,
-      title: 'QA 모임',
-      imageUrl:
-        'https://makers-web-img.s3.ap-northeast-2.amazonaws.com/meeting/2023/09/28/e604fd62-6b6f-4f48-a5fa-85a1806126c0.png',
-      category: '스터디',
-      isActiveMeeting: false,
-      mstartDate: '2023-01-09T00:00:00',
-      mendDate: '2024-01-01T00:00:00',
-    },
-    {
-      id: 82,
-      isMeetingLeader: true,
-      title: '고기 좋아요',
-      imageUrl:
-        'https://makers-web-img.s3.ap-northeast-2.amazonaws.com/meeting/2023/09/28/270911ef-e176-4323-b713-b0352a8363a7.jpeg',
-      category: '스터디',
-      isActiveMeeting: false,
-      mstartDate: '2100-01-01T00:00:00',
-      mendDate: '2100-01-02T00:00:00',
-    },
-  ],
-  meta: {
-    page: 1,
-    take: 6,
-    itemCount: 22,
-    pageCount: 4,
-    hasPreviousPage: false,
-    hasNextPage: true,
-  },
-};
-
 interface MemberDetailProps {
   memberId: string;
 }
@@ -125,6 +57,7 @@ const MemberDetail: FC<MemberDetailProps> = ({ memberId }) => {
   const { data: profile, isLoading, error } = useGetMemberProfileById(safeParseInt(memberId) ?? undefined);
   const { data: memberCrewData, fetchNextPage } = useGetMemberCrewInfiniteQuery(safeParseInt(memberId) ?? undefined);
   const { data: me } = useGetMemberOfMe();
+  const meetingList = memberCrewData?.pages.map((page) => page.meetings).flat() ?? [];
 
   const sortedSoptActivities = useMemo(() => {
     if (!profile?.soptActivities) {
@@ -335,11 +268,11 @@ const MemberDetail: FC<MemberDetailProps> = ({ memberId }) => {
         </ActivityContainer>
         <ActivityContainer>
           <ActivityTitle>{profile.name}님이 참여한 모임</ActivityTitle>
-          {DUMMY.meetings.length > 0 && (
+          {meetingList.length > 0 && (
             <>
-              <ActivitySub>{DUMMY.meetings.length}개의 모임에 참여</ActivitySub>
+              <ActivitySub>{meetingList.length}개의 모임에 참여</ActivitySub>
               <ActivityDisplay>
-                {DUMMY.meetings.map((meeting) => (
+                {meetingList.map((meeting) => (
                   <MemberMeetingCard
                     key={meeting.id}
                     {...meeting}
@@ -349,7 +282,7 @@ const MemberDetail: FC<MemberDetailProps> = ({ memberId }) => {
               </ActivityDisplay>
             </>
           )}
-          {DUMMY.meetings.length === 0 && (
+          {meetingList.length === 0 && (
             <>
               <ActivitySub>아직 참여한 모임이 없어요</ActivitySub>
               {String(me?.id) === memberId && (
@@ -364,6 +297,7 @@ const MemberDetail: FC<MemberDetailProps> = ({ memberId }) => {
               )}
             </>
           )}
+          <Target ref={ref} />
         </ActivityContainer>
       </Wrapper>
     </Container>
@@ -671,6 +605,10 @@ const ActivityUploadButton = styled(Link)`
     margin-top: 50px;
     width: 100%;
   }
+`;
+
+const Target = styled.div`
+  width: 100%;
 `;
 
 export default MemberDetail;

--- a/src/components/members/detail/ActivitySection/MemberDetail.tsx
+++ b/src/components/members/detail/ActivitySection/MemberDetail.tsx
@@ -1,5 +1,6 @@
 import styled from '@emotion/styled';
 import { colors } from '@sopt-makers/colors';
+import axios from 'axios';
 import dayjs from 'dayjs';
 import { uniq } from 'lodash-es';
 import Link from 'next/link';
@@ -91,7 +92,7 @@ const MemberDetail: FC<MemberDetailProps> = ({ memberId }) => {
     }
   }, [profile, memberId]);
 
-  if (profileError?.response?.status === 400 || crewError?.response?.status === 400) {
+  if (profileError?.response?.status === 400 || (axios.isAxiosError(crewError) && crewError.response?.status === 400)) {
     return <EmptyProfile />;
   }
 

--- a/src/components/members/detail/ActivitySection/MemberDetail.tsx
+++ b/src/components/members/detail/ActivitySection/MemberDetail.tsx
@@ -8,7 +8,7 @@ import CallIcon from 'public/icons/icon-call.svg';
 import EditIcon from 'public/icons/icon-edit.svg';
 import MailIcon from 'public/icons/icon-mail.svg';
 import ProfileIcon from 'public/icons/icon-profile.svg';
-import { FC, useEffect, useMemo } from 'react';
+import { FC, useMemo } from 'react';
 
 import { useGetMemberCrewInfiniteQuery } from '@/api/endpoint/members/getMemberCrew';
 import { useGetMemberOfMe } from '@/api/endpoint/members/getMemberOfMe';
@@ -30,7 +30,7 @@ import PartItem from '@/components/members/detail/PartItem';
 import { DEFAULT_DATE } from '@/components/members/upload/constants';
 import { Category } from '@/components/projects/types';
 import { playgroundLink } from '@/constants/links';
-import useIntersectionObserver from '@/hooks/useIntersectionObserver';
+import useEnterScreen from '@/hooks/useEnterScreen';
 import { useRunOnce } from '@/hooks/useRunOnce';
 import { MOBILE_MEDIA_QUERY } from '@/styles/mediaQuery';
 import { textStyles } from '@/styles/typography';
@@ -53,7 +53,13 @@ const convertBirthdayFormat = (birthday?: string) => {
 const MemberDetail: FC<MemberDetailProps> = ({ memberId }) => {
   const { logClickEvent, logPageViewEvent } = useEventLogger();
   const router = useRouter();
-  const { ref, isVisible } = useIntersectionObserver();
+
+  const { ref } = useEnterScreen({
+    onEnter: () => {
+      fetchNextPage();
+    },
+  });
+
   const {
     data: profile,
     isLoading,
@@ -84,12 +90,6 @@ const MemberDetail: FC<MemberDetailProps> = ({ memberId }) => {
       });
     }
   }, [profile, memberId]);
-
-  useEffect(() => {
-    if (isVisible) {
-      fetchNextPage();
-    }
-  }, [isVisible, fetchNextPage]);
 
   if (profileError?.response?.status === 400 || crewError?.response?.status === 400) {
     return <EmptyProfile />;

--- a/src/components/members/detail/ActivitySection/MemberDetail.tsx
+++ b/src/components/members/detail/ActivitySection/MemberDetail.tsx
@@ -63,7 +63,7 @@ const MemberDetail: FC<MemberDetailProps> = ({ memberId }) => {
     data: memberCrewData,
     fetchNextPage,
     error: crewError,
-  } = useGetMemberCrewInfiniteQuery(safeParseInt(memberId) ?? undefined);
+  } = useGetMemberCrewInfiniteQuery(20, safeParseInt(memberId) ?? undefined);
   const { data: me } = useGetMemberOfMe();
   const meetingList = memberCrewData?.pages.map((page) => page.meetings).flat() ?? [];
 

--- a/src/components/members/detail/ActivitySection/MemberMeetingCard.tsx
+++ b/src/components/members/detail/ActivitySection/MemberMeetingCard.tsx
@@ -11,12 +11,12 @@ import { dateIntoPeriod } from '@/utils/parseDate';
 interface MemberMeetingCardProps {
   id: number;
   title: string;
-  category: string;
+  category: string | null;
   isMeetingLeader: boolean;
   isActiveMeeting: boolean;
   mstartDate: string;
   mendDate: string;
-  imageUrl: string;
+  imageUrl: string | null;
   userName?: string;
 }
 

--- a/src/components/members/detail/ActivitySection/MemberMeetingCard.tsx
+++ b/src/components/members/detail/ActivitySection/MemberMeetingCard.tsx
@@ -16,7 +16,7 @@ interface MemberMeetingCardProps {
   isActiveMeeting: boolean;
   mstartDate: string;
   mendDate: string;
-  imageUrl: string | null;
+  imageUrl: string;
   userName?: string;
 }
 

--- a/src/components/members/detail/ActivitySection/MemberMeetingCard.tsx
+++ b/src/components/members/detail/ActivitySection/MemberMeetingCard.tsx
@@ -16,7 +16,7 @@ interface MemberMeetingCardProps {
   isActiveMeeting: boolean;
   mstartDate: string;
   mendDate: string;
-  imageUrl: string;
+  imageUrl: string | null;
   userName?: string;
 }
 
@@ -52,7 +52,7 @@ const MemberMeetingCard: FC<MemberMeetingCardProps> = ({
 
   return (
     <Link href={playgroundLink.groupDetail(id)}>
-      <ContentsCard thumbnail={imageUrl} title={title} top={meetingCategory} bottom={meetingDate} />
+      <ContentsCard thumbnail={imageUrl ? imageUrl : ''} title={title} top={meetingCategory} bottom={meetingDate} />
     </Link>
   );
 };


### PR DESCRIPTION
### 🤫 쉿, 나한테만 말해줘요. 이슈넘버
- close #1317

제 PR은 왜이렇게 길어지는 것일까여,, 죄송합니다흑 모르는게 많아 궁금한 것에 대한 주저리들이니 일단 돌아가는 것 먼저 확인해주시면 되겠습니다...!!!

### 🧐 어떤 것을 변경했어요~?
<!-- 실제로 변경한 사항을 설명해주세요.-->
- 나눠서 구현한 API와 UI 부를 합쳐 완전한 기능으로 마무리했습니다.
- 존재하지 않는 유저 id에 대해 요청시 서버에서 에러코드 400을 추가해줘서 이에 대한 에러처리를 추가했습니다.
- 무한스크롤에 사용한 `useIntersectionObserver` 훅을 `useEnterScreen` 훅으로 대체했습니다.

### 🤔 그렇다면, 어떻게 구현했어요~?
<!-- 실제로 구현한 로직에 대해 설명해주세요.-->
지난 리뷰에서 지수언니가 `useIntersectionObserver`를 이용한 무한스크롤 구현을 위해 `useEffect`를 쓴 이유에 대해 질문해줘서 많이 고민해봤는데...
일단 `useIntersectionObserver` (커스텀훅) 은 `IntersectionObserver`라는 Web API를 이용한 훅이고, 관찰할 노드에 대한 `ref`와 뷰포트에 들어왔는지 여부를 반환하는 boolean값인 `isVisible`을 return하고 있습니다. 따라서 이 훅을 사용할 때 isVisible값의 변화에 따라 무한스크롤에서 다음 값을 불러올지 여부를 판단해야 했는데요. 즉 특정 요소가 화면에 들어왔는지 아닌지에 대해 브라우저라는 외부세계와 통신하며 값을 동기화해주는 것이 필요하기 때문에 useEffect가 필요하다는 판단을 내리게 되었습니다.
그러나 이게 이미 만들어져있던 커스텀훅이기 때문에 .. 이미 내려진 정답에 이유를 끼워맞추는 느낌이 들어서 좀 찜찜했는데요ㅜㅜ

히스토리를 좀 더 찾아보니 이런 [코멘트](https://github.com/sopt-makers/sopt-playground-frontend/pull/307#discussion_r1058706239)를 발견하였습니다. `useIntersectionObserver`와 비슷한 목적으로 구현된 `useEnterScreen`훅이 존재했고, 이 훅은 현재 `ResizedImage`에서만 쓰이고 있는 것 같습니다.
두가지 훅을 비교해보니 똑같이 특정 요소가 화면에 들어옴을 감지하기 위해 사용되는 훅이지만, `useEnterScreen`의 경우 타겟 요소가 화면에 들어올 경우 인자로 넣은 callback함수를 실행시키는 형태였고(`useIntersectionObserver`와 다르게 현재 visible한지에 따른 처리를 내부로 은닉) 따라서 사용시 useEffect를 사용할 필요가 없어졌습니다.

앞서 참조한 [코멘트](https://github.com/sopt-makers/sopt-playground-frontend/pull/307#discussion_r1058706239)에서도 `useEnterScreen`을 사용한다고 얘기가 되었다가 이유모를 에러로 `useIntersectionObserver`를 쓴 코드를 그대로 남겨둔 것 같습니다만 제가 사용했을 땐 `useEnterScreen`에서 에러가 나지 않습니다..!!!

### ❤️‍🔥 당신이 생각하는 PR포인트, 내겐 매력포인트.
<!-- 해당 PR에서 논의가 필요한 사항을 적어주세요. -->
- [쓰레드](https://sopt-makers.slack.com/archives/C042T81PW80/p1709996556618759)에서 한번 얘기했었는데 무한스크롤에서 한번에 노출하는 모임 갯수를 20개로 지정했습니다! 적절한 것 같다는 생각입니다!

### 도움필요 🥵
- 멤버 프로필 페이지인 `MemberDetail.ts`에서 기존에 받아오던 멤버 프로필 데이터와 이번에 추가된 멤버의 모임 데이터를 각각 다른 api에서 따로 받아오고 있는데요, 따라서 api 에러처리도 따로 하게 되었는데..
이를 위해 각 query에 대한 error 반환값을 다르게 이름붙여주었습니다.
```ts
  const {
    data: profile,
    isLoading,
    error: profileError, //프로필 정보 api 에러
  } = useGetMemberProfileById(safeParseInt(memberId) ?? undefined);
  const {
    data: memberCrewData,
    fetchNextPage,
    error: crewError, //모임 정보 api 에러
  } = useGetMemberCrewInfiniteQuery(20, safeParseInt(memberId) ?? undefined);
```

그리고 나서 이렇게 에러처리중인데..!
```ts
  if (profileError?.response?.status === 400 || crewError?.response?.status === 400) {
    return <EmptyProfile />;
  }
```
crewError의 경우 AxiosError가 아니라 그냥 Error 객체여서 `'Error' 형식에 'response' 속성이 없습니다.`라는 ts에러가 뜨는 중입니다ㅠ___ㅠ **이거때문에 지금 빌드가 안되네요....🚨**
profileError의 경우 `useGetMemberProfileById` 내에서 다음과같이 AxiosError로 내보내고 있어서 참고해보려고 했는데... 흐아 이해가 어려워서 이부분 처리를 아직 못했습니다 ㅠㅠ  어떻게하면 `useGetMemberCrewInfiniteQuery`에서도 error를 AxiosError 형태로 내보낼 수 있을까요...?
```ts
export const useGetMemberProfileById = (
  id: number | undefined,
  options?: Omit<
    UseQueryOptions<unknown, AxiosError, ProfileDetail, (string | number | undefined)[]>,
    'queryKey' | 'queryFn'
  >,
) => {
```


### 📸 스크린샷, 없으면 이것 참,, 섭섭한데요?

https://github.com/sopt-makers/sopt-playground-frontend/assets/55528304/2fb1795c-a092-40c2-890d-2d90ec24f15e



