### PR TITLE
feat: 다짐메시지 로깅 추가

### DIFF
--- a/src/components/common/Banner/WelcomeBanner/index.tsx
+++ b/src/components/common/Banner/WelcomeBanner/index.tsx
@@ -4,6 +4,7 @@ import { useEffect, useLayoutEffect, useState } from 'react';
 
 import Loading from '@/components/common/Loading';
 import Responsive from '@/components/common/Responsive';
+import { LoggingClick } from '@/components/eventLogger/components/LoggingClick';
 import ResolutionModal from '@/components/resolution/ResolutionModal';
 import { useOpenResolutionModal } from '@/components/resolution/useOpenResolutionModal';
 import desktop34Banner1 from '@/public/icons/img/banner_34_desktop_ver1.gif';
@@ -53,7 +54,7 @@ const WelcomeBanner = ({ is34 }: WelcomeBannerProp) => {
     mobile: { 1: mobileOthersBanner1.src, 2: mobileOthersBanner2.src },
   };
 
-  const { isOpenResolutionModal, onCloseResolutionModal, handleResolutionModalOpen, profileImage } =
+  const { isOpenResolutionModal, onCloseResolutionModal, handleResolutionModalOpen, profileImage, isRegistration } =
     useOpenResolutionModal();
 
   return (
@@ -64,9 +65,14 @@ const WelcomeBanner = ({ is34 }: WelcomeBannerProp) => {
             {is34 ? (
               <>
                 <ButtonWrapper>
-                  <ResolutionButton type='button' onClick={handleResolutionModalOpen}>
-                    NOW, 다짐하러 가기
-                  </ResolutionButton>
+                  <LoggingClick
+                    eventKey='WelcomeBannerResolution'
+                    param={{ isAlreadySubmitted: isRegistration ?? false }}
+                  >
+                    <ResolutionButton type='button' onClick={handleResolutionModalOpen}>
+                      NOW, 다짐하러 가기
+                    </ResolutionButton>
+                  </LoggingClick>
                   {isOpenResolutionModal && (
                     <ResolutionModal profileImageUrl={profileImage ?? ''} onClose={onCloseResolutionModal} />
                   )}

--- a/src/components/eventLogger/events.ts
+++ b/src/components/eventLogger/events.ts
@@ -88,6 +88,11 @@ export interface ClickEvents {
     feedId: string;
   };
   feedUploadButton: undefined;
+  //다짐메시지
+  WelcomeBannerResolution: {
+    isAlreadySubmitted: boolean;
+  };
+  ProfileUploadResolution: undefined;
 }
 
 export interface SubmitEvents {
@@ -122,6 +127,8 @@ export interface SubmitEvents {
     referral: 'more' | 'detail';
     isBlindWriter: boolean;
   };
+  //다짐메시지
+  postResolution: undefined;
 }
 
 export interface PageViewEvents {

--- a/src/components/resolution/useConfirmResolution.ts
+++ b/src/components/resolution/useConfirmResolution.ts
@@ -5,6 +5,7 @@ import { ResolutionRequestBody } from '@/api/endpoint/resolution/postResolution'
 import { usePostResolutionMutation } from '@/api/endpoint/resolution/postResolution';
 import useConfirm from '@/components/common/Modal/useConfirm';
 import useToast from '@/components/common/Toast/useToast';
+import useEventLogger from '@/components/eventLogger/hooks/useEventLogger';
 import { zIndex } from '@/styles/zIndex';
 
 interface Options extends ResolutionRequestBody {
@@ -15,6 +16,7 @@ export const useConfirmResolution = () => {
   const { confirm } = useConfirm();
   const { mutateAsync, isPending } = usePostResolutionMutation();
   const toast = useToast();
+  const { logSubmitEvent } = useEventLogger();
 
   const handleConfirmResolution = useCallback(
     async (options: Options) => {
@@ -32,13 +34,14 @@ export const useConfirmResolution = () => {
       if (result) {
         mutateAsync(options, {
           onSuccess: () => {
+            logSubmitEvent('postResolution');
             toast.show({ message: '💌 전송이 완료되었어요. 종무식 때 만나요!' });
             options.onSuccess?.();
           },
         });
       }
     },
-    [confirm, mutateAsync, toast],
+    [confirm, mutateAsync, toast, logSubmitEvent],
   );
 
   return { handleConfirmResolution, isPending };

--- a/src/components/resolution/useOpenResolutionModal.ts
+++ b/src/components/resolution/useOpenResolutionModal.ts
@@ -40,5 +40,6 @@ export const useOpenResolutionModal = () => {
     onCloseResolutionModal,
     handleResolutionModalOpen,
     profileImage,
+    isRegistration,
   };
 };

--- a/src/pages/members/complete.tsx
+++ b/src/pages/members/complete.tsx
@@ -7,6 +7,7 @@ import { FC } from 'react';
 import { useGetMemberProfileOfMe } from '@/api/endpoint_LEGACY/hooks';
 import Responsive from '@/components/common/Responsive';
 import Text from '@/components/common/Text';
+import { LoggingClick } from '@/components/eventLogger/components/LoggingClick';
 import CardBack from '@/components/resolution/CardBack';
 import MemberCardOfMe from '@/components/resolution/MemberCardOfMe';
 import ResolutionModal from '@/components/resolution/ResolutionModal';
@@ -17,7 +18,6 @@ import { MOBILE_MEDIA_QUERY } from '@/styles/mediaQuery';
  * @desc 신규 프로필 등록 후 다짐 메시지를 유도하는 페이지입니다.
  */
 import { textStyles } from '@/styles/typography';
-import { zIndex } from '@/styles/zIndex';
 import { setLayout } from '@/utils/layout';
 
 const CompletePage: FC = () => {
@@ -63,7 +63,9 @@ const CompletePage: FC = () => {
             >
               홈으로 돌아가기
             </DefaultButton>
-            <CtaButton onClick={handleResolutionModalOpen}>NOW, 다짐하러 가기</CtaButton>
+            <LoggingClick eventKey='ProfileUploadResolution'>
+              <CtaButton onClick={handleResolutionModalOpen}>NOW, 다짐하러 가기</CtaButton>
+            </LoggingClick>
             {isOpenResolutionModal && (
               <ResolutionModal profileImageUrl={profileImage ?? ''} onClose={onCloseResolutionModal} />
             )}


### PR DESCRIPTION
### 🤫 쉿, 나한테만 말해줘요. 이슈넘버
- close #1349

### 🧐 어떤 것을 변경했어요~?
<!-- 실제로 변경한 사항을 설명해주세요.-->
다짐메시지에 관련 로깅을 추가했습니다.

### 🤔 그렇다면, 어떻게 구현했어요~?
<!-- 실제로 구현한 로직에 대해 설명해주세요.-->
1. 환영배너에서 cta클릭 (이미 등록한 사용자인지 아닌지 구분)
2. 프로필등록완료페이지에서 cta클릭
3. 다짐메시지 제출

### ❤️‍🔥 당신이 생각하는 PR포인트, 내겐 매력포인트.
<!-- 해당 PR에서 논의가 필요한 사항을 적어주세요. -->

다짐메시지 제출할 때 유저 id도 같이 받을까했는데 user정보가 들어있는 컴포넌트랑 분리되어있는 로직이라 값을 받아오기 어려워 생략했습니다.

### 📸 스크린샷, 없으면 이것 참,, 섭섭한데요?
