### PR TITLE
feat: 멤버 프로필 필터링 수정

### DIFF
--- a/src/api/endpoint/members/getMembersSearchByName.ts
+++ b/src/api/endpoint/members/getMembersSearchByName.ts
@@ -3,9 +3,9 @@ import { z } from 'zod';
 import { createEndpoint } from '@/api/typedAxios';
 
 export const getMembersSearchByName = createEndpoint({
-  request: (name: string) => ({
+  request: (cond: string) => ({
     method: 'GET',
-    url: `api/v1/members/search?name=${encodeURIComponent(name)}`,
+    url: `api/v1/members/search?cond=${encodeURIComponent(cond)}`,
   }),
   serverResponseScheme: z.array(
     z.object({

--- a/src/api/endpoint/members/getMembersSearchByName.ts
+++ b/src/api/endpoint/members/getMembersSearchByName.ts
@@ -3,9 +3,9 @@ import { z } from 'zod';
 import { createEndpoint } from '@/api/typedAxios';
 
 export const getMembersSearchByName = createEndpoint({
-  request: (cond: string) => ({
+  request: (search: string) => ({
     method: 'GET',
-    url: `api/v1/members/search?cond=${encodeURIComponent(cond)}`,
+    url: `api/v1/members/search?search=${encodeURIComponent(search)}`,
   }),
   serverResponseScheme: z.array(
     z.object({

--- a/src/components/eventLogger/events.ts
+++ b/src/components/eventLogger/events.ts
@@ -100,6 +100,9 @@ export interface ClickEvents {
     isAlreadySubmitted: boolean;
   };
   profileUploadResolution: undefined;
+
+  // 프로젝트 등록 후 공유하러 가기
+  clickProjectShare: undefined;
 }
 
 export interface SubmitEvents {

--- a/src/components/eventLogger/events.ts
+++ b/src/components/eventLogger/events.ts
@@ -43,8 +43,8 @@ export interface ClickEvents {
   filterMbti: {
     mbti: string;
   };
-  filterSojuCapacity: {
-    sojuCapacity: string;
+  filterWorking: {
+    working: string;
   };
   filterOrderBy: {
     orderBy: string;

--- a/src/components/eventLogger/events.ts
+++ b/src/components/eventLogger/events.ts
@@ -43,8 +43,8 @@ export interface ClickEvents {
   filterMbti: {
     mbti: string;
   };
-  filterWorking: {
-    working: string;
+  filterEmployed: {
+    employed: string;
   };
   filterOrderBy: {
     orderBy: string;

--- a/src/components/feed/list/FeedCard.tsx
+++ b/src/components/feed/list/FeedCard.tsx
@@ -62,7 +62,7 @@ const Base = forwardRef<HTMLDivElement, PropsWithChildren<BaseProps>>(
     },
     ref,
   ) => {
-    const isFor솝커톤 = postId === 196; //TODO : 솝커톤용 게시물 id로 변경
+    const isFor솝커톤 = postId === 388; //TODO : 솝커톤용 게시물 id로 변경
     return (
       <Flex
         ref={ref}

--- a/src/components/members/main/MemberCard/MessageButton.tsx
+++ b/src/components/members/main/MemberCard/MessageButton.tsx
@@ -1,6 +1,7 @@
 import styled from '@emotion/styled';
 import * as Tooltip from '@radix-ui/react-tooltip';
 import { colors } from '@sopt-makers/colors';
+import { fonts } from '@sopt-makers/fonts';
 import { FC, MouseEvent } from 'react';
 
 import IconMessage from '@/public/icons/icon-message.svg';
@@ -23,9 +24,9 @@ const MessageButton: FC<MessageButtonProps> = ({ className, name, onClick }) => 
         </Tooltip.Trigger>
         <Tooltip.Portal>
           <TooltipContent sideOffset={5}>
-            {name}님께 하고 싶은 말이 있다면,
+            {name}님이 궁금하시다면
             <br />
-            작성해 볼까요?
+            쪽지를 보내보세요!
             <TooltipArrow />
           </TooltipContent>
         </Tooltip.Portal>
@@ -58,19 +59,17 @@ const Button = styled.div`
 `;
 
 const TooltipContent = styled(Tooltip.Content)`
-  border-radius: 4px;
-  box-shadow: hsl(206deg 22% 7% / 35%) 0 10px 38px -10px, hsl(206deg 22% 7% / 20%) 0 10px 20px -15px;
-  background-color: ${colors.gray700};
-  padding: 17px 26px;
+  ${fonts.BODY_14_M};
+
+  border-radius: 14px;
+  background-color: ${colors.gray600};
+  padding: 10px 20px;
   animation-duration: 400ms;
   animation-timing-function: cubic-bezier(0.16, 1, 0.3, 1);
   text-align: center;
-  line-height: 1;
-  font-size: 15px;
+  color: ${colors.gray100};
   will-change: transform, opacity;
   user-select: none;
-
-  ${textStyles.SUIT_12_M}
 
   &[data-state='delayed-open'] {
     &[data-side='top'] {
@@ -108,5 +107,7 @@ const TooltipContent = styled(Tooltip.Content)`
 `;
 
 const TooltipArrow = styled(Tooltip.Arrow)`
-  fill: ${colors.gray700};
+  fill: ${colors.gray600};
+  width: 11px;
+  height: 11px;
 `;

--- a/src/components/members/main/MemberList/filters/MemberListFilter.tsx
+++ b/src/components/members/main/MemberList/filters/MemberListFilter.tsx
@@ -45,18 +45,19 @@ export function MemberListFilter<T extends string>({
 export default MemberListFilter;
 
 const StyledSelect = styled(Select)<{ selected: boolean }>`
-  transition: background-color 0.2s;
-  border-radius: 20px;
-  padding: 9px 26px 9px 22px;
-  min-width: 110px;
-
+  gap: 12px;
   ${({ selected }) =>
     selected &&
     css`
+      gap: 12px;
       border-color: ${colors.gray400};
       background-color: ${colors.gray800};
       color: ${colors.white};
     `};
+
+  transition: background-color 0.2s;
+  border-radius: 20px;
+  padding: 11px 16px;
 
   @media ${MOBILE_MEDIA_QUERY} {
     border-radius: 14px;

--- a/src/components/members/main/MemberList/filters/MemberListFilter.tsx
+++ b/src/components/members/main/MemberList/filters/MemberListFilter.tsx
@@ -45,7 +45,6 @@ export function MemberListFilter<T extends string>({
 export default MemberListFilter;
 
 const StyledSelect = styled(Select)<{ selected: boolean }>`
-  gap: 12px;
   ${({ selected }) =>
     selected &&
     css`
@@ -57,7 +56,8 @@ const StyledSelect = styled(Select)<{ selected: boolean }>`
 
   transition: background-color 0.2s;
   border-radius: 20px;
-  padding: 11px 16px;
+  padding: 9px 26px 9px 22px;
+  min-width: 110px;
 
   @media ${MOBILE_MEDIA_QUERY} {
     border-radius: 14px;

--- a/src/components/members/main/MemberList/filters/constants.ts
+++ b/src/components/members/main/MemberList/filters/constants.ts
@@ -24,7 +24,7 @@ export const PART_OPTIONS: Option[] = [
     value: '',
   },
   {
-    label: 'PM',
+    label: '기획',
     value: PART_VALUE.PM,
   },
   {
@@ -32,15 +32,15 @@ export const PART_OPTIONS: Option[] = [
     value: PART_VALUE.DESIGN,
   },
   {
-    label: 'WEB',
+    label: '웹',
     value: PART_VALUE.WEB,
   },
   {
-    label: 'SERVER',
+    label: '서버',
     value: PART_VALUE.SERVER,
   },
   {
-    label: 'Android',
+    label: '안드로이드',
     value: PART_VALUE.ANDROID,
   },
   {

--- a/src/components/members/main/MemberList/filters/constants.ts
+++ b/src/components/members/main/MemberList/filters/constants.ts
@@ -109,18 +109,18 @@ export const WORKING_OPTIONS: Option[] = [{ value: '1', label: '재직 중이에
 export const ORDER_OPTIONS: Option[] = [
   {
     value: '1',
-    label: '최근에 등록했순',
+    label: '최근등록순',
   },
   {
     value: '2',
-    label: '예전에 등록했순',
+    label: '예전등록순',
   },
   {
     value: '3',
-    label: '최근에 활동했순',
+    label: '최근활동순',
   },
   {
     value: '4',
-    label: '예전에 활동했순',
+    label: '예전활동순',
   },
 ];

--- a/src/components/members/main/MemberList/filters/constants.ts
+++ b/src/components/members/main/MemberList/filters/constants.ts
@@ -85,7 +85,7 @@ export const MBTI = [
   'ENTJ',
 ] as const;
 
-export const MBTI_OPTIONS: Option<typeof MBTI[number]>[] = [
+export const MBTI_OPTIONS: Option<(typeof MBTI)[number]>[] = [
   { value: 'ISTJ', label: 'ISTJ' },
   { value: 'ISFJ', label: 'ISFJ' },
   { value: 'INFJ', label: 'INFJ' },
@@ -104,15 +104,7 @@ export const MBTI_OPTIONS: Option<typeof MBTI[number]>[] = [
   { value: 'ENTJ', label: 'ENTJ' },
 ];
 
-export const SOJU_CAPACITY_OPTIONS: Option[] = [
-  { value: '0', label: '못마셔요' },
-  { value: '0.5', label: '0.5병' },
-  { value: '1', label: '1병' },
-  { value: '1.5', label: '1.5병' },
-  { value: '2', label: '2병' },
-  { value: '2.5', label: '2.5병' },
-  { value: '3', label: '3병 이상' },
-];
+export const WORKING_OPTIONS: Option[] = [{ value: '1', label: '재직 중이에요' }];
 
 export const ORDER_OPTIONS: Option[] = [
   {

--- a/src/components/members/main/MemberList/filters/constants.ts
+++ b/src/components/members/main/MemberList/filters/constants.ts
@@ -104,7 +104,7 @@ export const MBTI_OPTIONS: Option<(typeof MBTI)[number]>[] = [
   { value: 'ENTJ', label: 'ENTJ' },
 ];
 
-export const WORKING_OPTIONS: Option[] = [{ value: '1', label: '재직 중이에요' }];
+export const EMPLOYED_OPTIONS: Option[] = [{ value: '1', label: '재직 중이에요' }];
 
 export const ORDER_OPTIONS: Option[] = [
   {

--- a/src/components/members/main/MemberList/index.tsx
+++ b/src/components/members/main/MemberList/index.tsx
@@ -69,7 +69,7 @@ const MemberList: FC<MemberListProps> = ({ banner }) => {
   const [mbti, setMbti] = useState<string | undefined>(undefined);
   const [orderBy, setOrderBy] = useState<string>(ORDER_OPTIONS[0].value);
 
-  const [name, setName] = useState<string>('');
+  const [cond, setCond] = useState<string>('');
   const [messageModalState, setMessageModalState] = useState<MessageModalState>({ show: false });
 
   const router = useRouter();
@@ -108,15 +108,15 @@ const MemberList: FC<MemberListProps> = ({ banner }) => {
 
   useEffect(() => {
     if (router.isReady) {
-      const { generation, filter, name, working, team, mbti, orderBy } = router.query;
+      const { generation, filter, cond, working, team, mbti, orderBy } = router.query;
       if (typeof generation === 'string' || generation === undefined) {
         setGeneration(generation);
       }
       if (typeof filter === 'string' || filter === undefined) {
         setPart(filter);
       }
-      if (typeof name === 'string') {
-        setName(name);
+      if (typeof cond === 'string') {
+        setCond(cond);
       }
       if (typeof team === 'string' || team === undefined) {
         setTeam(team);
@@ -158,7 +158,7 @@ const MemberList: FC<MemberListProps> = ({ banner }) => {
     logClickEvent('filterOrderBy', { orderBy });
   };
   const handleSearch = (searchQuery: string) => {
-    addQueryParamsToUrl({ name: searchQuery });
+    addQueryParamsToUrl({ cond: searchQuery });
     logSubmitEvent('searchMember', { content: 'searchQuery' });
   };
   const handleClickCard = (profile: Profile) => {
@@ -177,8 +177,8 @@ const MemberList: FC<MemberListProps> = ({ banner }) => {
         <Responsive only='mobile' css={{ marginTop: '40px' }}>
           <StyledMemberSearch
             placeholder='이름, 학교, 회사를 검색해보세요!'
-            value={name}
-            onChange={setName}
+            value={cond}
+            onChange={setCond}
             onSearch={handleSearch}
           />
           <StyledMobileFilterWrapper>
@@ -352,8 +352,8 @@ const MemberList: FC<MemberListProps> = ({ banner }) => {
                 </StyledFilterWrapper>
                 <StyledMemberSearch
                   placeholder='이름, 학교, 회사를 검색해보세요!'
-                  value={name}
-                  onChange={setName}
+                  value={cond}
+                  onChange={setCond}
                   onSearch={handleSearch}
                 />
               </div>

--- a/src/components/members/main/MemberList/index.tsx
+++ b/src/components/members/main/MemberList/index.tsx
@@ -17,6 +17,7 @@ import { DESKTOP_ONE_MEDIA_QUERY, DESKTOP_TWO_MEDIA_QUERY } from '@/components/m
 import { useMemberProfileQuery } from '@/components/members/main/hooks/useMemberProfileQuery';
 import MemberCard from '@/components/members/main/MemberCard';
 import {
+  EMPLOYED_OPTIONS,
   FILTER_DEFAULT_OPTION,
   GENERATION_DEFAULT_OPTION,
   GENERATION_OPTIONS,
@@ -24,7 +25,6 @@ import {
   ORDER_OPTIONS,
   PART_OPTIONS,
   TEAM_OPTIONS,
-  WORKING_OPTIONS,
 } from '@/components/members/main/MemberList/filters/constants';
 import MemberListFilter from '@/components/members/main/MemberList/filters/MemberListFilter';
 import MemberSearch from '@/components/members/main/MemberList/MemberSearch';
@@ -64,7 +64,7 @@ type MessageModalState =
 const MemberList: FC<MemberListProps> = ({ banner }) => {
   const [generation, setGeneration] = useState<string | undefined>(undefined);
   const [part, setPart] = useState<string | undefined>(undefined);
-  const [working, setWorking] = useState<string | undefined>(undefined);
+  const [employed, setEmployed] = useState<string | undefined>(undefined);
   const [team, setTeam] = useState<string | undefined>(undefined);
   const [mbti, setMbti] = useState<string | undefined>(undefined);
   const [orderBy, setOrderBy] = useState<string>(ORDER_OPTIONS[0].value);
@@ -108,7 +108,7 @@ const MemberList: FC<MemberListProps> = ({ banner }) => {
 
   useEffect(() => {
     if (router.isReady) {
-      const { generation, filter, cond, working, team, mbti, orderBy } = router.query;
+      const { generation, filter, cond, employed, team, mbti, orderBy } = router.query;
       if (typeof generation === 'string' || generation === undefined) {
         setGeneration(generation);
       }
@@ -124,8 +124,8 @@ const MemberList: FC<MemberListProps> = ({ banner }) => {
       if (typeof mbti === 'string' || mbti === undefined) {
         setMbti(mbti);
       }
-      if (typeof working === 'string' || working === undefined) {
-        setWorking(working);
+      if (typeof employed === 'string' || employed === undefined) {
+        setEmployed(employed);
       }
       if (typeof orderBy === 'string') {
         setOrderBy(orderBy);
@@ -135,23 +135,23 @@ const MemberList: FC<MemberListProps> = ({ banner }) => {
 
   const handleSelectPart = (filter: string) => {
     addQueryParamsToUrl({ filter });
-    logClickEvent('filterPart', { part: filter });
+    logClickEvent('filterPart', { part: filter || 'all' });
   };
-  const handleSelectGeneration = (generation: string | undefined) => {
+  const handleSelectGeneration = (generation: string) => {
     addQueryParamsToUrl({ generation });
-    logClickEvent('filterGeneration', { generation: generation ?? 'all' });
+    logClickEvent('filterGeneration', { generation: generation || 'all' });
   };
   const handleSelectTeam = (team: string) => {
     addQueryParamsToUrl({ team });
-    logClickEvent('filterTeam', { team });
+    logClickEvent('filterTeam', { team: team || 'all' });
   };
   const handleSelectMbti = (mbti: string) => {
     addQueryParamsToUrl({ mbti });
-    logClickEvent('filterMbti', { mbti });
+    logClickEvent('filterMbti', { mbti: mbti || 'all' });
   };
-  const handleSelectWorking = (working: string) => {
-    addQueryParamsToUrl({ working });
-    logClickEvent('filterWorking', { working });
+  const handleSelectEmployed = (employed: string) => {
+    addQueryParamsToUrl({ employed });
+    logClickEvent('filterEmployed', { employed: employed || 'all' });
   };
   const handleSelectOrderBy = (orderBy: string) => {
     addQueryParamsToUrl({ orderBy });
@@ -236,11 +236,11 @@ const MemberList: FC<MemberListProps> = ({ banner }) => {
             <StyledMobileFilter
               placeholder='재직 상태'
               defaultOption={FILTER_DEFAULT_OPTION}
-              options={WORKING_OPTIONS}
-              value={working}
-              onChange={handleSelectWorking}
+              options={EMPLOYED_OPTIONS}
+              value={employed}
+              onChange={handleSelectEmployed}
               trigger={(placeholder) => (
-                <MobileFilterTrigger selected={Boolean(working)}>
+                <MobileFilterTrigger selected={Boolean(employed)}>
                   {placeholder}
                   <IconExpand />
                 </MobileFilterTrigger>
@@ -345,9 +345,9 @@ const MemberList: FC<MemberListProps> = ({ banner }) => {
                   <MemberListFilter
                     placeholder='재직 상태'
                     defaultOption={FILTER_DEFAULT_OPTION}
-                    options={WORKING_OPTIONS}
-                    value={working}
-                    onChange={handleSelectWorking}
+                    options={EMPLOYED_OPTIONS}
+                    value={employed}
+                    onChange={handleSelectEmployed}
                   />
                 </StyledFilterWrapper>
                 <StyledMemberSearch

--- a/src/components/members/main/MemberList/index.tsx
+++ b/src/components/members/main/MemberList/index.tsx
@@ -69,7 +69,7 @@ const MemberList: FC<MemberListProps> = ({ banner }) => {
   const [mbti, setMbti] = useState<string | undefined>(undefined);
   const [orderBy, setOrderBy] = useState<string>(ORDER_OPTIONS[0].value);
 
-  const [cond, setCond] = useState<string>('');
+  const [search, setSearch] = useState<string>('');
   const [messageModalState, setMessageModalState] = useState<MessageModalState>({ show: false });
 
   const router = useRouter();
@@ -108,15 +108,15 @@ const MemberList: FC<MemberListProps> = ({ banner }) => {
 
   useEffect(() => {
     if (router.isReady) {
-      const { generation, filter, cond, employed, team, mbti, orderBy } = router.query;
+      const { generation, filter, search, employed, team, mbti, orderBy } = router.query;
       if (typeof generation === 'string' || generation === undefined) {
         setGeneration(generation);
       }
       if (typeof filter === 'string' || filter === undefined) {
         setPart(filter);
       }
-      if (typeof cond === 'string') {
-        setCond(cond);
+      if (typeof search === 'string') {
+        setSearch(search);
       }
       if (typeof team === 'string' || team === undefined) {
         setTeam(team);
@@ -158,7 +158,7 @@ const MemberList: FC<MemberListProps> = ({ banner }) => {
     logClickEvent('filterOrderBy', { orderBy });
   };
   const handleSearch = (searchQuery: string) => {
-    addQueryParamsToUrl({ cond: searchQuery });
+    addQueryParamsToUrl({ search: searchQuery });
     logSubmitEvent('searchMember', { content: 'searchQuery' });
   };
   const handleClickCard = (profile: Profile) => {
@@ -177,8 +177,8 @@ const MemberList: FC<MemberListProps> = ({ banner }) => {
         <Responsive only='mobile' css={{ marginTop: '40px' }}>
           <StyledMemberSearch
             placeholder='이름, 학교, 회사를 검색해보세요!'
-            value={cond}
-            onChange={setCond}
+            value={search}
+            onChange={setSearch}
             onSearch={handleSearch}
           />
           <StyledMobileFilterWrapper>
@@ -352,8 +352,8 @@ const MemberList: FC<MemberListProps> = ({ banner }) => {
                 </StyledFilterWrapper>
                 <StyledMemberSearch
                   placeholder='이름, 학교, 회사를 검색해보세요!'
-                  value={cond}
-                  onChange={setCond}
+                  value={search}
+                  onChange={setSearch}
                   onSearch={handleSearch}
                 />
               </div>

--- a/src/components/members/main/MemberList/index.tsx
+++ b/src/components/members/main/MemberList/index.tsx
@@ -175,7 +175,12 @@ const MemberList: FC<MemberListProps> = ({ banner }) => {
       >
         <Responsive only='mobile'>{banner}</Responsive>
         <Responsive only='mobile' css={{ marginTop: '40px' }}>
-          <StyledMemberSearch placeholder='멤버 검색' value={name} onChange={setName} onSearch={handleSearch} />
+          <StyledMemberSearch
+            placeholder='이름, 학교, 회사를 검색해보세요!'
+            value={name}
+            onChange={setName}
+            onSearch={handleSearch}
+          />
           <StyledMobileFilterWrapper>
             <StyledMobileFilter
               value={generation}
@@ -345,7 +350,12 @@ const MemberList: FC<MemberListProps> = ({ banner }) => {
                     onChange={handleSelectWorking}
                   />
                 </StyledFilterWrapper>
-                <StyledMemberSearch placeholder='멤버 검색' value={name} onChange={setName} onSearch={handleSearch} />
+                <StyledMemberSearch
+                  placeholder='이름, 학교, 회사를 검색해보세요!'
+                  value={name}
+                  onChange={setName}
+                  onSearch={handleSearch}
+                />
               </div>
               {memberProfileData && (
                 <div
@@ -524,6 +534,7 @@ const StyledMakersLink = styled.div`
 `;
 
 const StyledMemberSearch = styled(MemberSearch)`
+  min-width: 335px;
   @media ${DESKTOP_TWO_MEDIA_QUERY} {
     grid-area: 'search';
     order: 1;

--- a/src/components/members/main/MemberList/index.tsx
+++ b/src/components/members/main/MemberList/index.tsx
@@ -23,8 +23,8 @@ import {
   MBTI_OPTIONS,
   ORDER_OPTIONS,
   PART_OPTIONS,
-  SOJU_CAPACITY_OPTIONS,
   TEAM_OPTIONS,
+  WORKING_OPTIONS,
 } from '@/components/members/main/MemberList/filters/constants';
 import MemberListFilter from '@/components/members/main/MemberList/filters/MemberListFilter';
 import MemberSearch from '@/components/members/main/MemberList/MemberSearch';
@@ -64,7 +64,7 @@ type MessageModalState =
 const MemberList: FC<MemberListProps> = ({ banner }) => {
   const [generation, setGeneration] = useState<string | undefined>(undefined);
   const [part, setPart] = useState<string | undefined>(undefined);
-  const [sojuCapacity, setSojuCapacity] = useState<string | undefined>(undefined);
+  const [working, setWorking] = useState<string | undefined>(undefined);
   const [team, setTeam] = useState<string | undefined>(undefined);
   const [mbti, setMbti] = useState<string | undefined>(undefined);
   const [orderBy, setOrderBy] = useState<string>(ORDER_OPTIONS[0].value);
@@ -108,7 +108,7 @@ const MemberList: FC<MemberListProps> = ({ banner }) => {
 
   useEffect(() => {
     if (router.isReady) {
-      const { generation, filter, name, sojuCapacity, team, mbti, orderBy } = router.query;
+      const { generation, filter, name, working, team, mbti, orderBy } = router.query;
       if (typeof generation === 'string' || generation === undefined) {
         setGeneration(generation);
       }
@@ -124,8 +124,8 @@ const MemberList: FC<MemberListProps> = ({ banner }) => {
       if (typeof mbti === 'string' || mbti === undefined) {
         setMbti(mbti);
       }
-      if (typeof sojuCapacity === 'string' || sojuCapacity === undefined) {
-        setSojuCapacity(sojuCapacity);
+      if (typeof working === 'string' || working === undefined) {
+        setWorking(working);
       }
       if (typeof orderBy === 'string') {
         setOrderBy(orderBy);
@@ -149,9 +149,9 @@ const MemberList: FC<MemberListProps> = ({ banner }) => {
     addQueryParamsToUrl({ mbti });
     logClickEvent('filterMbti', { mbti });
   };
-  const handleSelectSojuCapacity = (sojuCapacity: string) => {
-    addQueryParamsToUrl({ sojuCapacity });
-    logClickEvent('filterSojuCapacity', { sojuCapacity });
+  const handleSelectWorking = (working: string) => {
+    addQueryParamsToUrl({ working });
+    logClickEvent('filterWorking', { working });
   };
   const handleSelectOrderBy = (orderBy: string) => {
     addQueryParamsToUrl({ orderBy });
@@ -229,13 +229,13 @@ const MemberList: FC<MemberListProps> = ({ banner }) => {
               )}
             />
             <StyledMobileFilter
-              placeholder='주량'
+              placeholder='재직 상태'
               defaultOption={FILTER_DEFAULT_OPTION}
-              options={SOJU_CAPACITY_OPTIONS}
-              value={sojuCapacity}
-              onChange={handleSelectSojuCapacity}
+              options={WORKING_OPTIONS}
+              value={working}
+              onChange={handleSelectWorking}
               trigger={(placeholder) => (
-                <MobileFilterTrigger selected={Boolean(sojuCapacity)}>
+                <MobileFilterTrigger selected={Boolean(working)}>
                   {placeholder}
                   <IconExpand />
                 </MobileFilterTrigger>
@@ -338,11 +338,11 @@ const MemberList: FC<MemberListProps> = ({ banner }) => {
                     onChange={handleSelectMbti}
                   />
                   <MemberListFilter
-                    placeholder='주량'
+                    placeholder='재직 상태'
                     defaultOption={FILTER_DEFAULT_OPTION}
-                    options={SOJU_CAPACITY_OPTIONS}
-                    value={sojuCapacity}
-                    onChange={handleSelectSojuCapacity}
+                    options={WORKING_OPTIONS}
+                    value={working}
+                    onChange={handleSelectWorking}
                   />
                 </StyledFilterWrapper>
                 <StyledMemberSearch placeholder='멤버 검색' value={name} onChange={setName} onSearch={handleSearch} />

--- a/src/components/projects/upload/hooks/useGetMembersByNameQuery.ts
+++ b/src/components/projects/upload/hooks/useGetMembersByNameQuery.ts
@@ -1,6 +1,7 @@
 import { keepPreviousData, useQuery } from '@tanstack/react-query';
 
 import { getMembersSearchByName } from '@/api/endpoint/members/getMembersSearchByName';
+
 interface GetMembersByNameQueryVariables {
   name: string;
 }

--- a/src/pages/projects/upload/index.tsx
+++ b/src/pages/projects/upload/index.tsx
@@ -22,7 +22,7 @@ const ProjectUploadPage = () => {
   const router = useRouter();
   const slideUp = useSlideUp();
   const queryClient = useQueryClient();
-  const { logSubmitEvent } = useEventLogger();
+  const { logSubmitEvent, logClickEvent } = useEventLogger();
   const { confirm } = useConfirm();
 
   const handleSubmit = async (formData: ProjectFormType) => {
@@ -44,6 +44,7 @@ const ProjectUploadPage = () => {
             message: '프로젝트를 하면서 배우고 느낀 점을 SOPT 회원들에게 공유해보세요.',
             buttonText: '공유하러 가기',
             action: async () => {
+              logClickEvent('clickProjectShare');
               slideUp.close();
               await router.push(playgroundLink.feedUpload());
             },


### PR DESCRIPTION
### 🤫 쉿, 나한테만 말해줘요. 이슈넘버
- close #1414

### 🧐 어떤 것을 변경했어요~?
<!-- 실제로 변경한 사항을 설명해주세요.-->
- 기존 이름 검색을 이름, 학교, 회사 검색으로 변경
- 주량 필터링 제거하고 재직 상태 필터링 추가
- UX라이팅 변경(정렬 필터, 파트 네이밍, 쪽지 버튼 호버 툴팁)

### 🤔 그렇다면, 어떻게 구현했어요~?
<!-- 실제로 구현한 로직에 대해 설명해주세요.-->
#### 재직 상태 필터링
재직 상태를 검색하는 employed=1 파라미터를 추가하였습니다

#### 이름, 학교, 회사 검색
기존에 이름을 검색하던 name 파라미터의 명칭을 cond로 변경하였습니다

### ❤️‍🔥 당신이 생각하는 PR포인트, 내겐 매력포인트.
<!-- 해당 PR에서 논의가 필요한 사항을 적어주세요. -->
피그마는 mds로 디자인이 구현되어 있는데, 다음에 한번에 바꾸는게 나을 것 같아서
다른 사용처에서 문제 안생길 정도로 최소한의 것만 수정하였습니다.

+ 셀렉트 컴포넌트에서 문제가 발견되어서 열심히 파헤쳐보고있습니당...
1. 옵션을 선택한 다음에
2. '전체' 옵션을 누르고
3. 1번에서 누른 옵션을 다시 누르면 적용이 안되는 문제예요 ㅜㅜ

### 📸 스크린샷, 없으면 이것 참,, 섭섭한데요?

https://github.com/sopt-makers/sopt-playground-frontend/assets/55528304/aa011da7-7eeb-48e9-8a58-4307918305d4

