### PR TITLE
feat: 프로젝트 이미지 ResizedImage로 변경, 엑박 이미지 대응

### DIFF
--- a/src/components/common/ResizedImage/index.tsx
+++ b/src/components/common/ResizedImage/index.tsx
@@ -1,4 +1,4 @@
-import { FC, useCallback, useRef, useState } from 'react';
+import { FC, ComponentProps, useCallback, useRef, useState, SyntheticEvent } from 'react';
 
 import useEnterScreen from '@/hooks/useEnterScreen';
 
@@ -10,11 +10,11 @@ type ImageProps = {
   width?: number;
   height?: number;
   alt?: string;
-
+  onError?: ComponentProps<'img'>['onError'];
   onLoad?: () => void;
 } & ({ width: number } | { height: number }); // Width나 Height 둘중 하나는 있어야함
 
-const ResizedImage: FC<ImageProps> = ({ className, src, width, height, alt, onLoad }) => {
+const ResizedImage: FC<ImageProps> = ({ className, src, width, height, alt, onLoad, onError }) => {
   const [isUsingOriginal, setIsUsingOriginal] = useState(false);
 
   const timeoutTokenRef = useRef<ReturnType<typeof setTimeout>>();
@@ -38,8 +38,9 @@ const ResizedImage: FC<ImageProps> = ({ className, src, width, height, alt, onLo
     }
   };
 
-  const handleResizedLoadError = () => {
+  const handleResizedLoadError = (e: SyntheticEvent<HTMLImageElement, Event>) => {
     setIsUsingOriginal(true);
+    onError?.(e);
   };
 
   const handleResizedLoaded = () => {
@@ -64,7 +65,15 @@ const ResizedImage: FC<ImageProps> = ({ className, src, width, height, alt, onLo
   return (
     <>
       {isUsingOriginal ? (
-        <img src={src} alt={alt} className={className} onLoad={onLoad} loading='lazy' decoding='async' />
+        <img
+          src={src}
+          alt={alt}
+          className={className}
+          onLoad={onLoad}
+          onError={onError}
+          loading='lazy'
+          decoding='async'
+        />
       ) : (
         <img
           ref={imgRef}

--- a/src/components/projects/main/card/MobileProjectCard.tsx
+++ b/src/components/projects/main/card/MobileProjectCard.tsx
@@ -1,3 +1,4 @@
+import ResizedImage from '@/components/common/ResizedImage';
 import ProjectCardMemberList, { MemberType } from '@/components/projects/main/card/ProjectCardMemberList';
 import ProjectCardStatus from '@/components/projects/main/card/ProjectCardStatus';
 import styled from '@emotion/styled';
@@ -28,7 +29,7 @@ const MobileProjectCard = ({
   return (
     <Stack gutter={12} css={{ padding: '16px 0' }}>
       <Flex css={{ gap: 12 }} align='center'>
-        <Image src={logoImage} alt='프로젝트_썸네일_이미지' />
+        <Image width={40} height={40} src={logoImage} alt='프로젝트_썸네일_이미지' />
         <Flex align='center' css={{ gap: 5 }}>
           <Title>{title}</Title>
           <Separated with={<ServiceType>∙</ServiceType>}>
@@ -54,7 +55,7 @@ const MobileProjectCard = ({
   );
 };
 
-const Image = styled.img`
+const Image = styled(ResizedImage)`
   flex-shrink: 0;
   border-radius: 8px;
   width: 40px;

--- a/src/components/projects/main/card/ProjectCard.tsx
+++ b/src/components/projects/main/card/ProjectCard.tsx
@@ -6,6 +6,7 @@ import { m } from 'framer-motion';
 import { Separated } from '@toss/react';
 import ProjectCardMemberList, { MemberType } from '@/components/projects/main/card/ProjectCardMemberList';
 import ProjectCardStatus from '@/components/projects/main/card/ProjectCardStatus';
+import ResizedImage from '@/components/common/ResizedImage';
 
 interface ProjectCardProps {
   image: string;
@@ -32,7 +33,7 @@ const ProjectCard = ({
         y: -8,
       }}
     >
-      <Image src={image} alt='프로젝트_이미지' />
+      <Image height={192} src={image} alt='프로젝트_이미지' />
       <Stack gutter={4}>
         <Flex align='center'>
           <Title
@@ -86,7 +87,7 @@ const Title = styled.h1`
   ${fonts.HEADING_18_B};
 `;
 
-const Image = styled(m.img)`
+const Image = styled(ResizedImage)`
   flex: none;
   border-radius: 8px;
   width: 100%;

--- a/src/components/projects/main/card/ProjectCardMemberList.tsx
+++ b/src/components/projects/main/card/ProjectCardMemberList.tsx
@@ -1,8 +1,10 @@
+import ResizedImage from '@/components/common/ResizedImage';
 import { MOBILE_MEDIA_QUERY } from '@/styles/mediaQuery';
 import styled from '@emotion/styled';
 import { colors } from '@sopt-makers/colors';
 import { fonts } from '@sopt-makers/fonts';
 import { Flex } from '@toss/emotion-utils';
+import { useState } from 'react';
 
 const MEMBER_CIRCLE_WIDTH = 30;
 
@@ -52,30 +54,34 @@ const MemberCircle = ({ className, profileImage }: MemberCircleProps) => {
         align='center'
         justify='center'
         css={{
-          borderRadius: 30,
+          borderRadius: '100%',
           width: 30,
           height: 30,
           border: `2px solid ${colors.background}`,
         }}
       >
-        {profileImage == null ? (
-          <DefaultProfileImage />
-        ) : (
-          <img
-            css={{
-              borderRadius: 26,
-              width: 26,
-              height: 26,
-              objectFit: 'cover',
-            }}
-            src={profileImage}
-            alt='프로젝트_멤버_프로필'
-          />
-        )}
+        {profileImage == null ? <DefaultProfileImage /> : <ProfileImage src={profileImage} />}
       </Flex>
     </div>
   );
 };
+
+const ProfileImage = ({ src }: { src: string }) => {
+  const [isError, setIsError] = useState<boolean>(false);
+
+  return isError ? (
+    <DefaultProfileImage />
+  ) : (
+    <Profile width={26} height={26} src={src} alt='' onError={() => setIsError(true)} />
+  );
+};
+
+const Profile = styled(ResizedImage)`
+  border-radius: 100%;
+  width: 26px;
+  height: 26px;
+  object-fit: cover;
+`;
 
 const DefaultProfileImage = () => (
   <svg width='30' height='30' viewBox='0 0 30 30' fill='none' xmlns='http://www.w3.org/2000/svg'>


### PR DESCRIPTION
### 🤫 쉿, 나한테만 말해줘요. 이슈넘버
- close #1365

### 🧐 어떤 것을 변경했어요~?
<!-- 실제로 변경한 사항을 설명해주세요.-->
- 프로젝트 이미지들을 모두 `ResizedImage`로 변경했어요. 요게 건영이가 커뮤니티때 만들어준 멋진 친구였군요.. webp로 바꿔주는걸 넣고싶었는데 딱 이게 있었군뇨..
- 그것과 더불어 엑박뜨는 이미지가 많아서 엑박뜰때 기본이미지로 보여지도록 변경했어요.

### 🤔 그렇다면, 어떻게 구현했어요~?
<!-- 실제로 구현한 로직에 대해 설명해주세요.-->

### ❤️‍🔥 당신이 생각하는 PR포인트, 내겐 매력포인트.
<!-- 해당 PR에서 논의가 필요한 사항을 적어주세요. -->

### 📸 스크린샷, 없으면 이것 참,, 섭섭한데요?
#### 👉 왼쪽: ResziedImage + 엑박 제거 / 오른쪽: 기존

https://github.com/sopt-makers/sopt-playground-frontend/assets/26808056/6826f97a-e890-420b-bb19-6b7541ea2649

