### PR TITLE
fix: 태그가 아주 많을 경우의 프로필 카드 수정

### DIFF
--- a/src/components/members/main/MemberCard/index.tsx
+++ b/src/components/members/main/MemberCard/index.tsx
@@ -119,6 +119,7 @@ const ImageHolder = styled(m.div)`
 
 const ContentArea = styled.div`
   grid-area: content;
+  min-width: 0;
   min-height: 120px;
 
   @media ${MOBILE_MEDIA_QUERY} {

--- a/src/components/members/main/MemberList/index.tsx
+++ b/src/components/members/main/MemberList/index.tsx
@@ -549,18 +549,18 @@ const StyledMemberSearch = styled(MemberSearch)`
 
 const StyledCardWrapper = styled.div`
   display: grid;
-  grid-template-columns: repeat(4, minmax(auto, 303px));
+  grid-template-columns: repeat(4, minmax(10px, 303px));
   gap: 30px;
   align-items: center;
   justify-items: stretch;
   margin-top: 28px;
 
   @media ${DESKTOP_ONE_MEDIA_QUERY} {
-    grid-template-columns: repeat(3, minmax(auto, 303px));
+    grid-template-columns: repeat(3, minmax(10px, 303px));
   }
 
   @media ${DESKTOP_TWO_MEDIA_QUERY} {
-    grid-template-columns: repeat(2, minmax(auto, 303px));
+    grid-template-columns: repeat(2, minmax(10px, 303px));
   }
 
   @media ${MOBILE_MEDIA_QUERY} {


### PR DESCRIPTION
### 🤫 쉿, 나한테만 말해줘요. 이슈넘버
- close #

### 🧐 어떤 것을 변경했어요~?
<!-- 실제로 변경한 사항을 설명해주세요.-->
- 태그가 아주 많을 경우, 프로필 카드의 내용이 넘치는 문제를 해결했어요. 

### 🤔 그렇다면, 어떻게 구현했어요~?
<!-- 실제로 구현한 로직에 대해 설명해주세요.-->
- grid minmax값을 auto가 아닌 값을 부여하고, min-width:0을 주었어요.

### ❤️‍🔥 당신이 생각하는 PR포인트, 내겐 매력포인트.
<!-- 해당 PR에서 논의가 필요한 사항을 적어주세요. -->

### 📸 스크린샷, 없으면 이것 참,, 섭섭한데요?
