### PR TITLE
feat: 활동 후기 메시지 전시 구현

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
   "dependencies": {
     "@amplitude/analytics-browser": "^1.10.4",
     "@badrap/bar-of-progress": "^0.2.2",
+    "@egjs/react-infinitegrid": "^4.12.0",
     "@emotion/react": "^11.9.0",
     "@emotion/styled": "^11.8.1",
     "@headlessui/react": "^1.6.6",

--- a/src/api/endpoint/remember/getReviews.ts
+++ b/src/api/endpoint/remember/getReviews.ts
@@ -1,0 +1,18 @@
+import { z } from 'zod';
+
+import { createEndpoint } from '@/api/typedAxios';
+
+const ReviewSchema = z.array(
+  z.object({
+    id: z.number(),
+    content: z.string(),
+  }),
+);
+
+export const getReviews = createEndpoint({
+  request: () => ({
+    method: 'GET',
+    url: `review`,
+  }),
+  serverResponseScheme: ReviewSchema,
+});

--- a/src/api/endpoint/remember/uploadReview.ts
+++ b/src/api/endpoint/remember/uploadReview.ts
@@ -1,0 +1,12 @@
+import { z } from 'zod';
+
+import { createEndpoint } from '@/api/typedAxios';
+
+export const uploadFeed = createEndpoint({
+  request: (reqeustBody) => ({
+    method: 'POST',
+    url: 'review/upload',
+    data: reqeustBody,
+  }),
+  serverResponseScheme: z.unknown(),
+});

--- a/src/components/remember/index.tsx
+++ b/src/components/remember/index.tsx
@@ -1,3 +1,5 @@
+import Reviews from '@/components/remember/reviews';
+import { MOBILE_MEDIA_QUERY } from '@/styles/mediaQuery';
 import styled from '@emotion/styled';
 import { colors } from '@sopt-makers/colors';
 import { fonts } from '@sopt-makers/fonts';
@@ -5,7 +7,8 @@ import { fonts } from '@sopt-makers/fonts';
 export default function RememberPage() {
   return (
     <>
-      <Header>34기 NOW SOPT 활동 후기를 남겨주세요!</Header>
+      <Header>{'34기 NOW SOPT \n활동 후기를 남겨주세요!'}</Header>
+      <Reviews />
     </>
   );
 }
@@ -13,6 +16,13 @@ export default function RememberPage() {
 const Header = styled.header`
   margin-bottom: 28px;
   text-align: center;
+  white-space: nowrap;
   color: ${colors.white};
   ${fonts.HEADING_28_B};
+
+  @media ${MOBILE_MEDIA_QUERY} {
+    ${fonts.HEADING_18_B};
+
+    white-space: pre;
+  }
 `;

--- a/src/components/remember/mocks/handlers.ts
+++ b/src/components/remember/mocks/handlers.ts
@@ -1,58 +1,59 @@
+import { API_URL } from '@/constants/env';
 import { http, HttpResponse } from 'msw';
 
 export const REVIEW_LIST = [
-  { id: 1, message: '솝트해서 좋았다!' },
+  { id: 1, content: '솝트해서 좋았다!' },
   {
     id: 2,
-    message:
+    content:
       '솝트에서 이루고 싶은 것, \n현재의 다짐 등 34기 활동을 시작하는 \n스스로에게 하고 싶은 말을 자유롭게 \n적어주세요! 솝트에서 이루고 싶은 것, 현재의 다짐 등 34기 활동을 시작하는 스스로에게 하고 싶은 말을 자유롭게 적어주세요! 솝트에서 이루고 싶은 것, 현재의 다짐 등 34기 활동을 시',
   },
   {
     id: 3,
-    message:
+    content:
       '솝트에서 이루고 싶은 것, \n현재의 다짐 등 34기 활동을 시작하는 \n스스로에게 하고 싶은 말을 자유롭게 \n적어주세요! 솝트에서 이루고 싶은 것, 현재의',
   },
   {
     id: 4,
-    message:
+    content:
       '솝트에서 이루고 싶은 것, \n현재의 다짐 등 34기 활동을 시작하는 \n스스로에게 하고 싶은 말을 자유롭게 \n적어주세요! 솝트에서 이루고 싶은 것, \n현재의 다짐 등 34기 활동을 시작하는 \n스스로에게 하고 싶은 말을 자유롭게 \n적어주세요! 솝트에서 이루고 싶은 것, 현재의 다짐 등 34기 활동을 시작하는 스스로에게 하고 싶은 말을 자유롭게 적어주세요! 솝트에서 이루고 싶은 것, 현재의 다짐 등 34기 활동을 시',
   },
   {
     id: 5,
-    message:
+    content:
       '솝트에서 이루고 싶은 것, \n현재의 다짐 등 34기 활동을 시작하는 \n스스로에게 하고 싶은 말을 자유롭게 \n적어주세요! 솝트에서 이루고 싶은 것, 현재의',
   },
   {
     id: 6,
-    message:
+    content:
       '솝트에서 이루고 싶은 것, \n현재의 다짐 등 34기 활동을 시작하는 \n스스로에게 하고 싶은 말을 자유롭게 \n적어주세요! 솝트에서 이루고 싶은 것, 현재의',
   },
-  { id: 7, message: '솝트 굿' },
+  { id: 7, content: '솝트 굿' },
   {
     id: 8,
-    message:
+    content:
       '솝트에서 이루고 싶은 것, \n현재의 다짐 등 34기 활동을 시작하는 \n스스로에게 하고 싶은 말을 자유롭게 \n적어주세요! 솝트에서 이루고 싶은 것, 현재의',
   },
-  { id: 9, message: '솝트해서 좋았다!\n솝트해서 좋았다!\n솝트해서 좋았다!' },
-  { id: 10, message: '재밌었다 ㅋ' },
+  { id: 9, content: '솝트해서 좋았다!\n솝트해서 좋았다!\n솝트해서 좋았다!' },
+  { id: 10, content: '재밌었다 ㅋ' },
   {
     id: 11,
-    message:
+    content:
       '솝트에서 이루고 싶은 것, \n현재의 다짐 등 34기 활동을 시작하는 \n스스로에게 하고 싶은 말을 자유롭게 \n적어주세요! 솝트에서 이루고 싶은 것, 현재의',
   },
   {
     id: 12,
-    message:
+    content:
       '솝트에서 이루고 싶은 것, \n현재의 다짐 등 34기 활동을 시작하는 \n스스로에게 하고 싶은 말을 자유롭게 \n적어주세요! 솝트에서 이루고 싶은 것, 현재의',
   },
-  { id: 13, message: '솝트해서 좋았다!\n솝트해서 좋았다!\n솝트해서 좋았다!' },
+  { id: 13, content: '솝트해서 좋았다!\n솝트해서 좋았다!\n솝트해서 좋았다!' },
 ];
 
 export const handlers = [
-  http.get('/review', async () => {
+  http.get(`${API_URL}/review`, async () => {
     return HttpResponse.json(REVIEW_LIST);
   }),
-  http.post('/review/upload', async ({ request }) => {
+  http.post(`${API_URL}/review/upload`, async ({ request }) => {
     const requestBody = await request.json();
     console.log(requestBody);
     return HttpResponse.text(JSON.stringify('ok'), {});

--- a/src/components/remember/reviews/ReviewCard/index.stories.tsx
+++ b/src/components/remember/reviews/ReviewCard/index.stories.tsx
@@ -1,0 +1,24 @@
+import { Meta } from '@storybook/react';
+
+import ReviewCard from '@/components/remember/reviews/ReviewCard';
+
+export default {
+  component: ReviewCard,
+} as Meta<typeof ReviewCard>;
+
+export const Default = {
+  args: {
+    id: 1,
+    message: '솝트 좋아요!\n솝트 좋아요!\n솝트 좋아요!',
+  },
+  name: '리뷰카드 기본',
+};
+
+export const Long = {
+  args: {
+    id: 2,
+    message:
+      '솝트에서 이루고 싶은 것, \n현재의 다짐 등 34기 활동을 시작하는 \n스스로에게 하고 싶은 말을 자유롭게 \n적어주세요!솝트에서 이루고 싶은 것, \n현재의 다짐 등 34기 활동을 시작하는 \n스스로에게 하고 싶은 말을 자유롭게 \n적어주세요!솝트에서 이루고 싶은 것, \n현재의 다짐 등 34기 활동을 시작하는 \n스스로에게 하고 싶은 말을 자유롭게 \n적어주세요! 솝트에서 이루고 싶은 것, \n현재의 다짐 등 34기 활동을 시작하는 \n스스로에게 하고 싶은 말을 자유롭게 \n적어주세요! ',
+  },
+  name: '리뷰카드 긴 버전',
+};

--- a/src/components/remember/reviews/ReviewCard/index.tsx
+++ b/src/components/remember/reviews/ReviewCard/index.tsx
@@ -1,0 +1,67 @@
+import { MOBILE_MEDIA_QUERY } from '@/styles/mediaQuery';
+import styled from '@emotion/styled';
+import { fonts } from '@sopt-makers/fonts';
+
+interface ReviewCardProp {
+  id: number;
+  content: string;
+}
+
+export default function ReviewCard({ id, content }: ReviewCardProp) {
+  const cardColor = [
+    'rgba(31, 41, 156, 0.6)',
+
+    'rgba(255, 110, 29, 0.6)',
+    'rgba(255, 202, 0, 0.6)',
+    'rgba(93, 219, 255, 0.6)',
+    'rgba(255, 255, 255, 0.3)',
+    'rgba(31, 41, 156, 0.6)',
+    'rgba(253, 187, 249, 0.6)',
+
+    'rgba(93, 219, 255, 0.6)',
+    'rgba(253, 187, 249, 0.6)',
+    'rgba(255, 110, 29, 0.6)',
+    'rgba(255, 255, 255, 0.3)',
+    'rgba(255, 202, 0, 0.6)',
+  ];
+
+  return (
+    <Card color={cardColor[id % 12]}>
+      <CardInner>{content}</CardInner>
+    </Card>
+  );
+}
+
+const Card = styled.article<{ color: string }>`
+  display: flex;
+  border-radius: 10px;
+  background: ${({ color }) => color};
+  padding: 16px 20px;
+  width: 100%;
+  max-width: 335px;
+  max-height: 214px;
+
+  ${fonts.BODY_16_M};
+
+  @media ${MOBILE_MEDIA_QUERY} {
+    max-width: 100%;
+    max-height: 138px;
+  }
+`;
+
+const CardInner = styled.div`
+  box-sizing: border-box;
+  /* stylelint-disable-next-line value-no-vendor-prefix */
+  display: -webkit-box;
+  width: 100%;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: pre;
+  -webkit-line-clamp: 7;
+  -webkit-box-orient: vertical;
+
+  @media ${MOBILE_MEDIA_QUERY} {
+    max-height: 138px;
+    -webkit-line-clamp: 4;
+  }
+`;

--- a/src/components/remember/reviews/ReviewCard/index.tsx
+++ b/src/components/remember/reviews/ReviewCard/index.tsx
@@ -17,16 +17,10 @@ export default function ReviewCard({ id, content }: ReviewCardProp) {
     'rgba(255, 255, 255, 0.3)',
     'rgba(31, 41, 156, 0.6)',
     'rgba(253, 187, 249, 0.6)',
-
-    'rgba(93, 219, 255, 0.6)',
-    'rgba(253, 187, 249, 0.6)',
-    'rgba(255, 110, 29, 0.6)',
-    'rgba(255, 255, 255, 0.3)',
-    'rgba(255, 202, 0, 0.6)',
   ];
 
   return (
-    <Card color={cardColor[id % 12]}>
+    <Card color={cardColor[id % 7]}>
       <CardInner>{content}</CardInner>
     </Card>
   );
@@ -56,7 +50,7 @@ const CardInner = styled.div`
   width: 100%;
   overflow: hidden;
   text-overflow: ellipsis;
-  white-space: pre;
+  white-space: pre-wrap;
   -webkit-line-clamp: 7;
   -webkit-box-orient: vertical;
 

--- a/src/components/remember/reviews/index.tsx
+++ b/src/components/remember/reviews/index.tsx
@@ -1,7 +1,8 @@
 import { getReviews } from '@/api/endpoint/remember/getReviews';
 import Loading from '@/components/common/Loading';
+import Responsive from '@/components/common/Responsive';
 import ReviewCard from '@/components/remember/reviews/ReviewCard';
-import { MOBILE_MEDIA_QUERY } from '@/styles/mediaQuery';
+import { MasonryInfiniteGrid } from '@egjs/react-infinitegrid';
 import styled from '@emotion/styled';
 import { useQuery } from '@tanstack/react-query';
 
@@ -11,38 +12,42 @@ export default function Reviews() {
     queryFn: () => getReviews.request(),
   });
 
+  const renderedReviewData =
+    reviewData &&
+    reviewData.length > 0 &&
+    reviewData.map(({ id, content }) => {
+      return <ReviewCard key={id} id={id} content={content} />;
+    });
+
   return (
     <Container>
       {isFetching ? (
         <Loading />
       ) : (
-        <ReviewCardWrapper>
-          {reviewData &&
-            reviewData.length > 0 &&
-            reviewData.map(({ id, content }) => {
-              return (
-                <Card>
-                  <ReviewCard key={id} id={id} content={content} />
-                </Card>
-              );
-            })}
-        </ReviewCardWrapper>
+        <>
+          <Responsive only='mobile'>
+            <ReviewCardMobileWrapper>{renderedReviewData}</ReviewCardMobileWrapper>
+          </Responsive>
+          <Responsive only='desktop'>
+            <MasonryInfiniteGrid align='center' gap={16} column={3}>
+              {renderedReviewData}
+            </MasonryInfiniteGrid>
+          </Responsive>
+        </>
       )}
     </Container>
   );
 }
 
-const Card = styled.div``;
-
 const Container = styled.div`
-  padding: 0 242px;
+  width: 100%;
 `;
 
-const ReviewCardWrapper = styled.section`
-  @media ${MOBILE_MEDIA_QUERY} {
-    display: flex;
-    flex-direction: column;
-    gap: 16px;
-    width: 100%;
-  }
+const ReviewCardMobileWrapper = styled.section`
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  width: 100%;
 `;
+
+const ReviewCardDesktopWrapper = styled(MasonryInfiniteGrid)``;

--- a/src/components/remember/reviews/index.tsx
+++ b/src/components/remember/reviews/index.tsx
@@ -1,0 +1,48 @@
+import { getReviews } from '@/api/endpoint/remember/getReviews';
+import Loading from '@/components/common/Loading';
+import ReviewCard from '@/components/remember/reviews/ReviewCard';
+import { MOBILE_MEDIA_QUERY } from '@/styles/mediaQuery';
+import styled from '@emotion/styled';
+import { useQuery } from '@tanstack/react-query';
+
+export default function Reviews() {
+  const { data: reviewData, isFetching } = useQuery({
+    queryKey: ['getReviews'],
+    queryFn: () => getReviews.request(),
+  });
+
+  return (
+    <Container>
+      {isFetching ? (
+        <Loading />
+      ) : (
+        <ReviewCardWrapper>
+          {reviewData &&
+            reviewData.length > 0 &&
+            reviewData.map(({ id, content }) => {
+              return (
+                <Card>
+                  <ReviewCard key={id} id={id} content={content} />
+                </Card>
+              );
+            })}
+        </ReviewCardWrapper>
+      )}
+    </Container>
+  );
+}
+
+const Card = styled.div``;
+
+const Container = styled.div`
+  padding: 0 242px;
+`;
+
+const ReviewCardWrapper = styled.section`
+  @media ${MOBILE_MEDIA_QUERY} {
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+    width: 100%;
+  }
+`;

--- a/src/pages/remember/index.tsx
+++ b/src/pages/remember/index.tsx
@@ -4,6 +4,7 @@ import { FC, useEffect, useRef, useState } from 'react';
 
 import AuthRequired from '@/components/auth/AuthRequired';
 import RememberPage from '@/components/remember';
+import { MOBILE_MEDIA_QUERY } from '@/styles/mediaQuery';
 import { setLayout } from '@/utils/layout';
 
 const Remember34Page: FC = () => {
@@ -46,4 +47,8 @@ const StyledRemember34Page = styled.div`
   flex-direction: column;
   align-items: center;
   padding: 64px 0;
+
+  @media ${MOBILE_MEDIA_QUERY} {
+    padding: 24px 20px;
+  }
 `;

--- a/yarn.lock
+++ b/yarn.lock
@@ -2399,6 +2399,24 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@cfcs/core@npm:^0.0.24":
+  version: 0.0.24
+  resolution: "@cfcs/core@npm:0.0.24"
+  dependencies:
+    "@egjs/component": ^3.0.4
+  checksum: 6e1873f0ce85d2a401f3938a5bc9ce396c49b1fdcac0a3b2369245be25d7a7522e98515b7b7157ad6f0ce7b4e0a996b47ed2d3b8c70a4531e57d83b6dedbafa9
+  languageName: node
+  linkType: hard
+
+"@cfcs/core@npm:^0.0.5":
+  version: 0.0.5
+  resolution: "@cfcs/core@npm:0.0.5"
+  dependencies:
+    "@egjs/component": ^3.0.2
+  checksum: 4c2043e15f3330461de2519acc64581310e1078923034e27565a64938df9b9ff8e1066137ebba635ea16e937daace76154770b17fd44913156e078b1bf5ad6f0
+  languageName: node
+  linkType: hard
+
 "@cloudflare/workers-types@npm:^3.18.0":
   version: 3.19.0
   resolution: "@cloudflare/workers-types@npm:3.19.0"
@@ -2623,6 +2641,72 @@ __metadata:
   version: 0.5.7
   resolution: "@discoveryjs/json-ext@npm:0.5.7"
   checksum: 2176d301cc258ea5c2324402997cf8134ebb212469c0d397591636cea8d3c02f2b3cf9fd58dcb748c7a0dade77ebdc1b10284fa63e608c033a1db52fddc69918
+  languageName: node
+  linkType: hard
+
+"@egjs/children-differ@npm:^1.0.1":
+  version: 1.0.1
+  resolution: "@egjs/children-differ@npm:1.0.1"
+  dependencies:
+    "@egjs/list-differ": ^1.0.0
+  checksum: 087f286822a93cc5ac2ba0beb9f332f3828a8870fea0e9d0a177078c96fc265ce74979be827a78dab674a833e3a22d4fe60636112a1aae93252e0a38f58ff754
+  languageName: node
+  linkType: hard
+
+"@egjs/component@npm:^3.0.0, @egjs/component@npm:^3.0.1, @egjs/component@npm:^3.0.2, @egjs/component@npm:^3.0.4":
+  version: 3.0.5
+  resolution: "@egjs/component@npm:3.0.5"
+  checksum: d2ca53cc86b82df0fac3f21045a05d70a542c1f6a061cf534c67b336830644d0fbef07e322fcbe5bd809f59504103319a2c6467af58a9f8009a81655c3fe366f
+  languageName: node
+  linkType: hard
+
+"@egjs/grid@npm:~1.16.0":
+  version: 1.16.0
+  resolution: "@egjs/grid@npm:1.16.0"
+  dependencies:
+    "@egjs/children-differ": ^1.0.1
+    "@egjs/component": ^3.0.0
+    "@egjs/imready": ^1.3.0
+  checksum: d43cfe76a516a278974093381712902aa4892d64350d7d41e79a5c58972f6ff1242ed11889b026d104bb4a04e63e4a0068f16ba0bec3c394cd3165c9ad2a6a74
+  languageName: node
+  linkType: hard
+
+"@egjs/imready@npm:^1.3.0":
+  version: 1.4.1
+  resolution: "@egjs/imready@npm:1.4.1"
+  dependencies:
+    "@cfcs/core": ^0.0.24
+    "@egjs/component": ^3.0.1
+  checksum: 719afe734c4346555ffb75a5a487242c02a26509cfda9cc77272c7ec878e5058fff68027ea64a70a460b3e9393164df8adb70cba9a008d13d2029e8932687df9
+  languageName: node
+  linkType: hard
+
+"@egjs/infinitegrid@npm:~4.12.0":
+  version: 4.12.0
+  resolution: "@egjs/infinitegrid@npm:4.12.0"
+  dependencies:
+    "@cfcs/core": ^0.0.5
+    "@egjs/children-differ": ^1.0.1
+    "@egjs/component": ^3.0.0
+    "@egjs/grid": ~1.16.0
+    "@egjs/list-differ": ^1.0.0
+  checksum: 0aa2d8e000c6341515c16508cf16a7b3370f5cd2465789bf0c36fe39e342486054a8ef80052f8c5d02b006b1434157ba9fd421a8e1c4c6759b1efb455c62e146
+  languageName: node
+  linkType: hard
+
+"@egjs/list-differ@npm:^1.0.0":
+  version: 1.0.1
+  resolution: "@egjs/list-differ@npm:1.0.1"
+  checksum: 2c126c66d7753c1b86816192f265fa8a58fc45b62b739ebce9008202c2485dcc81d62a9e8d26ceb73efd1679140d39dd5ae3638d63e1ebaf5ca9d6bc824a16c7
+  languageName: node
+  linkType: hard
+
+"@egjs/react-infinitegrid@npm:^4.12.0":
+  version: 4.12.0
+  resolution: "@egjs/react-infinitegrid@npm:4.12.0"
+  dependencies:
+    "@egjs/infinitegrid": ~4.12.0
+  checksum: 16adb9cba668d8847be7a9e9504f0f7a14ed436f5c1b26981592c93bb0177ae6d55d305e279a1d50fbac38188b199937b87d86b6d6db731c1c98c2f5f1f0f0df
   languageName: node
   linkType: hard
 
@@ -18465,6 +18549,7 @@ __metadata:
     "@cloudflare/workers-types": ^3.18.0
     "@commitlint/cli": ^16.2.3
     "@commitlint/config-conventional": ^16.2.1
+    "@egjs/react-infinitegrid": ^4.12.0
     "@emotion/babel-preset-css-prop": ^11.11.0
     "@emotion/react": ^11.9.0
     "@emotion/styled": ^11.8.1


### PR DESCRIPTION
### 🤫 쉿, 나한테만 말해줘요. 이슈넘버
- close #1458

### 🧐 어떤 것을 변경했어요~?
<!-- 실제로 변경한 사항을 설명해주세요.-->
- 목서버로 받아온 데이터를 기반으로, 활동 후기 메시지 전시를 구현했어요. 

### 🤔 그렇다면, 어떻게 구현했어요~?
<!-- 실제로 구현한 로직에 대해 설명해주세요.-->
- masonryInfiniteGrid 라이브러리를 이용했어요. 
    - 핀터레스트와 같은 스타일을 위해 많이 사용되는 라이브러리이고, 크루에서도 해당 라이브러리를 이용하길래 선택해보았습니다!

### ❤️‍🔥 당신이 생각하는 PR포인트, 내겐 매력포인트.
<!-- 해당 PR에서 논의가 필요한 사항을 적어주세요. -->
- 겉을 감싸는 태그의 width값을 꼭 주어야 문제없이 보여지더라고요!

### 📸 스크린샷, 없으면 이것 참,, 섭섭한데요?
<img width="1440" alt="스크린샷 2024-07-21 오전 1 51 15" src="https://github.com/user-attachments/assets/aa4d42b7-3b0a-48d2-891d-1d7d2195f139">
