### PR TITLE
fix: 프로필 내 모임 카드 무한 스크롤 트리거 수정

### DIFF
--- a/src/api/endpoint/members/getMemberCrew.ts
+++ b/src/api/endpoint/members/getMemberCrew.ts
@@ -20,7 +20,7 @@ export const getMemberCrew = createEndpoint({
         id: z.number(),
         isMeetingLeader: z.boolean(),
         title: z.string(),
-        imageUrl: z.string().nullable(),
+        imageUrl: z.string(),
         category: z.string().nullable(),
         isActiveMeeting: z.boolean(),
         mstartDate: z.string(),

--- a/src/components/members/detail/ActivitySection/MemberDetail.tsx
+++ b/src/components/members/detail/ActivitySection/MemberDetail.tsx
@@ -273,6 +273,7 @@ const MemberDetail: FC<MemberDetailProps> = ({ memberId }) => {
                   />
                 ))}
               </ActivityDisplay>
+              <Target ref={ref} />
             </>
           )}
           {meetingList.length === 0 && (
@@ -290,7 +291,6 @@ const MemberDetail: FC<MemberDetailProps> = ({ memberId }) => {
               )}
             </>
           )}
-          <Target ref={ref} />
         </ActivityContainer>
       </Wrapper>
     </Container>


### PR DESCRIPTION
### 🤫 쉿, 나한테만 말해줘요. 이슈넘버
- close #1341 

### 🧐 어떤 것을 변경했어요~?
<!-- 실제로 변경한 사항을 설명해주세요.-->
참여한 모임이 없을 때도 무한스크롤이 트리거되는 문제를 발견했습니다.

### 🤔 그렇다면, 어떻게 구현했어요~?
<!-- 실제로 구현한 로직에 대해 설명해주세요.-->
무한 스크롤을 트리거하는 Target 컴포넌트를, 참여한 모임이 존재할 때만 노출되도록 변경하였습니다.

### ❤️‍🔥 당신이 생각하는 PR포인트, 내겐 매력포인트.
<!-- 해당 PR에서 논의가 필요한 사항을 적어주세요. -->

### 📸 스크린샷, 없으면 이것 참,, 섭섭한데요?
