### PR TITLE
feat: 환영배너 및 다짐메시지 내리기

### DIFF
--- a/src/components/common/Banner/ActiveBannerSlot.tsx
+++ b/src/components/common/Banner/ActiveBannerSlot.tsx
@@ -1,8 +1,6 @@
 import styled from '@emotion/styled';
 import { FC } from 'react';
 
-import Welcome34 from '@/components/common/Banner/WelcomeBanner/Welcome34';
-
 interface ActiveBannerSlotProps {}
 
 const ActiveBannerSlot: FC<ActiveBannerSlotProps> = ({}) => {

--- a/src/components/common/Banner/ActiveBannerSlot.tsx
+++ b/src/components/common/Banner/ActiveBannerSlot.tsx
@@ -9,7 +9,6 @@ const ActiveBannerSlot: FC<ActiveBannerSlotProps> = ({}) => {
   return (
     <StyledActiveBanner>
       {/* 이 밑에 노출할 배너를 넣으세요. */}
-      <Welcome34 />
       {/* ==== */}
     </StyledActiveBanner>
   );

--- a/src/components/resolution/CardBack.tsx
+++ b/src/components/resolution/CardBack.tsx
@@ -7,7 +7,7 @@ const CardBack: FC = () => {
   return (
     <MemberCard>
       <ImageHolder>
-        <Image className='image' src='/logos/now-sopt.svg' width={187} alt='now_sopt' />
+        <Image className='image' src='/logos/logo-makers-full.svg' width={187} alt='now_sopt' />
       </ImageHolder>
     </MemberCard>
   );

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -14,7 +14,7 @@ const Home: NextPage = () => {
   );
 };
 
-// TODO: 환영배너 내린 후, 'header'로 변경
-setLayout(Home, 'headerOnlyDesktop');
+// 환영배너 삽입시, 'headerOnlyDesktop'로 변경
+setLayout(Home, 'header');
 
 export default Home;

--- a/src/pages/members/complete.tsx
+++ b/src/pages/members/complete.tsx
@@ -61,11 +61,11 @@ const CompletePage: FC = () => {
                 router.push(playgroundLink.feedList());
               }}
             >
-              홈으로 돌아가기
+              플레이그라운드 시작하기
             </DefaultButton>
-            <LoggingClick eventKey='profileUploadResolution'>
+            {/* <LoggingClick eventKey='profileUploadResolution'>
               <CtaButton onClick={handleResolutionModalOpen}>NOW, 다짐하러 가기</CtaButton>
-            </LoggingClick>
+            </LoggingClick> */}
             {isOpenResolutionModal && (
               <ResolutionModal profileImageUrl={profileImage ?? ''} onClose={onCloseResolutionModal} />
             )}


### PR DESCRIPTION
### 🤫 쉿, 나한테만 말해줘요. 이슈넘버
- close #1371

### 🧐 어떤 것을 변경했어요~?
<!-- 실제로 변경한 사항을 설명해주세요.-->
- [x] 환영배너 내리기
- [x] 프로필 등록완료 페이지 cta 변경하기
- [x] 프로필 등록완료 카드 뒷면 NOW SOPT 로고에서 playground 로고로 변경

### 🤔 그렇다면, 어떻게 구현했어요~?
<!-- 실제로 구현한 로직에 대해 설명해주세요.-->
- `ActiveBannerSlot.tsx`에서 `<Welcome34/>` 제거
- 프로필 등록 완료 페이지에서 다짐하러가기 CTA 제거

### ❤️‍🔥 당신이 생각하는 PR포인트, 내겐 매력포인트.
<!-- 해당 PR에서 논의가 필요한 사항을 적어주세요. -->
<img width="612" alt="image" src="https://github.com/sopt-makers/sopt-playground-frontend/assets/55528304/17ea8270-7f98-43c7-8dad-3395132144a7">
새로운 CTA가 아직 픽스가 안되었는데 일단 '플레이그라운드 시작하기'로 넣어놨습니다. 혹시 변경되면 반영하겠습니다.

### 📸 스크린샷, 없으면 이것 참,, 섭섭한데요?

https://github.com/sopt-makers/sopt-playground-frontend/assets/55528304/f62fe78f-8996-4c38-acbe-31580fa5f4b0

