### PR TITLE
refactor: 다짐 메시지 모달 로직 개선 및 자잘한 UI 수정

### DIFF
--- a/src/components/common/Banner/WelcomeBanner/index.tsx
+++ b/src/components/common/Banner/WelcomeBanner/index.tsx
@@ -2,10 +2,7 @@ import styled from '@emotion/styled';
 import { colors } from '@sopt-makers/colors';
 import { useEffect, useLayoutEffect, useState } from 'react';
 
-import { useGetResolutionValidation } from '@/api/endpoint/resolution/getResolutionValidation';
 import Loading from '@/components/common/Loading';
-import useAlert from '@/components/common/Modal/useAlert';
-import useModalState from '@/components/common/Modal/useModalState';
 import Responsive from '@/components/common/Responsive';
 import ResolutionModal from '@/components/resolution/ResolutionModal';
 import { useOpenResolutionModal } from '@/components/resolution/useOpenResolutionModal';
@@ -19,7 +16,6 @@ import mobileOthersBanner1 from '@/public/icons/img/banner_other_mobile_ver1.gif
 import mobileOthersBanner2 from '@/public/icons/img/banner_other_mobile_ver2.gif';
 import { MOBILE_MEDIA_QUERY } from '@/styles/mediaQuery';
 import { textStyles } from '@/styles/typography';
