### PR TITLE
feat: 좋아요 클릭에 로깅 추가

### DIFF
--- a/src/components/eventLogger/events.ts
+++ b/src/components/eventLogger/events.ts
@@ -88,6 +88,13 @@ export interface ClickEvents {
     feedId: string;
   };
   feedUploadButton: undefined;
+  feedLike: {
+    feedId: string;
+  };
+  feedUnlike: {
+    feedId: string;
+  };
+
   //다짐메시지
   welcomeBannerResolution: {
     isAlreadySubmitted: boolean;

--- a/src/components/feed/list/FeedListItems.tsx
+++ b/src/components/feed/list/FeedListItems.tsx
@@ -206,22 +206,24 @@ const FeedListItems: FC<FeedListItemsProps> = ({ categoryId, renderFeedDetailLin
                   </FeedDropdown>
                 }
                 like={
-                  <FeedLike
-                    isLiked={post.isLiked}
-                    likes={post.likes}
-                    onClick={(e) => {
-                      e.stopPropagation();
-                      e.preventDefault();
-                      handleToggleLike({
-                        postId: post.id,
-                        isLiked: post.isLiked,
-                        likes: post.likes,
-                        allPostsQueryKey: useGetPostsInfiniteQuery.getKey(''),
-                        postsQueryKey: useGetPostsInfiniteQuery.getKey(post.categoryId.toString()),
-                        postQueryKey: getPost.cacheKey(post.id.toString()),
-                      });
-                    }}
-                  />
+                  <LoggingClick eventKey={post.isLiked ? 'feedUnlike' : 'feedLike'} param={{ feedId: String(post.id) }}>
+                    <FeedLike
+                      isLiked={post.isLiked}
+                      likes={post.likes}
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        e.preventDefault();
+                        handleToggleLike({
+                          postId: post.id,
+                          isLiked: post.isLiked,
+                          likes: post.likes,
+                          allPostsQueryKey: useGetPostsInfiniteQuery.getKey(''),
+                          postsQueryKey: useGetPostsInfiniteQuery.getKey(post.categoryId.toString()),
+                          postQueryKey: getPost.cacheKey(post.id.toString()),
+                        });
+                      }}
+                    />
+                  </LoggingClick>
                 }
               >
                 {post.images.length !== 0 && (


### PR DESCRIPTION
### 🤫 쉿, 나한테만 말해줘요. 이슈넘버
- close #1391

### 🧐 어떤 것을 변경했어요~?
<!-- 실제로 변경한 사항을 설명해주세요.-->
좋아요 클릭에 로깅을 추가했습니다.
좋아요 취소(FeedUnlike)와 좋아요(FeedLike)을 나누어 로깅했습니다.

### 🤔 그렇다면, 어떻게 구현했어요~?
<!-- 실제로 구현한 로직에 대해 설명해주세요.-->

### ❤️‍🔥 당신이 생각하는 PR포인트, 내겐 매력포인트.
<!-- 해당 PR에서 논의가 필요한 사항을 적어주세요. -->

### 📸 스크린샷, 없으면 이것 참,, 섭섭한데요?
<img width="451" alt="image" src="https://github.com/sopt-makers/sopt-playground-frontend/assets/55528304/3be2d9d7-6c6c-4300-8feb-42ec42a6ec41">
