### PR TITLE
fix: 모바일 프로필 상세 스타일링 수정

### DIFF
--- a/src/components/members/detail/ActivitySection/MemberDetail.tsx
+++ b/src/components/members/detail/ActivitySection/MemberDetail.tsx
@@ -105,7 +105,7 @@ const MemberDetail: FC<MemberDetailProps> = ({ memberId }) => {
     <Container>
       <Wrapper>
         <ProfileContainer>
-          {!profile.profileImage ? (
+          {profile.profileImage ? (
             <ProfileImage src={profile.profileImage} height={171} />
           ) : (
             <EmptyProfileImage>

--- a/src/components/members/detail/ActivitySection/MemberDetail.tsx
+++ b/src/components/members/detail/ActivitySection/MemberDetail.tsx
@@ -105,7 +105,7 @@ const MemberDetail: FC<MemberDetailProps> = ({ memberId }) => {
     <Container>
       <Wrapper>
         <ProfileContainer>
-          {profile.profileImage ? (
+          {!profile.profileImage ? (
             <ProfileImage src={profile.profileImage} height={171} />
           ) : (
             <EmptyProfileImage>
@@ -344,7 +344,13 @@ const EmptyProfileImage = styled.div`
   @media ${MOBILE_MEDIA_QUERY} {
     border-radius: 20px;
     width: 78px;
+    min-width: 78px;
     height: 78px;
+
+    & > svg {
+      width: 40px;
+      height: 40px;
+    }
   }
 `;
 

--- a/src/components/members/detail/ActivitySection/MemberDetail.tsx
+++ b/src/components/members/detail/ActivitySection/MemberDetail.tsx
@@ -328,6 +328,7 @@ const ProfileContainer = styled.div`
   letter-spacing: -0.01em;
   font-weight: 500;
   @media ${MOBILE_MEDIA_QUERY} {
+    gap: 20px;
     align-items: flex-start;
   }
 `;
@@ -349,8 +350,8 @@ const ProfileImage = styled(ResizedImage)`
   object-fit: cover;
   @media ${MOBILE_MEDIA_QUERY} {
     border-radius: 20px;
-    width: 88px;
-    height: 88px;
+    width: 78px;
+    height: 78px;
   }
 `;
 
@@ -396,7 +397,7 @@ const EditButton = styled.div`
   }
 
   @media ${MOBILE_MEDIA_QUERY} {
-    top: -12px;
+    top: 5px;
     width: 32px;
     height: 32px;
 
@@ -442,7 +443,7 @@ const ContactWrapper = styled.div<{ shouldDivide: boolean }>`
     gap: 4px;
     align-items: center;
     @media ${MOBILE_MEDIA_QUERY} {
-      gap: 7;
+      gap: 7px;
     }
   }
 

--- a/src/components/members/detail/ActivitySection/MemberDetail.tsx
+++ b/src/components/members/detail/ActivitySection/MemberDetail.tsx
@@ -341,6 +341,11 @@ const EmptyProfileImage = styled.div`
   background: ${colors.gray700};
   width: 171px;
   height: 171px;
+  @media ${MOBILE_MEDIA_QUERY} {
+    border-radius: 20px;
+    width: 78px;
+    height: 78px;
+  }
 `;
 
 const ProfileImage = styled(ResizedImage)`


### PR DESCRIPTION
### 🤫 쉿, 나한테만 말해줘요. 이슈넘버
- close #1363 

### 🧐 어떤 것을 변경했어요~?
<!-- 실제로 변경한 사항을 설명해주세요.-->
프로필 이미지 사이즈랑 gap 사이즈도 조금 줄이고, 프로필 수정 버튼 윗 부분이 헤더에서 가려지지 않게 하였습니다. 

### 🤔 그렇다면, 어떻게 구현했어요~?
<!-- 실제로 구현한 로직에 대해 설명해주세요.-->

### ❤️‍🔥 당신이 생각하는 PR포인트, 내겐 매력포인트.
<!-- 해당 PR에서 논의가 필요한 사항을 적어주세요. -->

### 📸 스크린샷, 없으면 이것 참,, 섭섭한데요?
|전|후|
|--|--|
|<img width="368" alt="image" src="https://github.com/sopt-makers/sopt-playground-frontend/assets/63948884/f9854db5-e26a-4ef2-9607-dadca5726345">|<img width="364" alt="image" src="https://github.com/sopt-makers/sopt-playground-frontend/assets/63948884/993e56d8-ef3d-4130-8d48-00e5bec4fda7">|


