### PR TITLE
feat: 카카오톡 채팅 기능 추가

### DIFF
--- a/src/components/common/Footer/index.tsx
+++ b/src/components/common/Footer/index.tsx
@@ -6,7 +6,8 @@ import { useRouter } from 'next/router';
 import { FC } from 'react';
 
 import useEventLogger from '@/components/eventLogger/hooks/useEventLogger';
-import { FEEDBACK_FORM_URL, MAKERS_TEAM_URL, playgroundLink } from '@/constants/links';
+import { MAKERS_TEAM_URL, playgroundLink } from '@/constants/links';
+import useKakao from '@/hooks/useKakao';
 import useScroll from '@/hooks/useScroll';
 import { MOBILE_MEDIA_QUERY } from '@/styles/mediaQuery';
 import { zIndex } from '@/styles/zIndex';
@@ -19,6 +20,7 @@ const Footer: FC<FooterProps> = ({}) => {
   const { isScrollingDown, isScrollTop } = useScroll();
   const { logClickEvent } = useEventLogger();
   const { pathname } = useRouter();
+  const { handleKakaoChat } = useKakao();
 
   return (
     <StyledFooter hide={isScrollingDown && !isScrollTop}>
@@ -30,9 +32,9 @@ const Footer: FC<FooterProps> = ({}) => {
       <FooterLink href={MAKERS_TEAM_URL} target='_blank'>
         메이커스 소개
       </FooterLink>
-      <FooterLink href={FEEDBACK_FORM_URL} target='_blank'>
+      <FooterButton type='button' onClick={handleKakaoChat}>
         의견 제안하기
-      </FooterLink>
+      </FooterButton>
     </StyledFooter>
   );
 };
@@ -63,6 +65,19 @@ const StyledFooter = styled.div<{ hide: boolean }>`
 `;
 
 const FooterLink = styled.a<{ highlight?: boolean }>`
+  padding: 17px 10px;
+
+  ${(props) =>
+    props.highlight
+      ? css`
+          color: ${colors.white};
+        `
+      : css`
+          color: ${colors.gray200};
+        `}
+`;
+
+const FooterButton = styled.button<{ highlight?: boolean }>`
   padding: 17px 10px;
 
   ${(props) =>

--- a/src/components/common/Header/mobile/MobileSideBar.tsx
+++ b/src/components/common/Header/mobile/MobileSideBar.tsx
@@ -7,7 +7,8 @@ import { FC, ReactNode, useState } from 'react';
 import { DEFAULT_PROFILE_IMAGE_MOBILE_SVG, RIGHT_ARROW_SVG } from '@/components/common/Header/imageData';
 import { LinkRenderer, PathMatcher } from '@/components/common/Header/types';
 import ResizedImage from '@/components/common/ResizedImage';
-import { FEEDBACK_FORM_URL, MAKERS_TEAM_URL, playgroundLink } from '@/constants/links';
+import { MAKERS_TEAM_URL, playgroundLink } from '@/constants/links';
+import useKakao from '@/hooks/useKakao';
 import { textStyles } from '@/styles/typography';
 
 const DialogPortal = dynamic<Dialog.DialogPortalProps>(
@@ -37,6 +38,7 @@ const MobileSideBar: FC<MobileSideBarProps> = ({
   activePathMatcher,
 }) => {
   const [open, setOpen] = useState(false);
+  const { handleKakaoChat } = useKakao();
 
   function close() {
     setOpen(false);
@@ -114,9 +116,7 @@ const MobileSideBar: FC<MobileSideBarProps> = ({
             <a href={MAKERS_TEAM_URL} target='_blank' rel='noreferrer'>
               <NavLinkSmall onClick={close}>메이커스 소개</NavLinkSmall>
             </a>
-            <a href={FEEDBACK_FORM_URL} target='_blank' rel='noreferrer'>
-              <NavLinkSmall onClick={close}>의견 제안하기</NavLinkSmall>
-            </a>
+            <NavLinkSmall onClick={handleKakaoChat}>의견 제안하기</NavLinkSmall>
             <NavLinkSmall
               onClick={() => {
                 onLogout?.();

--- a/src/components/common/KakaoScript/index.tsx
+++ b/src/components/common/KakaoScript/index.tsx
@@ -1,0 +1,33 @@
+import Script from 'next/script';
+import { useEffect } from 'react';
+
+export default function KakaoScript() {
+  useEffect(() => {
+    const initializeKakao = () => {
+      if (window.Kakao && !window.Kakao.isInitialized()) {
+        window.Kakao.init(process.env.NEXT_PUBLIC_KAKAO_APP_KEY);
+        console.log('Kakao SDK initialized');
+      }
+    };
+
+    if (document.readyState === 'complete') {
+      initializeKakao();
+    } else {
+      window.addEventListener('load', initializeKakao);
+      return () => window.removeEventListener('load', initializeKakao);
+    }
+  }, []);
+
+  const handleAddChannel = () => {
+    console.debug('Kakao SDK script loaded');
+  };
+
+  return (
+    <Script
+      src='https://t1.kakaocdn.net/kakao_js_sdk/2.7.1/kakao.min.js'
+      integrity='sha384-kDljxUXHaJ9xAb2AzRd59KxjrFjzHa5TAoFQ6GbYTCAG0bjM55XohjjDT7tDDC01'
+      crossOrigin='anonymous'
+      onLoad={handleAddChannel}
+    />
+  );
+}

--- a/src/components/common/KakaoScript/index.tsx
+++ b/src/components/common/KakaoScript/index.tsx
@@ -6,7 +6,7 @@ export default function KakaoScript() {
     const initializeKakao = () => {
       if (window.Kakao && !window.Kakao.isInitialized()) {
         window.Kakao.init(process.env.NEXT_PUBLIC_KAKAO_APP_KEY);
-        console.log('Kakao SDK initialized');
+        console.debug('Kakao SDK initialized');
       }
     };
 

--- a/src/hooks/useKakao.ts
+++ b/src/hooks/useKakao.ts
@@ -1,0 +1,30 @@
+import { useEffect, useState } from 'react';
+
+export default function useKakao() {
+  const [isKakaoInitialized, setIsKakaoInitialized] = useState(false);
+
+  useEffect(() => {
+    if (window.Kakao && window.Kakao.isInitialized()) {
+      setIsKakaoInitialized(true);
+    } else {
+      const checkKakao = setInterval(() => {
+        if (window.Kakao && window.Kakao.isInitialized()) {
+          setIsKakaoInitialized(true);
+          clearInterval(checkKakao);
+        }
+      }, 100);
+    }
+  }, []);
+
+  const handleKakaoChat = () => {
+    if (window.Kakao && isKakaoInitialized) {
+      window.Kakao.Channel.chat({
+        channelPublicId: '_sxaIWG',
+      });
+    } else {
+      console.error('Kakao SDK is not initialized');
+    }
+  };
+
+  return { handleKakaoChat };
+}

--- a/src/kakao.d.ts
+++ b/src/kakao.d.ts
@@ -1,0 +1,11 @@
+interface Kakao {
+  init(appKey?: string): void;
+  isInitialized(): boolean;
+  Channel: {
+    chat(params: { channelPublicId: string }): void;
+  };
+}
+
+interface Window {
+  Kakao: Kakao;
+}

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -14,6 +14,7 @@ import { useEffect } from 'react';
 import { RecoilRoot } from 'recoil';
 import { QueryParamProvider } from 'use-query-params';
 
+import KakaoScript from '@/components/common/KakaoScript';
 import ResponsiveProvider from '@/components/common/Responsive/ResponsiveProvider';
 import SlidUpProvider from '@/components/common/SlideUp/providers/SlideUpProvider';
 import ToastProvider from '@/components/common/Toast/providers/ToastProvider';
@@ -117,6 +118,7 @@ function MyApp({ Component, pageProps }: AppProps) {
           images: [{ url: `${ORIGIN}/icons/img/og_playground.jpeg` }],
         }}
       />
+      <KakaoScript />
       <Head>
         <meta name='theme-color' media='(prefers-color-scheme: dark)' content={colors.gray400} />
       </Head>


### PR DESCRIPTION
### 🤫 쉿, 나한테만 말해줘요. 이슈넘버
- close #1404 

### 🧐 어떤 것을 변경했어요~?
<!-- 실제로 변경한 사항을 설명해주세요.-->
- 구글폼으로 이루어졌던 의견 제안하기를 카카오톡 버튼으로 수정하였어요.

### 🤔 그렇다면, 어떻게 구현했어요~?
<!-- 실제로 구현한 로직에 대해 설명해주세요.-->
- 카카오 SDK 로드 및 초기화 
<KakaoScript/> 라는 컴포넌트를 만들어서, SDK를 로드하고 초기화하였어요. 
해당 컴포넌트가 적용이 안되어서 애를 먹었는데, 알고보니 Next에서는 Head에 script를 넣으면 안된다고 하더라구요! Head바깥으로 KakaoScript를 넣어주어서 해결했습니다. 
- SDK 초기화되었는지 확인하는 로직
초기화되었는지를 확인하고, 그렇지 않다면 100밀리초마다 반복하여 초기화 작업을 진행했습니다. 
- onClick이벤트
메이커스 채널 고유 id인 _sxaIWG를 통해 채팅을 시작하도록 하고, 문제가 발생한다면 에러를 뱉도록 했습니다.

### ❤️‍🔥 당신이 생각하는 PR포인트, 내겐 매력포인트.
<!-- 해당 PR에서 논의가 필요한 사항을 적어주세요. -->
- env에 새로운 키가 추가되었습니다! 해당 내용은 카카오톡으로 전달드릴게요~
    - cloudFlare에 키 추가 필요
- 배포 후, 사이트 도메인 테스트 필요
- 모바일에서는 헤더에 의견 제안하기가 들어가있어서, 헤더 배포가 필요합니다. 배포 후 크루에서도 문제없는지 확인하기

### 📸 스크린샷, 없으면 이것 참,, 섭섭한데요?

<img width="352" alt="스크린샷 2024-05-30 오전 12 58 57" src="https://github.com/sopt-makers/sopt-playground-frontend/assets/76681519/ebef057c-77ac-4160-a18d-db1309b10f31">

