### PR TITLE
fix: 끝말잇기 이용규칙 디자인 수정

### DIFF
--- a/src/components/wordchain/WordchainRules.tsx
+++ b/src/components/wordchain/WordchainRules.tsx
@@ -70,5 +70,11 @@ const StyledTitle = styled(Text)`
 `;
 
 const StyledModal = styled(Modal)`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding: 30px;
+  min-height: 316px;
+
   /* TODO: 모바일 대응 */
 `;

--- a/src/components/wordchain/WordchainRules.tsx
+++ b/src/components/wordchain/WordchainRules.tsx
@@ -28,13 +28,20 @@ const WordchainRules: FC<WordchainRulesProps> = ({ trigger }) => {
         <MessageIcon />
         <StyledTitle>SOPT와 함께하는 끝말잇기</StyledTitle>
         <Content>
-          · 표준국어대사전에 있는 단어만 사용할 수 있어요. <br />
-          &nbsp;&nbsp;&nbsp;시작 단어에는 적용하지 않았어요 :) <br />
-          · 두 글자 이상 단어만 사용할 수 있어요. <br />
-          · 한 회차에서는 중복된 단어를 사용할 수 없어요. <br />
-          · 아무도 단어를 잇지 못하면 마지막 사람이 <br />
-          &nbsp;&nbsp;&nbsp;해당 회차 우승자가 되어 명예의 전당에 올라갈 수 있어요 💪🏻 <br />
-          · 두음법칙이 적용돼요. <br />
+          <StyledList>
+            <li>
+              표준국어대사전에 있는 단어만 사용할 수 있어요.
+              <br />
+              시작 단어에는 적용하지 않았어요 :)
+            </li>
+            <li>두 글자 이상 단어만 사용할 수 있어요.</li>
+            <li>한 회차에서는 중복된 단어를 사용할 수 없어요.</li>
+            <li>
+              아무도 단어를 잇지 못하면 마지막 사람이 <br />
+              해당 회차 우승자가 되어 명예의 전당에 올라갈 수 있어요 💪🏻
+            </li>
+            <li>두음법칙이 적용돼요.</li>
+          </StyledList>
         </Content>
       </StyledModal>
     </>
@@ -50,6 +57,7 @@ const StyledButton = styled.button`
 
 const Content = styled.div`
   margin-top: 24px;
+  padding-left: 10.8px;
   line-height: 130%;
 
   ${textStyles.SUIT_15_M};
@@ -77,4 +85,14 @@ const StyledModal = styled(Modal)`
   min-height: 316px;
 
   /* TODO: 모바일 대응 */
+`;
+
+const StyledList = styled.ul`
+  display: flex;
+  flex-direction: column;
+  gap: 5px;
+
+  li::marker {
+    content: '· ';
+  }
 `;

--- a/src/pages/members/complete.tsx
+++ b/src/pages/members/complete.tsx
@@ -5,6 +5,7 @@ import { playgroundLink } from 'playground-common/export';
 import { FC } from 'react';
 
 import { useGetMemberProfileOfMe } from '@/api/endpoint_LEGACY/hooks';
+import AuthRequired from '@/components/auth/AuthRequired';
 import Responsive from '@/components/common/Responsive';
 import Text from '@/components/common/Text';
 import { LoggingClick } from '@/components/eventLogger/components/LoggingClick';
@@ -36,7 +37,7 @@ const CompletePage: FC = () => {
     useOpenResolutionModal();
 
   return (
-    <>
+    <AuthRequired>
       {profile && (
         <StyledCompletePage>
           <Responsive only='desktop'>
@@ -73,7 +74,7 @@ const CompletePage: FC = () => {
           </ButtonWrapper>
         </StyledCompletePage>
       )}
-    </>
+    </AuthRequired>
   );
 };
 

--- a/src/pages/members/complete.tsx
+++ b/src/pages/members/complete.tsx
@@ -5,7 +5,6 @@ import { playgroundLink } from 'playground-common/export';
 import { FC } from 'react';
 
 import { useGetMemberProfileOfMe } from '@/api/endpoint_LEGACY/hooks';
-import AuthRequired from '@/components/auth/AuthRequired';
 import Responsive from '@/components/common/Responsive';
 import Text from '@/components/common/Text';
 import { LoggingClick } from '@/components/eventLogger/components/LoggingClick';
@@ -37,7 +36,7 @@ const CompletePage: FC = () => {
     useOpenResolutionModal();
 
   return (
-    <AuthRequired>
+    <>
       {profile && (
         <StyledCompletePage>
           <Responsive only='desktop'>
@@ -74,7 +73,7 @@ const CompletePage: FC = () => {
           </ButtonWrapper>
         </StyledCompletePage>
       )}
-    </AuthRequired>
+    </>
   );
 };
 


### PR DESCRIPTION
### 🤫 쉿, 나한테만 말해줘요. 이슈넘버
- close #1375

### 🧐 어떤 것을 변경했어요~?
<!-- 실제로 변경한 사항을 설명해주세요.-->
끝말잇기 이용규칙 디자인의 패딩 등을 올바르게 적용했습니다.

### 🤔 그렇다면, 어떻게 구현했어요~?
<!-- 실제로 구현한 로직에 대해 설명해주세요.-->

### ❤️‍🔥 당신이 생각하는 PR포인트, 내겐 매력포인트.
<!-- 해당 PR에서 논의가 필요한 사항을 적어주세요. -->

### 📸 스크린샷, 없으면 이것 참,, 섭섭한데요?
<img width="461" alt="스크린샷 2024-04-14 오전 1 34 20" src="https://github.com/sopt-makers/sopt-playground-frontend/assets/55528304/3a01688b-637d-418a-b9fe-a70fe682a9ee">
<img width="335" alt="스크린샷 2024-04-14 오전 1 34 29" src="https://github.com/sopt-makers/sopt-playground-frontend/assets/55528304/2876dd30-797c-4d24-9e2d-6bba660f68c5">
