### PR TITLE
fix: 프로필 등록 완료 페이지에 AuthRequired 추가

### DIFF
--- a/src/pages/members/complete.tsx
+++ b/src/pages/members/complete.tsx
@@ -5,6 +5,7 @@ import { playgroundLink } from 'playground-common/export';
 import { FC } from 'react';
 
 import { useGetMemberProfileOfMe } from '@/api/endpoint_LEGACY/hooks';
+import AuthRequired from '@/components/auth/AuthRequired';
 import Responsive from '@/components/common/Responsive';
 import Text from '@/components/common/Text';
 import { LoggingClick } from '@/components/eventLogger/components/LoggingClick';
@@ -36,7 +37,7 @@ const CompletePage: FC = () => {
     useOpenResolutionModal();
 
   return (
-    <>
+    <AuthRequired>
       {profile && (
         <StyledCompletePage>
           <Responsive only='desktop'>
@@ -73,7 +74,7 @@ const CompletePage: FC = () => {
           </ButtonWrapper>
         </StyledCompletePage>
       )}
-    </>
+    </AuthRequired>
   );
 };
 

--- a/src/pages/members/complete.tsx
+++ b/src/pages/members/complete.tsx
@@ -5,7 +5,6 @@ import { playgroundLink } from 'playground-common/export';
 import { FC } from 'react';
 
 import { useGetMemberProfileOfMe } from '@/api/endpoint_LEGACY/hooks';
-import AuthRequired from '@/components/auth/AuthRequired';
 import Responsive from '@/components/common/Responsive';
 import Text from '@/components/common/Text';
 import { LoggingClick } from '@/components/eventLogger/components/LoggingClick';
@@ -37,7 +36,7 @@ const CompletePage: FC = () => {
     useOpenResolutionModal();
 
   return (
-    <AuthRequired>
+    <>
       {profile && (
         <StyledCompletePage>
           <Responsive only='desktop'>
@@ -74,7 +73,7 @@ const CompletePage: FC = () => {
           </ButtonWrapper>
         </StyledCompletePage>
       )}
-    </AuthRequired>
+    </>
   );
 };
 


### PR DESCRIPTION
### 🤫 쉿, 나한테만 말해줘요. 이슈넘버
- close #1373

### 🧐 어떤 것을 변경했어요~?
<!-- 실제로 변경한 사항을 설명해주세요.-->
해당페이지가 AuthRequired로 감싸지지 않아서 로그인 없이 접속했을 시 intro로 redirect되지 않는 문제를 발견하였습니다.


### 📸 스크린샷, 없으면 이것 참,, 섭섭한데요?

https://github.com/sopt-makers/sopt-playground-frontend/assets/55528304/d73118c7-a1f7-469b-88d0-23a6bf87fea7

