### PR TITLE
fix: 멤버 프로필 필터링 오류 해결

### DIFF
--- a/src/components/members/common/select/Select.tsx
+++ b/src/components/members/common/select/Select.tsx
@@ -54,7 +54,7 @@ const SelectRoot: FC<PropsWithChildren<SelectProps>> = ({
         <StyledWrapper allowClear={allowClear && hasValue}>
           <Select.Trigger className={className} asChild>
             <StyledTrigger error={error}>
-              {props.value === undefined ? placeholder : label}
+              {!props.value ? placeholder : label}
               <StyledIconArrow className='icon-arrow'>
                 <IconSelectArrow width={18} height={18} alt='select-arrow-icon' />
               </StyledIconArrow>

--- a/src/components/members/main/MemberList/index.tsx
+++ b/src/components/members/main/MemberList/index.tsx
@@ -312,19 +312,19 @@ const MemberList: FC<MemberListProps> = ({ banner }) => {
                     placeholder='기수'
                     defaultOption={GENERATION_DEFAULT_OPTION}
                     options={GENERATION_OPTIONS}
-                    value={generation}
+                    value={generation ?? ''}
                     onChange={handleSelectGeneration}
                   />
                   <MemberListFilter
                     placeholder='파트'
-                    value={part}
+                    value={part ?? ''}
                     onChange={handleSelectPart}
                     options={PART_OPTIONS}
                   />
                   <MemberListFilter
                     placeholder='활동'
                     options={TEAM_OPTIONS}
-                    value={team}
+                    value={team ?? ''}
                     onChange={handleSelectTeam}
                     defaultOption={FILTER_DEFAULT_OPTION}
                   >
@@ -339,14 +339,14 @@ const MemberList: FC<MemberListProps> = ({ banner }) => {
                     placeholder='MBTI'
                     defaultOption={FILTER_DEFAULT_OPTION}
                     options={MBTI_OPTIONS}
-                    value={mbti}
+                    value={mbti ?? ''}
                     onChange={handleSelectMbti}
                   />
                   <MemberListFilter
                     placeholder='재직 상태'
                     defaultOption={FILTER_DEFAULT_OPTION}
                     options={EMPLOYED_OPTIONS}
-                    value={employed}
+                    value={employed ?? ''}
                     onChange={handleSelectEmployed}
                   />
                 </StyledFilterWrapper>


### PR DESCRIPTION
### 🤫 쉿, 나한테만 말해줘요. 이슈넘버
- close #1421

### 🧐 어떤 것을 변경했어요~?
<!-- 실제로 변경한 사항을 설명해주세요.-->

https://github.com/sopt-makers/sopt-playground-frontend/assets/55528304/711c378d-2f47-4ace-a26d-e0a1ffd647ed




멤버 목록을 필터링 할 때 발생하는 문제점이 있었습니다.
영상에서 보시다시피
1. 특정 값을 선택하고(ex. `34기`)
2. `전체 기수`를 선택한 뒤
3. 다시 특정 값(ex. `34기`)을 선택하면 → ⚠️ **아무런 동작도 발생하지 않습니다**
한번 더 `전체 기수`를 선택하고 다시 `34기`를 선택해야만 합니다.

기존에는 이런식으로 동작시키는게 흔치 않아서 그대로 남아있었던 것 같은데,
셀렉트 옵션이 '재직 중이에요' 1개 뿐인 재직 상태 필터링을 추가하면서 버그를 고쳐야겠다는 생각이 들었습니다!

### 🤔 그렇다면, 어떻게 구현했어요~?
<!-- 실제로 구현한 로직에 대해 설명해주세요.-->
기존에, 전체 기수를 비롯한 모든 필터링 박스의 '전체' 옵션을 누르면 해당 셀렉트 박스의 value로 undefined가 넘어가는 것을 확인했습니다.
그러나 undefined로 넘기면 위와 같이 비정상적인 동작이 발생해서, undefined 대신 빈 문자열('')을 넘김으로써 해결했습니다.

+ 문제의 원인을 좀더 알아보고있습니다

### ❤️‍🔥 당신이 생각하는 PR포인트, 내겐 매력포인트.
<!-- 해당 PR에서 논의가 필요한 사항을 적어주세요. -->

### 📸 스크린샷, 없으면 이것 참,, 섭섭한데요?

https://github.com/sopt-makers/sopt-playground-frontend/assets/55528304/02cd2683-624a-4438-b8a4-91ca84a54db4

해결완룡!!! 