### PR TITLE
fix: getMembersSearchByName parameter 네이밍 수정

### DIFF
--- a/src/api/endpoint/members/getMembersSearchByName.ts
+++ b/src/api/endpoint/members/getMembersSearchByName.ts
@@ -3,9 +3,9 @@ import { z } from 'zod';
 import { createEndpoint } from '@/api/typedAxios';
 
 export const getMembersSearchByName = createEndpoint({
-  request: (search: string) => ({
+  request: (name: string) => ({
     method: 'GET',
-    url: `api/v1/members/search?search=${encodeURIComponent(search)}`,
+    url: `api/v1/members/search?name=${encodeURIComponent(name)}`,
   }),
   serverResponseScheme: z.array(
     z.object({


### PR DESCRIPTION
### 🤫 쉿, 나한테만 말해줘요. 이슈넘버
- close #1448

### 🧐 어떤 것을 변경했어요~?
<!-- 실제로 변경한 사항을 설명해주세요.-->
멤버 프로필 기능을 수정하면서, 관련 없는 getMembersSearchByName api의 파라미터 명이 name에서 search로 변경되는 실수가있었습니다. 이를 name으로 다시 되돌렸습니다.

### 🤔 그렇다면, 어떻게 구현했어요~?
<!-- 실제로 구현한 로직에 대해 설명해주세요.-->

### ❤️‍🔥 당신이 생각하는 PR포인트, 내겐 매력포인트.
<!-- 해당 PR에서 논의가 필요한 사항을 적어주세요. -->

### 📸 스크린샷, 없으면 이것 참,, 섭섭한데요?
<img width="288" alt="image" src="https://github.com/sopt-makers/sopt-playground-frontend/assets/55528304/a52b6ef2-77f0-48ef-94d0-0ec1fb6d3a3c">

<img width="961" alt="image" src="https://github.com/sopt-makers/sopt-playground-frontend/assets/55528304/9485e8a8-b2fa-4a51-bd40-1dde8c7772e6">

프로젝트 업로드시 getMembersSearchByName를 사용하는 기능과
멤버 프로필 내 검색 모두 정상 작동 확인하였습니다!