-import { zIndex } from '@/styles/zIndex';
 
 type BannerType = {
   desktop: { [ver: number]: string };
@@ -57,7 +53,7 @@ const WelcomeBanner = ({ is34 }: WelcomeBannerProp) => {
     mobile: { 1: mobileOthersBanner1.src, 2: mobileOthersBanner2.src },
   };
 
-  const { isOpenResolutionModal, onCloseResolutionModal, handleResolutionModalOpen, memberProfileImgUrl } =
+  const { isOpenResolutionModal, onCloseResolutionModal, handleResolutionModalOpen, profileImage } =
     useOpenResolutionModal();
 
   return (
@@ -72,7 +68,7 @@ const WelcomeBanner = ({ is34 }: WelcomeBannerProp) => {
                     NOW, 다짐하러 가기
                   </ResolutionButton>
                   {isOpenResolutionModal && (
-                    <ResolutionModal profileImageUrl={memberProfileImgUrl ?? ''} onClose={onCloseResolutionModal} />
+                    <ResolutionModal profileImageUrl={profileImage ?? ''} onClose={onCloseResolutionModal} />
                   )}
                 </ButtonWrapper>
                 <BannerWrapper>

--- a/src/components/common/Banner/WelcomeBanner/index.tsx
+++ b/src/components/common/Banner/WelcomeBanner/index.tsx
@@ -8,6 +8,7 @@ import useAlert from '@/components/common/Modal/useAlert';
 import useModalState from '@/components/common/Modal/useModalState';
 import Responsive from '@/components/common/Responsive';
 import ResolutionModal from '@/components/resolution/ResolutionModal';
+import { useOpenResolutionModal } from '@/components/resolution/useOpenResolutionModal';
 import desktop34Banner1 from '@/public/icons/img/banner_34_desktop_ver1.gif';
 import desktop34Banner2 from '@/public/icons/img/banner_34_desktop_ver2.gif';
 import mobile34Banner1 from '@/public/icons/img/banner_34_mobile_ver1.gif';
@@ -56,31 +57,8 @@ const WelcomeBanner = ({ is34 }: WelcomeBannerProp) => {
     mobile: { 1: mobileOthersBanner1.src, 2: mobileOthersBanner2.src },
   };
 
-  const {
-    isOpen: isOpenResolutionModal,
-    onOpen: onOpenResolutionModal,
-    onClose: onCloseResolutionModal,
-  } = useModalState();
-
-  const { alert } = useAlert();
-  const { data } = useGetResolutionValidation();
-
-  const handleResolutionModalOpen = () => {
-    if (!data?.isRegistration) {
-      alert({
-        title: '편지는 한번만 전송할 수 있어요',
-        description: '전송된 편지는 종무식 때 열어볼 수 있어요!',
-        buttonText: '확인',
-        maxWidth: 400,
-        zIndex: zIndex.헤더 + 101,
-        buttonColor: colors.white,
-        buttonTextColor: colors.black,
-        hideCloseButton: true,
-      });
-    } else {
-      onOpenResolutionModal();
-    }
-  };
+  const { isOpenResolutionModal, onCloseResolutionModal, handleResolutionModalOpen, memberProfileImgUrl } =
+    useOpenResolutionModal();
 
   return (
     <WelcomeBannerContainer>
@@ -94,10 +72,7 @@ const WelcomeBanner = ({ is34 }: WelcomeBannerProp) => {
                     NOW, 다짐하러 가기
                   </ResolutionButton>
                   {isOpenResolutionModal && (
-                    <ResolutionModal
-                      profileImageUrl={data?.memberProfileImgUrl ?? ''}
-                      onClose={onCloseResolutionModal}
-                    />
+                    <ResolutionModal profileImageUrl={memberProfileImgUrl ?? ''} onClose={onCloseResolutionModal} />
                   )}
                 </ButtonWrapper>
                 <BannerWrapper>

--- a/src/components/common/Footer/index.tsx
+++ b/src/components/common/Footer/index.tsx
@@ -9,6 +9,7 @@ import useEventLogger from '@/components/eventLogger/hooks/useEventLogger';
 import { FEEDBACK_FORM_URL, MAKERS_TEAM_URL, playgroundLink } from '@/constants/links';
 import useScroll from '@/hooks/useScroll';
 import { MOBILE_MEDIA_QUERY } from '@/styles/mediaQuery';
+import { zIndex } from '@/styles/zIndex';
 
 interface FooterProps {
   className?: string;
@@ -43,7 +44,7 @@ const StyledFooter = styled.div<{ hide: boolean }>`
   position: fixed;
   bottom: 0;
   transition: transform 0.3s;
-  z-index: 99999;
+  z-index: ${zIndex.헤더}+1;
   border-top: 1px solid ${colors.gray600};
   background-color: ${colors.gray800};
   padding: 0 0 0 38px;

--- a/src/components/resolution/ResolutionModal.tsx
+++ b/src/components/resolution/ResolutionModal.tsx
@@ -219,7 +219,7 @@ const StyledForm = styled.form`
       max-width: 100dvw;
     }
 
-    padding: 0 18px;
+    padding: 0;
   }
 `;
 

--- a/src/components/resolution/useOpenResolutionModal.ts
+++ b/src/components/resolution/useOpenResolutionModal.ts
@@ -16,7 +16,7 @@ export const useOpenResolutionModal = () => {
   const { data: { memberProfileImgUrl, isRegistration } = {} } = useGetResolutionValidation();
 
   const handleResolutionModalOpen = () => {
-    if (!isRegistration) {
+    if (isRegistration) {
       alert({
         title: '편지는 한번만 전송할 수 있어요',
         description: '전송된 편지는 종무식 때 열어볼 수 있어요!',

--- a/src/components/resolution/useOpenResolutionModal.ts
+++ b/src/components/resolution/useOpenResolutionModal.ts
@@ -1,5 +1,6 @@
 import { colors } from '@sopt-makers/colors';
 
+import { useGetMemberOfMe } from '@/api/endpoint/members/getMemberOfMe';
 import { useGetResolutionValidation } from '@/api/endpoint/resolution/getResolutionValidation';
 import useAlert from '@/components/common/Modal/useAlert';
 import useModalState from '@/components/common/Modal/useModalState';
@@ -13,10 +14,12 @@ export const useOpenResolutionModal = () => {
   } = useModalState();
 
   const { alert } = useAlert();
-  const { data: { memberProfileImgUrl, isRegistration } = {} } = useGetResolutionValidation();
+  const { data: { isRegistration } = {} } = useGetResolutionValidation();
+
+  const { data: { profileImage } = {} } = useGetMemberOfMe();
 
   const handleResolutionModalOpen = () => {
-    if (isRegistration) {
+    if (!isRegistration) {
       alert({
         title: '편지는 한번만 전송할 수 있어요',
         description: '전송된 편지는 종무식 때 열어볼 수 있어요!',
@@ -36,6 +39,6 @@ export const useOpenResolutionModal = () => {
     isOpenResolutionModal,
     onCloseResolutionModal,
     handleResolutionModalOpen,
-    memberProfileImgUrl,
+    profileImage,
   };
 };

--- a/src/components/resolution/useOpenResolutionModal.ts
+++ b/src/components/resolution/useOpenResolutionModal.ts
@@ -1,0 +1,41 @@
+import { colors } from '@sopt-makers/colors';
+
+import { useGetResolutionValidation } from '@/api/endpoint/resolution/getResolutionValidation';
+import useAlert from '@/components/common/Modal/useAlert';
+import useModalState from '@/components/common/Modal/useModalState';
+import { zIndex } from '@/styles/zIndex';
+
+export const useOpenResolutionModal = () => {
+  const {
+    isOpen: isOpenResolutionModal,
+    onOpen: onOpenResolutionModal,
+    onClose: onCloseResolutionModal,
+  } = useModalState();
+
+  const { alert } = useAlert();
+  const { data: { memberProfileImgUrl, isRegistration } = {} } = useGetResolutionValidation();
+
+  const handleResolutionModalOpen = () => {
+    if (!isRegistration) {
+      alert({
+        title: '편지는 한번만 전송할 수 있어요',
+        description: '전송된 편지는 종무식 때 열어볼 수 있어요!',
+        buttonText: '확인',
+        maxWidth: 400,
+        zIndex: zIndex.헤더 + 101,
+        buttonColor: colors.white,
+        buttonTextColor: colors.black,
+        hideCloseButton: true,
+      });
+    } else {
+      onOpenResolutionModal();
+    }
+  };
+
+  return {
+    isOpenResolutionModal,
+    onCloseResolutionModal,
+    handleResolutionModalOpen,
+    memberProfileImgUrl,
+  };
+};

--- a/src/pages/members/complete.tsx
+++ b/src/pages/members/complete.tsx
@@ -89,11 +89,15 @@ const StyledCompletePage = styled.div`
   padding: 0 16px;
   width: 100%;
   @supports (height: 100dvh) {
-    height: 100dvh;
+    height: calc(100dvh - 100px);
   }
 
   @media ${MOBILE_MEDIA_QUERY} {
     margin: 20px 0;
+
+    @supports (height: 100dvh) {
+      height: 100dvh;
+    }
   }
 `;
 

--- a/src/pages/members/complete.tsx
+++ b/src/pages/members/complete.tsx
@@ -13,6 +13,7 @@ import Text from '@/components/common/Text';
 import CardBack from '@/components/resolution/CardBack';
 import MemberCardOfMe from '@/components/resolution/MemberCardOfMe';
 import ResolutionModal from '@/components/resolution/ResolutionModal';
+import { useOpenResolutionModal } from '@/components/resolution/useOpenResolutionModal';
 import { LATEST_GENERATION } from '@/constants/generation';
 import { MOBILE_MEDIA_QUERY } from '@/styles/mediaQuery';
 /**
@@ -34,31 +35,8 @@ const CompletePage: FC = () => {
       isActive: activity.generation === LATEST_GENERATION,
     }));
 
-  const {
-    isOpen: isOpenResolutionModal,
-    onOpen: onOpenResolutionModal,
-    onClose: onCloseResolutionModal,
-  } = useModalState();
-
-  const { alert } = useAlert();
-  const { data: { memberProfileImgUrl, isRegistration } = {} } = useGetResolutionValidation();
-
-  const handleResolutionModalOpen = () => {
-    if (isRegistration) {
-      alert({
-        title: '편지는 한번만 전송할 수 있어요',
-        description: '전송된 편지는 종무식 때 열어볼 수 있어요!',
-        buttonText: '확인',
-        maxWidth: 400,
-        zIndex: zIndex.헤더,
-        buttonColor: colors.white,
-        buttonTextColor: colors.black,
-        hideCloseButton: true,
-      });
-    } else {
-      onOpenResolutionModal();
-    }
-  };
+  const { isOpenResolutionModal, onCloseResolutionModal, handleResolutionModalOpen, memberProfileImgUrl } =
+    useOpenResolutionModal();
 
   return (
     <>

--- a/src/pages/members/complete.tsx
+++ b/src/pages/members/complete.tsx
@@ -4,10 +4,7 @@ import { useRouter } from 'next/router';
 import { playgroundLink } from 'playground-common/export';
 import { FC } from 'react';
 
-import { useGetResolutionValidation } from '@/api/endpoint/resolution/getResolutionValidation';
 import { useGetMemberProfileOfMe } from '@/api/endpoint_LEGACY/hooks';
-import useAlert from '@/components/common/Modal/useAlert';
-import useModalState from '@/components/common/Modal/useModalState';
 import Responsive from '@/components/common/Responsive';
 import Text from '@/components/common/Text';
 import CardBack from '@/components/resolution/CardBack';
@@ -35,7 +32,7 @@ const CompletePage: FC = () => {
       isActive: activity.generation === LATEST_GENERATION,
     }));
 
-  const { isOpenResolutionModal, onCloseResolutionModal, handleResolutionModalOpen, memberProfileImgUrl } =
+  const { isOpenResolutionModal, onCloseResolutionModal, handleResolutionModalOpen, profileImage } =
     useOpenResolutionModal();
 
   return (
@@ -68,7 +65,7 @@ const CompletePage: FC = () => {
             </DefaultButton>
             <CtaButton onClick={handleResolutionModalOpen}>NOW, 다짐하러 가기</CtaButton>
             {isOpenResolutionModal && (
-              <ResolutionModal profileImageUrl={memberProfileImgUrl ?? ''} onClose={onCloseResolutionModal} />
+              <ResolutionModal profileImageUrl={profileImage ?? ''} onClose={onCloseResolutionModal} />
             )}
           </ButtonsWrapper>
         </StyledCompletePage>


### PR DESCRIPTION
### 🤫 쉿, 나한테만 말해줘요. 이슈넘버
- close #1338 

### 🧐 어떤 것을 변경했어요~?
<!-- 실제로 변경한 사항을 설명해주세요.-->
- 다짐 메시지 모달 로직을 모듈화 했어요.
- 다짐 메시지 모달에 필요한 프로필 이미지를 가져오는 api를 변경했어요.

### 🤔 그렇다면, 어떻게 구현했어요~?
<!-- 실제로 구현한 로직에 대해 설명해주세요.-->
- 다짐 메시지 모달을 열기 위해 사용되는 useModalState 반환값들, alert, 재확인 모달 로직 등을 새로운 파일로 분리하여 커스텀훅을 만들었습니다. 이를 1. 환영배너 cta 2. 프로필 등록 완료 페이지 cta 에서 가져다 사용합니다.

### ❤️‍🔥 당신이 생각하는 PR포인트, 내겐 매력포인트.
<!-- 해당 PR에서 논의가 필요한 사항을 적어주세요. -->

- 메시지를 제출할 때 validation api를 refetch하는 로직으로 바꿨더니 생기는 문제를 발견했어요! 이렇게 하면 사용자가 처음으로 다짐 메시지를 쓸 때는 validation api가 한번도 호출되지 않게 되는데, validation api에서 이미 등록했는지 여부뿐만아니라 프로필 이미지도 가져오고 있기 때문에 처음 쓰는 유저는 프로필 이미지가 뜨지 않는 문제가 발생했습니다. 처음 쓰는 유저뿐아니라 메시지를 남기기 전에 프로필을 변경했다면 이 변경된 프로필이 모달에는 반영되지 않는 문제가 생기는 것입니다. 그래서 프로필 등록/수정 api에도 validation api를 refetch하도록 추가해야하나 생각했다가, 기존 api를 건드는 것 보단 resolution 피쳐 관련 파일내에서 해결하는게 좋을 것 같아서, 프로필 이미지를 validation api가 아니라 getMemberOfMe() api에서 가져오는 것으로 수정했습니다.

- 이슈와 관련없는 변경사항 죄송하지만 공통 컴포넌트 footer가 모달을 가려서, zIndex.헤더 값(100) 을 이용하여 zIndex를 변경했습니다.
기존 zIndex 값보다 낮아졌기 때문에 예상치못하게 다른 곳에서 어떤 요소가 footer 위로 올라올 위험이 있어보이지만
여기저기에서 zIndex가 임의의 값으로 남발되어있어서 상수화를 해서 정리해나가는게 필요하다고 생각했습니다!


### 📸 스크린샷, 없으면 이것 참,, 섭섭한데요?
