### PR TITLE
fix: 피드 레이아웃과 좋아요/댓글 텍스트 디자인 수정

### DIFF
--- a/src/components/feed/common/FeedLike.tsx
+++ b/src/components/feed/common/FeedLike.tsx
@@ -22,7 +22,7 @@ export const FeedLike = ({ isLiked, likes, onClick }: FeedLikeProps) => {
   return (
     <Flex align='center' css={[{ gap: '4px', cursor: 'pointer' }, hoverStyle]} onClick={onClick}>
       <IconHeart fill={isLiked ? undefined : 'none'} className='icon-heart-hover' />
-      <Text typography='SUIT_14_R' color={isLiked ? colors.error : colors.gray400}>{`좋아요 ${likes}`}</Text>
+      <Text typography='SUIT_14_SB' color={isLiked ? colors.error : colors.gray400}>{`좋아요 ${likes}`}</Text>
     </Flex>
   );
 };

--- a/src/components/feed/list/FeedCard.tsx
+++ b/src/components/feed/list/FeedCard.tsx
@@ -3,7 +3,7 @@ import styled from '@emotion/styled';
 import { colors } from '@sopt-makers/colors';
 import { Flex, Stack } from '@toss/emotion-utils';
 import Link from 'next/link';
-import { PropsWithChildren, ReactNode, forwardRef } from 'react';
+import { forwardRef, PropsWithChildren, ReactNode } from 'react';
 
 import HorizontalScroller from '@/components/common/HorizontalScroller';
 import ResizedImage from '@/components/common/ResizedImage';
@@ -120,12 +120,13 @@ const Base = forwardRef<HTMLDivElement, PropsWithChildren<BaseProps>>(
             </Flex>
             <Stack gutter={8}>
               {title && (
-                <Title typography='SUIT_17_SB'>
+                <Title typography='SUIT_17_SB' mr='28px'>
                   {isQuestion && <QuestionBadge>질문</QuestionBadge>}
                   {title}
                 </Title>
               )}
               <Text
+                mr='28px'
                 typography='SUIT_15_L'
                 color={colors.gray10}
                 lineHeight={22}

--- a/src/components/feed/list/FeedCard.tsx
+++ b/src/components/feed/list/FeedCard.tsx
@@ -142,7 +142,7 @@ const Base = forwardRef<HTMLDivElement, PropsWithChildren<BaseProps>>(
           {children}
           <Bottom gutter={2}>
             {like}
-            <Text typography='SUIT_14_R' mr='28px'>{`댓글 ${commentLength}개`}</Text>
+            <Text typography='SUIT_14_SB' mr='28px'>{`댓글 ${commentLength}개`}</Text>
           </Bottom>
         </Flex>
       </Flex>


### PR DESCRIPTION
### 🤫 쉿, 나한테만 말해줘요. 이슈넘버
- close #1401

### 🧐 어떤 것을 변경했어요~?
<!-- 실제로 변경한 사항을 설명해주세요.-->
- 게시글 텍스트 영역이 댓글 개수 표시 영역과 묶이도록 수정
- 좋아요, 댓글 텍스트를 mds에 맞게 디자인 수정

### 🤔 그렇다면, 어떻게 구현했어요~?
<!-- 실제로 구현한 로직에 대해 설명해주세요.-->

### ❤️‍🔥 당신이 생각하는 PR포인트, 내겐 매력포인트.
<!-- 해당 PR에서 논의가 필요한 사항을 적어주세요. -->

### 📸 스크린샷, 없으면 이것 참,, 섭섭한데요?
<img width="546" alt="image" src="https://github.com/sopt-makers/sopt-playground-frontend/assets/55528304/15b84650-6a2d-4a78-abbe-2959b05104ed">
<img width="544" alt="image" src="https://github.com/sopt-makers/sopt-playground-frontend/assets/55528304/e6bd593d-9a50-4353-a3de-714122a494f6">
