### PR TITLE
feat: 익명프로필 구현하기

### DIFF
--- a/src/api/endpoint/feed/getComment.ts
+++ b/src/api/endpoint/feed/getComment.ts
@@ -40,6 +40,12 @@ export const getComment = createEndpoint({
       parentCommentId: z.number().nullable(),
       content: z.string(),
       isBlindWriter: z.boolean(),
+      anonymousProfile: z
+        .object({
+          nickname: z.string(),
+          profileImgUrl: z.string(),
+        })
+        .nullable(),
       isReported: z.boolean(),
       isMine: z.boolean(),
       createdAt: z.string(),

--- a/src/api/endpoint/feed/getPost.ts
+++ b/src/api/endpoint/feed/getPost.ts
@@ -9,6 +9,12 @@ export const getPost = createEndpoint({
     url: `api/v1/community/posts/${postId}`,
   }),
   serverResponseScheme: z.object({
+    anonymousProfile: z
+      .object({
+        nickname: z.string(),
+        profileImgUrl: z.string(),
+      })
+      .nullable(),
     member: z
       .object({
         id: z.number(),

--- a/src/api/endpoint/feed/getPosts.ts
+++ b/src/api/endpoint/feed/getPosts.ts
@@ -57,6 +57,12 @@ export const getPosts = createEndpoint({
         images: z.array(z.string()),
         isQuestion: z.boolean(),
         isBlindWriter: z.boolean(),
+        anonymousProfile: z
+          .object({
+            nickname: z.string(),
+            profileImgUrl: z.string(),
+          })
+          .nullable(),
         createdAt: z.string(),
         comments: z.array(
           z.object({

--- a/src/components/feed/detail/DetailFeedCard.tsx
+++ b/src/components/feed/detail/DetailFeedCard.tsx
@@ -384,33 +384,35 @@ const Comment = ({
     <StyledComment>
       <Flex css={{ gap: 8, minWidth: 0 }}>
         {isBlindWriter ? (
+          <CommentProfileImageBox>
+            <CommentProfileImage width={32} src={anonymousProfile?.profileImgUrl ?? ''} alt='profileImage' />
+          </CommentProfileImageBox>
+        ) : (
           <Link href={playgroundLink.memberDetail(memberId)}>
             <CommentProfileImageBox>
-              <CommentProfileImage width={32} src={anonymousProfile?.profileImgUrl ?? ''} alt='profileImage' />
+              {profileImage ? (
+                <CommentProfileImage width={32} src={profileImage} alt='anonymousProfileImage' />
+              ) : (
+                <div css={{ flexShrink: 0 }}>
+                  <IconMember />
+                </div>
+              )}
             </CommentProfileImageBox>
           </Link>
-        ) : profileImage == null ? (
-          <div css={{ flexShrink: 0 }}>
-            <IconMember />
-          </div>
-        ) : (
-          <CommentProfileImageBox>
-            <CommentProfileImage width={32} src={profileImage} alt='anonymousProfileImage' />
-          </CommentProfileImageBox>
         )}
         <Stack css={{ minWidth: 0, width: '100%' }} gutter={2}>
           <Flex justify='space-between'>
             <Stack.Horizontal gutter={2}>
-              {!isBlindWriter ? (
+              {isBlindWriter ? (
+                <Text typography='SUIT_14_SB' color={colors.gray10} css={{ whiteSpace: 'nowrap' }}>
+                  {anonymousProfile?.nickname}
+                </Text>
+              ) : (
                 <Link href={playgroundLink.memberDetail(memberId)}>
                   <Text typography='SUIT_14_SB' color={colors.gray10} css={{ whiteSpace: 'nowrap' }}>
                     {name}
                   </Text>
                 </Link>
-              ) : (
-                <Text typography='SUIT_14_SB' color={colors.gray10} css={{ whiteSpace: 'nowrap' }}>
-                  {anonymousProfile?.nickname}
-                </Text>
               )}
               {!isBlindWriter && (
                 <InfoText typography='SUIT_14_M' color={colors.gray400}>

--- a/src/components/feed/detail/DetailFeedCard.tsx
+++ b/src/components/feed/detail/DetailFeedCard.tsx
@@ -146,6 +146,7 @@ const StyledMain = styled(Flex)`
 type TopProps = { createdAt: string } & (
   | {
       isBlindWriter: true;
+      anonymousProfile: { nickname: string; profileImgUrl: string } | null;
       profileImage?: null;
       name?: null;
       info?: null;
@@ -153,6 +154,7 @@ type TopProps = { createdAt: string } & (
     }
   | {
       isBlindWriter: false;
+      anonymousProfile?: null;
       profileImage: string | null;
       name: string;
       info: string;
@@ -160,12 +162,18 @@ type TopProps = { createdAt: string } & (
     }
 );
 
-const Top = ({ isBlindWriter, profileImage, name, info, memberId, createdAt }: TopProps) => {
+const Top = ({ isBlindWriter, anonymousProfile, profileImage, name, info, memberId, createdAt }: TopProps) => {
   return (
     <Flex justify='space-between'>
       <Flex css={{ gap: 8 }}>
         {isBlindWriter || memberId == null ? (
-          <IconMember size={36} />
+          <ProfileImageBox css={{ height: 40 }}>
+            {anonymousProfile ? (
+              <ProfileImage width={40} src={anonymousProfile?.profileImgUrl} alt='anonymousProfileImage' />
+            ) : (
+              <IconMember size={40} />
+            )}
+          </ProfileImageBox>
         ) : (
           <Link href={playgroundLink.memberDetail(memberId)}>
             <ProfileImageBox css={{ height: 40 }}>
@@ -179,7 +187,7 @@ const Top = ({ isBlindWriter, profileImage, name, info, memberId, createdAt }: T
         )}
         <Stack.Vertical gutter={0} justify='center'>
           {isBlindWriter || memberId == null ? (
-            <Name color={colors.gray10}>익명</Name>
+            <Name color={colors.gray10}>{anonymousProfile?.nickname}</Name>
           ) : (
             <Link href={playgroundLink.memberDetail(memberId)}>
               <Name color={colors.gray10}>{name}</Name>

--- a/src/components/feed/detail/DetailFeedCard.tsx
+++ b/src/components/feed/detail/DetailFeedCard.tsx
@@ -143,10 +143,12 @@ const StyledMain = styled(Flex)`
   }
 `;
 
+type RandomProfile = { nickname: string; profileImgUrl: string };
+
 type TopProps = { createdAt: string } & (
   | {
       isBlindWriter: true;
-      anonymousProfile: { nickname: string; profileImgUrl: string } | null;
+      anonymousProfile: RandomProfile | null;
       profileImage?: null;
       name?: null;
       info?: null;
@@ -362,7 +364,7 @@ type CommentProps = {
   | {
       isBlindWriter: true;
       profileImage?: null;
-      anonymousProfile: { nickname: string; profileImgUrl: string } | null;
+      anonymousProfile: RandomProfile | null;
       info?: null;
       name?: null;
       memberId?: number;

--- a/src/components/feed/detail/DetailFeedCard.tsx
+++ b/src/components/feed/detail/DetailFeedCard.tsx
@@ -346,6 +346,7 @@ type CommentProps = {
   | {
       isBlindWriter: false;
       profileImage: string | null;
+      anonymousProfile?: null;
       info: string;
       name: string;
       memberId?: number;
@@ -353,6 +354,7 @@ type CommentProps = {
   | {
       isBlindWriter: true;
       profileImage?: null;
+      anonymousProfile: { nickname: string; profileImgUrl: string } | null;
       info?: null;
       name?: null;
       memberId?: number;
@@ -365,6 +367,7 @@ const Comment = ({
   info,
   comment,
   isBlindWriter,
+  anonymousProfile,
   createdAt,
   moreIcon,
   memberId = 0,
@@ -372,16 +375,20 @@ const Comment = ({
   return (
     <StyledComment>
       <Flex css={{ gap: 8, minWidth: 0 }}>
-        {isBlindWriter || profileImage == null ? (
+        {isBlindWriter ? (
+          <Link href={playgroundLink.memberDetail(memberId)}>
+            <CommentProfileImageBox>
+              <CommentProfileImage width={32} src={anonymousProfile?.profileImgUrl ?? ''} alt='profileImage' />
+            </CommentProfileImageBox>
+          </Link>
+        ) : profileImage == null ? (
           <div css={{ flexShrink: 0 }}>
             <IconMember />
           </div>
         ) : (
-          <Link href={playgroundLink.memberDetail(memberId)}>
-            <CommentProfileImageBox>
-              <CommentProfileImage width={32} src={profileImage} alt='profileImage' />
-            </CommentProfileImageBox>
-          </Link>
+          <CommentProfileImageBox>
+            <CommentProfileImage width={32} src={profileImage} alt='anonymousProfileImage' />
+          </CommentProfileImageBox>
         )}
         <Stack css={{ minWidth: 0, width: '100%' }} gutter={2}>
           <Flex justify='space-between'>
@@ -394,7 +401,7 @@ const Comment = ({
                 </Link>
               ) : (
                 <Text typography='SUIT_14_SB' color={colors.gray10} css={{ whiteSpace: 'nowrap' }}>
-                  익명
+                  {anonymousProfile?.nickname}
                 </Text>
               )}
               {!isBlindWriter && (

--- a/src/components/feed/detail/FeedDetailComments.tsx
+++ b/src/components/feed/detail/FeedDetailComments.tsx
@@ -31,6 +31,7 @@ const FeedDetailComments: FC<FeedDetailCommentsProps> = ({ postId }) => {
             key={comment.id}
             comment={comment.content}
             isBlindWriter={comment.isBlindWriter}
+            anonymousProfile={comment.anonymousProfile}
             createdAt={comment.createdAt}
             moreIcon={
               <FeedDropdown

--- a/src/components/feed/detail/FeedDetailContent.tsx
+++ b/src/components/feed/detail/FeedDetailContent.tsx
@@ -22,6 +22,7 @@ const FeedDetailContent: FC<FeedDetailContentProps> = ({ postId }) => {
       {postData.posts.isBlindWriter ? (
         <DetailFeedCard.Top
           isBlindWriter={postData.posts.isBlindWriter}
+          anonymousProfile={postData.anonymousProfile}
           createdAt={postData.posts.createdAt}
           memberId={null}
         />

--- a/src/components/feed/list/FeedCard.stories.tsx
+++ b/src/components/feed/list/FeedCard.stories.tsx
@@ -55,7 +55,7 @@ export const 기본 = () => {
     <FeedCard {...defaultProps}>
       <FeedCard.Comment>
         {COMMENTS.map((comment) => (
-          <FeedCard.CommentItem key={comment.id} name={comment.name} comment={comment.comment} isBlindWriter={false} />
+          <FeedCard.CommentItem key={comment.id} name={comment.name} comment={comment.comment} />
         ))}
       </FeedCard.Comment>
     </FeedCard>
@@ -67,7 +67,7 @@ export const 익명 = () => {
     <FeedCard {...defaultProps} isBlindWriter>
       <FeedCard.Comment>
         {COMMENTS.map((comment) => (
-          <FeedCard.CommentItem key={comment.id} name={comment.name} comment={comment.comment} isBlindWriter={false} />
+          <FeedCard.CommentItem key={comment.id} name={comment.name} comment={comment.comment} />
         ))}
       </FeedCard.Comment>
     </FeedCard>
@@ -100,7 +100,7 @@ export const 질문 = () => {
     >
       <FeedCard.Comment>
         {QURESTION_COMMENTS.map((comment) => (
-          <FeedCard.CommentItem key={comment.id} name={comment.name} comment={comment.comment} isBlindWriter={false} />
+          <FeedCard.CommentItem key={comment.id} name={comment.name} comment={comment.comment} />
         ))}
       </FeedCard.Comment>
     </FeedCard>
@@ -118,7 +118,7 @@ export const 댓글한개 = () => {
             comment: 'LGTM!',
           },
         ].map((comment) => (
-          <FeedCard.CommentItem key={comment.id} name={comment.name} comment={comment.comment} isBlindWriter={false} />
+          <FeedCard.CommentItem key={comment.id} name={comment.name} comment={comment.comment} />
         ))}
       </FeedCard.Comment>
     </FeedCard>
@@ -160,7 +160,7 @@ export const 이미지와함께 = () => {
       </FeedCard.Image>
       <FeedCard.Comment>
         {IMAGES_COMMENTS.map((comment) => (
-          <FeedCard.CommentItem key={comment.id} name={comment.name} comment={comment.comment} isBlindWriter={false} />
+          <FeedCard.CommentItem key={comment.id} name={comment.name} comment={comment.comment} />
         ))}
       </FeedCard.Comment>
     </FeedCard>
@@ -175,7 +175,7 @@ export const 제목겁나길때 = () => {
     >
       <FeedCard.Comment>
         {COMMENTS.map((comment) => (
-          <FeedCard.CommentItem key={comment.id} name={comment.name} comment={comment.comment} isBlindWriter={false} />
+          <FeedCard.CommentItem key={comment.id} name={comment.name} comment={comment.comment} />
         ))}
       </FeedCard.Comment>
     </FeedCard>
@@ -187,7 +187,7 @@ export const 제목없을때 = () => {
     <FeedCard {...defaultProps} title=''>
       <FeedCard.Comment>
         {COMMENTS.map((comment) => (
-          <FeedCard.CommentItem key={comment.id} name={comment.name} comment={comment.comment} isBlindWriter={false} />
+          <FeedCard.CommentItem key={comment.id} name={comment.name} comment={comment.comment} />
         ))}
       </FeedCard.Comment>
     </FeedCard>
@@ -205,7 +205,7 @@ export const 내용겁나길때 = () => {
     >
       <FeedCard.Comment>
         {COMMENTS.map((comment) => (
-          <FeedCard.CommentItem key={comment.id} name={comment.name} comment={comment.comment} isBlindWriter={false} />
+          <FeedCard.CommentItem key={comment.id} name={comment.name} comment={comment.comment} />
         ))}
       </FeedCard.Comment>
     </FeedCard>

--- a/src/components/feed/list/FeedCard.tsx
+++ b/src/components/feed/list/FeedCard.tsx
@@ -258,23 +258,13 @@ const StyledComment = styled(Flex)`
   white-space: nowrap;
 `;
 
-type CommentItemProps =
-  | { comment: string } & (
-      | {
-          name?: null;
-          isBlindWriter: true;
-        }
-      | {
-          name: string;
-          isBlindWriter: false;
-        }
-    );
+type CommentItemProps = { comment: string; name: string };
 
-const CommentItem = ({ name, comment, isBlindWriter }: CommentItemProps) => {
+const CommentItem = ({ name, comment }: CommentItemProps) => {
   return (
     <StyledCommentItem>
       <Text typography='SUIT_13_R' color={colors.gray10}>
-        {isBlindWriter ? '익명' : name}
+        {name}
       </Text>
       <Text typography='SUIT_13_R' color={colors.gray300}>
         <CommentWrapper>{comment}</CommentWrapper>

--- a/src/components/feed/list/FeedCard.tsx
+++ b/src/components/feed/list/FeedCard.tsx
@@ -21,6 +21,7 @@ interface BaseProps {
   content: string;
   createdAt: string;
   isBlindWriter?: boolean;
+  anonymousProfile: { nickname: string; profileImgUrl: string } | null;
   isQuestion?: boolean;
   commentLength: number;
   hits: number;
@@ -47,6 +48,7 @@ const Base = forwardRef<HTMLDivElement, PropsWithChildren<BaseProps>>(
       rightIcon,
       memberId,
       isShowInfo,
+      anonymousProfile,
       onClick,
     },
     ref,
@@ -63,9 +65,13 @@ const Base = forwardRef<HTMLDivElement, PropsWithChildren<BaseProps>>(
         onClick={onClick}
       >
         {isBlindWriter ? (
-          <div css={{ flexShrink: 0 }}>
-            <IconMember size={32} />
-          </div>
+          <ProfileImageBox>
+            {anonymousProfile ? (
+              <ProfileImage width={32} height={32} src={anonymousProfile?.profileImgUrl} alt='anonymousProfileImage' />
+            ) : (
+              <IconMember size={32} />
+            )}
+          </ProfileImageBox>
         ) : (
           <Link href={playgroundLink.memberDetail(memberId)} css={{ height: 'fit-content' }}>
             <ProfileImageBox>
@@ -83,7 +89,7 @@ const Base = forwardRef<HTMLDivElement, PropsWithChildren<BaseProps>>(
               {isBlindWriter ? (
                 <Top align='center'>
                   <Text typography='SUIT_14_SB' lineHeight={20}>
-                    익명
+                    {anonymousProfile?.nickname}
                   </Text>
                   <InfoText typography='SUIT_14_M' lineHeight={20} color={colors.gray300}>
                     {isShowInfo && info}

--- a/src/components/feed/list/FeedCard.tsx
+++ b/src/components/feed/list/FeedCard.tsx
@@ -13,6 +13,11 @@ import { playgroundLink } from '@/constants/links';
 import { MOBILE_MEDIA_QUERY } from '@/styles/mediaQuery';
 import { textStyles } from '@/styles/typography';
 
+interface RandomProfile {
+  nickname: string;
+  profileImgUrl: string;
+}
+
 interface BaseProps {
   profileImage: string | null;
   name: string;
@@ -21,7 +26,7 @@ interface BaseProps {
   content: string;
   createdAt: string;
   isBlindWriter?: boolean;
-  anonymousProfile?: { nickname: string; profileImgUrl: string } | null;
+  anonymousProfile?: RandomProfile | null;
   isQuestion?: boolean;
   commentLength: number;
   hits: number;

--- a/src/components/feed/list/FeedCard.tsx
+++ b/src/components/feed/list/FeedCard.tsx
@@ -21,7 +21,7 @@ interface BaseProps {
   content: string;
   createdAt: string;
   isBlindWriter?: boolean;
-  anonymousProfile: { nickname: string; profileImgUrl: string } | null;
+  anonymousProfile?: { nickname: string; profileImgUrl: string } | null;
   isQuestion?: boolean;
   commentLength: number;
   hits: number;

--- a/src/components/feed/list/FeedListItems.tsx
+++ b/src/components/feed/list/FeedListItems.tsx
@@ -111,7 +111,7 @@ const FeedListItems: FC<FeedListItemsProps> = ({ categoryId, renderFeedDetailLin
             children: (
               <FeedCard
                 onClick={() => setMap((map) => ({ ...map, [categoryId ?? '']: idx }))}
-                name={post.member?.name ?? '익명'}
+                name={post.member?.name ?? ''}
                 title={post.title}
                 content={post.content}
                 profileImage={post.member?.profileImage ?? null}
@@ -119,6 +119,7 @@ const FeedListItems: FC<FeedListItemsProps> = ({ categoryId, renderFeedDetailLin
                 commentLength={post.commentCount}
                 hits={post.hits}
                 isBlindWriter={post.isBlindWriter}
+                anonymousProfile={post.anonymousProfile}
                 isQuestion={post.isQuestion}
                 isShowInfo={categoryId === ''}
                 memberId={post.member?.id ?? 0}


### PR DESCRIPTION
### 🤫 쉿, 나한테만 말해줘요. 이슈넘버
- close #1383

### 🧐 어떤 것을 변경했어요~?
<!-- 실제로 변경한 사항을 설명해주세요.-->

- 커뮤니티 게시글, 댓글의 익명 프로필을 구현했어요.

### 🤔 그렇다면, 어떻게 구현했어요~?
<!-- 실제로 구현한 로직에 대해 설명해주세요.-->
- 기존 api에서 추가된 anonymousProfile의 타입을 추가하고, 익명과 기본프로필을 보내던 부분들을 anonymousProfile로 변경했어요.

### ❤️‍🔥 당신이 생각하는 PR포인트, 내겐 매력포인트.
<!-- 해당 PR에서 논의가 필요한 사항을 적어주세요. -->
- isBlindWriter가 true면 anonymousProfile값은 객체로 오고, isBlindWriter가 false면 anonymousProfile가 null로 오게됩니다. 그래서 이 부분을 zod에서부터 검증되게 하고 싶었어요. 
- 하지만! 아래와 같이 유니온(A타입 or B타입)을 만들고, object끼리 합치는 방식으로 구현을 하였는데, zod와 흘러가는 타입 자체는 문제가 없었으나, 현재 서버에서 내려주는 데이터들 중에 isBlindWriter가 true인데도, anonymousProfile가 null인 데이터들이 존재해요ㅠ 
```
const anonymous = z.union([
  z.object({
    isBlindWriter: z.literal(true),
    anonymousProfile: z.object({
      nickname: z.string(),
      profileImgUrl: z.string(),
    }),
  }),
  z.object({ isBlindWriter: z.literal(false), anonymousProfile: z.null() }),
]);
```
- 그래서 결국와 아래와  같이 타입을 짰고... 컴포넌트 안에서  anonymousProfile가 null인지 아닌지 검증해주었어요.
```
        isBlindWriter: z.boolean(),
        anonymousProfile: z
          .object({
            nickname: z.string(),
            profileImgUrl: z.string(),
          })
          .nullable(),
```

- 만약 데이터값들이 원하는대로(isBlindWriter가 true면 anonymousProfile값은 객체로 오고, isBlindWriter가 false면 anonymousProfile가 null로 오게) 오게된다면.. 타입을 좀 수정해보아야겠어요...!


### 📸 스크린샷, 없으면 이것 참,, 섭섭한데요?

<img width="1141" alt="스크린샷 2024-04-24 오전 12 12 53" src="https://github.com/sopt-makers/sopt-playground-frontend/assets/76681519/583f879c-1250-4e47-be2f-6b2dceddfecd">
