### PR TITLE
chore: 환영배너 맞춰서 데스크탑 커뮤니티 레이아웃 조정

### DIFF
--- a/src/components/common/Banner/WelcomeBanner/Welcome34.tsx
+++ b/src/components/common/Banner/WelcomeBanner/Welcome34.tsx
@@ -3,8 +3,10 @@ import WelcomeBanner from '@/components/common/Banner/WelcomeBanner';
 import { LATEST_GENERATION } from '@/constants/generation';
 
 const Welcome34 = () => {
-  const { data: myData } = useGetMemberOfMe();
+  const { data: myData, isPending } = useGetMemberOfMe();
   const is34 = myData?.generation === LATEST_GENERATION;
+
+  if (isPending) return <></>;
 
   return <WelcomeBanner is34={is34} />;
 };

--- a/src/components/common/Banner/WelcomeBanner/index.tsx
+++ b/src/components/common/Banner/WelcomeBanner/index.tsx
@@ -61,7 +61,7 @@ const WelcomeBanner = ({ is34 }: WelcomeBannerProp) => {
       <WelcomeBannerWrapper>
         {isMounted ? (
           <>
-            {!is34 ? (
+            {is34 ? (
               <>
                 <ButtonWrapper>
                   <ResolutionButton type='button' onClick={handleResolutionModalOpen}>

--- a/src/components/layout/HeaderOnlyDesktopLayout.tsx
+++ b/src/components/layout/HeaderOnlyDesktopLayout.tsx
@@ -29,7 +29,8 @@ export default HeaderOnlyDesktopLayout;
 const StyledContainer = styled.div`
   padding-top: 80px;
 
-  ${createLayoutCSSVariable({ headerHeight: 80 })}
+  /* TODO: 환영배너 내려간 후, headerHeight: 80으로 반드시 변경 */
+  ${createLayoutCSSVariable({ headerHeight: 248 })}
 
   @media ${MOBILE_MEDIA_QUERY} {
     padding-top: 0;

--- a/src/components/resolution/useOpenResolutionModal.ts
+++ b/src/components/resolution/useOpenResolutionModal.ts
@@ -19,7 +19,7 @@ export const useOpenResolutionModal = () => {
   const { data: { profileImage } = {} } = useGetMemberOfMe();
 
   const handleResolutionModalOpen = () => {
-    if (!isRegistration) {
+    if (isRegistration) {
       alert({
         title: '편지는 한번만 전송할 수 있어요',
         description: '전송된 편지는 종무식 때 열어볼 수 있어요!',

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -14,6 +14,7 @@ const Home: NextPage = () => {
   );
 };
 
-setLayout(Home, 'header');
+// TODO: 환영배너 내린 후, 'header'로 변경
+setLayout(Home, 'headerOnlyDesktop');
 
 export default Home;

--- a/src/pages/members/index.tsx
+++ b/src/pages/members/index.tsx
@@ -3,7 +3,6 @@ import { FC } from 'react';
 
 import { useGetMemberOfMe } from '@/api/endpoint/members/getMemberOfMe';
 import AuthRequired from '@/components/auth/AuthRequired';
-import ActiveBannerSlot from '@/components/common/Banner/ActiveBannerSlot';
 import MemberList from '@/components/members/main/MemberList';
 import OnBoardingBanner from '@/components/members/main/MemberList/OnBoardingBanner';
 import { MOBILE_MEDIA_QUERY } from '@/styles/mediaQuery';
@@ -17,7 +16,6 @@ const MemberPage: FC = () => {
 
   return (
     <AuthRequired>
-      <ActiveBannerSlot />
       <MemberList banner={onboardingBanner} />
     </AuthRequired>
   );

--- a/src/pages/projects/index.tsx
+++ b/src/pages/projects/index.tsx
@@ -1,14 +1,12 @@
 import { FC } from 'react';
 
 import AuthRequired from '@/components/auth/AuthRequired';
-import ActiveBannerSlot from '@/components/common/Banner/ActiveBannerSlot';
 import ProjectList from '@/components/projects/main/ProjectList';
 import { setLayout } from '@/utils/layout';
 
 const ProjectPage: FC = () => {
   return (
     <AuthRequired>
-      <ActiveBannerSlot />
       <ProjectList />
     </AuthRequired>
   );


### PR DESCRIPTION
### 🤫 쉿, 나한테만 말해줘요. 이슈넘버
- close #

### 🧐 어떤 것을 변경했어요~?
<!-- 실제로 변경한 사항을 설명해주세요.-->
- 환영배너 맞춰서 데스크탑 커뮤니티 레이아웃 조정했어요.

### 🤔 그렇다면, 어떻게 구현했어요~?
<!-- 실제로 구현한 로직에 대해 설명해주세요.-->
- headerOnlyDesktop 이용, header크기를 80->248로 조정해주었어요.

### ❤️‍🔥 당신이 생각하는 PR포인트, 내겐 매력포인트.
<!-- 해당 PR에서 논의가 필요한 사항을 적어주세요. -->
- 환영배너 내릴 때 변경한 사항도 다시 롤백해야합니다.

### 📸 스크린샷, 없으면 이것 참,, 섭섭한데요?
