### PR TITLE
fix: 끝말잇기 탭 제거

### DIFF
--- a/src/components/common/Header/desktop/DesktopHeader.tsx
+++ b/src/components/common/Header/desktop/DesktopHeader.tsx
@@ -46,10 +46,6 @@ const DesktopHeader: FC<DesktopHeaderProps> = ({ user, onLogout, renderLink, act
         })}
         <NavItem isActive={false}>|</NavItem>
         {renderLink({
-          href: playgroundLink.wordchain(),
-          children: <NavItem isActive={activePathMatcher(playgroundLink.wordchain())}>끝말잇기</NavItem>,
-        })}
-        {renderLink({
           href: playgroundLink.sopticle(),
           children: <NavItem isActive={activePathMatcher(playgroundLink.sopticle())}>솝티클 업로드</NavItem>,
         })}


### PR DESCRIPTION
### 🤫 쉿, 나한테만 말해줘요. 이슈넘버
- close #1446

### 🧐 어떤 것을 변경했어요~?
<!-- 실제로 변경한 사항을 설명해주세요.-->
playground-common에 해당하는 DesktopHeader에서 끝말잇기 탭을 제거했습니다.

### 🤔 그렇다면, 어떻게 구현했어요~?
<!-- 실제로 구현한 로직에 대해 설명해주세요.-->

### ❤️‍🔥 당신이 생각하는 PR포인트, 내겐 매력포인트.
<!-- 해당 PR에서 논의가 필요한 사항을 적어주세요. -->
이 PR은 크루쪽이랑 시간 맞춰서 배포 하겠습니다!

### 📸 스크린샷, 없으면 이것 참,, 섭섭한데요?
<img width="593" alt="image" src="https://github.com/sopt-makers/sopt-playground-frontend/assets/55528304/b94937d3-c34b-4e08-b9ab-22d5753b0796">
