### PR TITLE
feat: 프로필 등록 완료 페이지 cta에 다짐메시지 모달 로직 연결

### DIFF
--- a/src/pages/members/complete.tsx
+++ b/src/pages/members/complete.tsx
@@ -4,10 +4,14 @@ import { useRouter } from 'next/router';
 import { playgroundLink } from 'playground-common/export';
 import { FC } from 'react';
 
+import { useGetResolutionValidation } from '@/api/endpoint/resolution/getResolutionValidation';
 import { useGetMemberProfileOfMe } from '@/api/endpoint_LEGACY/hooks';
+import useAlert from '@/components/common/Modal/useAlert';
+import useModalState from '@/components/common/Modal/useModalState';
 import Text from '@/components/common/Text';
 import CardBack from '@/components/resolution/CardBack';
 import MemberCardOfMe from '@/components/resolution/MemberCardOfMe';
+import ResolutionModal from '@/components/resolution/ResolutionModal';
 import { LATEST_GENERATION } from '@/constants/generation';
 import { MOBILE_MEDIA_QUERY } from '@/styles/mediaQuery';
 /**
@@ -27,6 +31,32 @@ const CompletePage: FC = () => {
       content: `${activity.generation}기 ${activity.part}`,
       isActive: activity.generation === LATEST_GENERATION,
     }));
+
+  const {
+    isOpen: isOpenResolutionModal,
+    onOpen: onOpenResolutionModal,
+    onClose: onCloseResolutionModal,
+  } = useModalState();
+
+  const { alert } = useAlert();
+  const { data: { memberProfileImgUrl, isRegistration } = {} } = useGetResolutionValidation();
+
+  const handleResolutionModalOpen = () => {
+    if (isRegistration) {
+      alert({
+        title: '편지는 한번만 전송할 수 있어요',
+        description: '전송된 편지는 종무식 때 열어볼 수 있어요!',
+        buttonText: '확인',
+        maxWidth: 400,
+        zIndex: zIndex.헤더,
+        buttonColor: colors.white,
+        buttonTextColor: colors.black,
+        hideCloseButton: true,
+      });
+    } else {
+      onOpenResolutionModal();
+    }
+  };
 
   return (
     <>
@@ -51,13 +81,10 @@ const CompletePage: FC = () => {
             >
               홈으로 돌아가기
             </DefaultButton>
-            <CtaButton
-              onClick={() => {
-                //다짐메시지 모달
-              }}
-            >
-              NOW, 다짐하러 가기
-            </CtaButton>
+            <CtaButton onClick={handleResolutionModalOpen}>NOW, 다짐하러 가기</CtaButton>
+            {isOpenResolutionModal && (
+              <ResolutionModal profileImageUrl={memberProfileImgUrl ?? ''} onClose={onCloseResolutionModal} />
+            )}
           </ButtonsWrapper>
         </StyledCompletePage>
       )}
@@ -87,7 +114,6 @@ const CardsWrapper = styled.div`
   transform-style: preserve-3d;
   transition: transform 0.3s;
   margin-top: 32px;
-  margin-bottom: 55px;
   width: 100%;
   animation-name: flip;
   animation-duration: 1s;
@@ -148,6 +174,7 @@ const ButtonsWrapper = styled.div`
   display: flex;
   gap: 10px;
   margin-top: 56px;
+  margin-bottom: 55px;
 
   @media ${MOBILE_MEDIA_QUERY} {
     flex-direction: column;

--- a/src/pages/members/complete.tsx
+++ b/src/pages/members/complete.tsx
@@ -8,6 +8,7 @@ import { useGetResolutionValidation } from '@/api/endpoint/resolution/getResolut
 import { useGetMemberProfileOfMe } from '@/api/endpoint_LEGACY/hooks';
 import useAlert from '@/components/common/Modal/useAlert';
 import useModalState from '@/components/common/Modal/useModalState';
+import Responsive from '@/components/common/Responsive';
 import Text from '@/components/common/Text';
 import CardBack from '@/components/resolution/CardBack';
 import MemberCardOfMe from '@/components/resolution/MemberCardOfMe';
@@ -18,6 +19,7 @@ import { MOBILE_MEDIA_QUERY } from '@/styles/mediaQuery';
  * @desc 신규 프로필 등록 후 다짐 메시지를 유도하는 페이지입니다.
  */
 import { textStyles } from '@/styles/typography';
+import { zIndex } from '@/styles/zIndex';
 import { setLayout } from '@/utils/layout';
 
 const CompletePage: FC = () => {
@@ -62,7 +64,12 @@ const CompletePage: FC = () => {
     <>
       {profile && (
         <StyledCompletePage>
-          <Text typography='SUIT_32_B'>프로필 등록 완료!</Text>
+          <Responsive only='desktop'>
+            <Text typography='SUIT_32_B'>프로필 등록 완료!</Text>
+          </Responsive>
+          <Responsive only='mobile'>
+            <Text typography='SUIT_24_B'>프로필 등록 완료!</Text>
+          </Responsive>
           <CardsWrapper>
             <CardBack />
             <MemberCardOfMe
@@ -105,6 +112,10 @@ const StyledCompletePage = styled.div`
   width: 100%;
   @supports (height: 100dvh) {
     height: 100dvh;
+  }
+
+  @media ${MOBILE_MEDIA_QUERY} {
+    margin: 20px 0;
   }
 `;
 
@@ -174,7 +185,6 @@ const ButtonsWrapper = styled.div`
   display: flex;
   gap: 10px;
   margin-top: 56px;
-  margin-bottom: 55px;
 
   @media ${MOBILE_MEDIA_QUERY} {
     flex-direction: column;


### PR DESCRIPTION
### 🤫 쉿, 나한테만 말해줘요. 이슈넘버
- close #1336 

### 🧐 어떤 것을 변경했어요~?
<!-- 실제로 변경한 사항을 설명해주세요.-->
- 프로필 등록 완료 페이지 cta에서도 다짐메시지를 작성하도록 했어요.
- 자잘한 css를 수정했어요.

### 🤔 그렇다면, 어떻게 구현했어요~?
<!-- 실제로 구현한 로직에 대해 설명해주세요.-->
환영배너에서 사용되는 다음의 로직을 동일하게 members/complete.tsx에도 적용했습니다.
```ts
const {
    isOpen: isOpenResolutionModal,
    onOpen: onOpenResolutionModal,
    onClose: onCloseResolutionModal,
  } = useModalState();

  const { alert } = useAlert();
  const { data: { memberProfileImgUrl, isRegistration } = {} } = useGetResolutionValidation();

  const handleResolutionModalOpen = () => {
    if (isRegistration) {
      alert({
        title: '편지는 한번만 전송할 수 있어요',
        description: '전송된 편지는 종무식 때 열어볼 수 있어요!',
        buttonText: '확인',
        maxWidth: 400,
        zIndex: zIndex.헤더,
        buttonColor: colors.white,
        buttonTextColor: colors.black,
        hideCloseButton: true,
      });
    } else {
      onOpenResolutionModal();
    }
  };
```

### ❤️‍🔥 당신이 생각하는 PR포인트, 내겐 매력포인트.
<!-- 해당 PR에서 논의가 필요한 사항을 적어주세요. -->

### 📸 스크린샷, 없으면 이것 참,, 섭섭한데요?

https://github.com/sopt-makers/sopt-playground-frontend/assets/55528304/7bae64d2-c01c-4428-964b-a8816e6c399e

