### PR TITLE
fix: 게시글 및 댓글 생성날짜 null 예외처리

### DIFF
--- a/src/components/feed/detail/DetailFeedCard.tsx
+++ b/src/components/feed/detail/DetailFeedCard.tsx
@@ -206,7 +206,7 @@ const Top = ({ isBlindWriter, anonymousProfile, profileImage, name, info, member
       </Flex>
       <Flex align='center'>
         <Text typography='SUIT_14_M' color={colors.gray400}>
-          {getRelativeTime(createdAt)}
+          {createdAt && getRelativeTime(createdAt)}
         </Text>
       </Flex>
     </Flex>
@@ -428,7 +428,7 @@ const Comment = ({
             </Stack.Horizontal>
             <Flex>
               <Text typography='SUIT_14_M' color={colors.gray400} css={{ whiteSpace: 'nowrap' }}>
-                {getRelativeTime(createdAt)}
+                {createdAt && getRelativeTime(createdAt)}
               </Text>
               {moreIcon}
             </Flex>


### PR DESCRIPTION
### 🤫 쉿, 나한테만 말해줘요. 이슈넘버
- close #1397

### 🧐 어떤 것을 변경했어요~?
<!-- 실제로 변경한 사항을 설명해주세요.-->
게시글 및 댓글 생성날짜 (createdAt)의 렌더링에 대해 `createdAt &&` 조건부를 추가했어요.

### 🤔 그렇다면, 어떻게 구현했어요~?
<!-- 실제로 구현한 로직에 대해 설명해주세요.-->

### ❤️‍🔥 당신이 생각하는 PR포인트, 내겐 매력포인트.
<!-- 해당 PR에서 논의가 필요한 사항을 적어주세요. -->

### 📸 스크린샷, 없으면 이것 참,, 섭섭한데요?
