### PR TITLE
feat: 활동 후기 메시지 input 구현

### DIFF
--- a/src/api/endpoint/remember/uploadReview.ts
+++ b/src/api/endpoint/remember/uploadReview.ts
@@ -1,0 +1,28 @@
+import { z } from 'zod';
+
+import { createEndpoint } from '@/api/typedAxios';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+
+interface RequestBody {
+  content: string;
+}
+
+export const uploadReview = createEndpoint({
+  request: (reqeustBody: RequestBody) => ({
+    method: 'POST',
+    url: 'review/upload',
+    data: reqeustBody,
+  }),
+  serverResponseScheme: z.unknown(),
+});
+
+export const useUploadReviewMutation = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (reqeustBody: RequestBody) => uploadReview.request(reqeustBody),
+    onSuccess: () => {
+      //   queryClient.invalidateQueries({ queryKey: useGetReviewsInfiniteQuery.getKey('') }); // review
+    },
+  });
+};

--- a/src/components/remember/ReviewInput/index.tsx
+++ b/src/components/remember/ReviewInput/index.tsx
@@ -1,0 +1,171 @@
+import { useUploadReviewMutation } from '@/api/endpoint/remember/uploadReview';
+import styled from '@emotion/styled';
+import { colors } from '@sopt-makers/colors';
+import { fonts } from '@sopt-makers/fonts';
+import { ChangeEvent, useState } from 'react';
+import TextareaAutosize from 'react-textarea-autosize';
+
+const MAX_LENGTH = 3000;
+
+export default function ReviewInput() {
+  const [content, setContent] = useState<string>();
+  const [inputStatus, setInputStatus] = useState<'error' | 'focus'>();
+  const { mutate } = useUploadReviewMutation();
+
+  const handleWrite = (e: ChangeEvent<HTMLTextAreaElement>) => {
+    const content = e.target.value;
+
+    if (content === undefined || (content && content.length > MAX_LENGTH)) return;
+    if (content.length === 3000) {
+      setInputStatus('error');
+    } else {
+      setInputStatus('focus');
+    }
+
+    setContent(content);
+  };
+
+  const handleFocus = () => {
+    setInputStatus('focus');
+  };
+
+  const handleBlur = () => {
+    setInputStatus(undefined);
+  };
+
+  const handleSubmit = () => {
+    if (content !== undefined && content !== '') {
+      mutate({ content: content });
+    }
+  };
+
+  const isError = inputStatus === 'error';
+  const isFocus = inputStatus === 'focus';
+
+  return (
+    <>
+      <InputBox isFocus={isFocus} isError={isError}>
+        <Input
+          value={content}
+          placeholder='SOPT를 하며 재밌었던 일, 힘들었던 기억 등을 자유롭게 공유해주세요!'
+          maxLength={MAX_LENGTH}
+          onChange={(e) => handleWrite(e)}
+          onFocus={handleFocus}
+          onBlur={handleBlur}
+        />
+        <SendButton onClick={handleSubmit}>
+          <SendIcon isActivate={isError || isFocus} />
+        </SendButton>
+      </InputBox>
+      <Bottom>
+        {isError ? <Error /> : <div />}
+        <Length>{content ? content.length : 0}/3,000</Length>
+      </Bottom>
+    </>
+  );
+}
+
+const Error = () => {
+  return (
+    <ErrorWrapper>
+      <ErrorIcon />
+      <p>3,000자 이상 입력할 수 없어요</p>
+    </ErrorWrapper>
+  );
+};
+
+const ErrorIcon = () => {
+  return (
+    <svg xmlns='http://www.w3.org/2000/svg' width='14' height='14' viewBox='0 0 14 14' fill='none'>
+      <g clip-path='url(#clip0_2553_295)'>
+        <path
+          d='M6.99984 4.6665V6.99984M6.99984 9.33317H7.00567M12.8332 6.99984C12.8332 10.2215 10.2215 12.8332 6.99984 12.8332C3.77818 12.8332 1.1665 10.2215 1.1665 6.99984C1.1665 3.77818 3.77818 1.1665 6.99984 1.1665C10.2215 1.1665 12.8332 3.77818 12.8332 6.99984Z'
+          stroke='#F04251'
+          stroke-linecap='round'
+          stroke-linejoin='round'
+        />
+      </g>
+      <defs>
+        <clipPath id='clip0_2553_295'>
+          <rect width='14' height='14' fill='white' />
+        </clipPath>
+      </defs>
+    </svg>
+  );
+};
+
+const SendIcon = ({ isActivate }: { isActivate: boolean }) => {
+  const stroke = isActivate ? 'white' : '#515159';
+
+  return (
+    <svg xmlns='http://www.w3.org/2000/svg' width='20' height='20' viewBox='0 0 20 20' fill='none'>
+      <path
+        d='M8.74976 11.2501L17.4998 2.50014M8.85608 11.5235L11.0462 17.1552C11.2391 17.6513 11.3356 17.8994 11.4746 17.9718C11.5951 18.0346 11.7386 18.0347 11.8592 17.972C11.9983 17.8998 12.095 17.6518 12.2886 17.1559L17.7805 3.08281C17.9552 2.63516 18.0426 2.41133 17.9948 2.26831C17.9533 2.1441 17.8558 2.04663 17.7316 2.00514C17.5886 1.95736 17.3647 2.0447 16.9171 2.21939L2.84398 7.71134C2.34808 7.90486 2.10013 8.00163 2.02788 8.14071C1.96524 8.26129 1.96532 8.40483 2.0281 8.52533C2.10052 8.66433 2.34859 8.7608 2.84471 8.95373L8.47638 11.1438C8.57708 11.183 8.62744 11.2026 8.66984 11.2328C8.70742 11.2596 8.74028 11.2925 8.76709 11.3301C8.79734 11.3725 8.81692 11.4228 8.85608 11.5235Z'
+        stroke={stroke}
+        stroke-width='1.5'
+        stroke-linecap='round'
+        stroke-linejoin='round'
+      />
+    </svg>
+  );
+};
+
+const ErrorWrapper = styled.div`
+  display: flex;
+  gap: 4px;
+  align-items: center;
+  color: ${colors.error};
+  ${fonts.LABEL_12_SB};
+`;
+
+const Bottom = styled.footer`
+  display: flex;
+  justify-content: space-between;
+  margin-top: 8px;
+  width: 100%;
+`;
+
+const Length = styled.div`
+  color: ${colors.gray200};
+  ${fonts.LABEL_12_SB};
+`;
+
+const SendButton = styled.i`
+  display: flex;
+  align-items: center;
+`;
+
+const InputBox = styled.div<{ isFocus: boolean; isError: boolean }>`
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  border: 1px solid ${({ isError, isFocus }) => (isError ? colors.error : isFocus ? colors.gray200 : 'transparent')};
+  border-radius: 10px;
+  background-color: ${colors.gray800};
+  padding: 11px 16px;
+  width: 100%;
+
+  > svg {
+    cursor: pointer;
+  }
+`;
+
+const Input = styled(TextareaAutosize)`
+  outline: none;
+  background-color: transparent;
+  width: 100%;
+  max-width: calc(100% - 35px);
+  min-height: 26px;
+  max-height: 52px;
+  overflow-y: scroll;
+  resize: none;
+  white-space: pre-wrap;
+  overflow-wrap: break-word;
+  word-break: break-word;
+  color: ${colors.white};
+  ${fonts.BODY_16_M};
+
+  ::placeholder {
+    color: ${colors.gray300};
+  }
+`;

--- a/src/components/remember/index.tsx
+++ b/src/components/remember/index.tsx
@@ -1,3 +1,4 @@
+import ReviewInput from '@/components/remember/ReviewInput';
 import styled from '@emotion/styled';
 import { colors } from '@sopt-makers/colors';
 import { fonts } from '@sopt-makers/fonts';
@@ -6,6 +7,7 @@ export default function RememberPage() {
   return (
     <>
       <Header>34기 NOW SOPT 활동 후기를 남겨주세요!</Header>
+      <ReviewInput />
     </>
   );
 }


### PR DESCRIPTION
### 🤫 쉿, 나한테만 말해줘요. 이슈넘버
- close #1461 

### 🧐 어떤 것을 변경했어요~?
<!-- 실제로 변경한 사항을 설명해주세요.-->
- 활동 후기 메시지 input을 구현했어요. 

### 🤔 그렇다면, 어떻게 구현했어요~?
<!-- 실제로 구현한 로직에 대해 설명해주세요.-->
- 목서버를 연결해서 input 내용이 넘어가도록 구현했어요.

### ❤️‍🔥 당신이 생각하는 PR포인트, 내겐 매력포인트.
<!-- 해당 PR에서 논의가 필요한 사항을 적어주세요. -->
- 2번째 줄까지는 늘어나고 그 이상은 스크롤 되는 점, \n까지 인식해야한다는 점에서 기존에 커뮤니티 업로드에서 사용하던 TextareaAutosize를 사용했어요.
- focus와 error를 상태값으로 포괄하여 생각하여 status라는 변수를 이용했어요.

### 📸 스크린샷, 없으면 이것 참,, 섭섭한데요?
<img width="738" alt="스크린샷 2024-07-23 오전 12 44 44" src="https://github.com/user-attachments/assets/c946ba22-98a3-4a85-a183-7718a5590ed1">
<img width="738" alt="스크린샷 2024-07-23 오전 12 45 15" src="https://github.com/user-attachments/assets/083eb96e-731d-4e36-aa7f-9712db8936c9">

<img width="743" alt="스크린샷 2024-07-23 오전 12 45 30" src="https://github.com/user-attachments/assets/c8ae78ce-237b-4f03-bf1f-98a7fed01670">

<img width="738" alt="스크린샷 2024-07-23 오전 12 45 50" src="https://github.com/user-attachments/assets/05626890-a072-416d-8b74-dae7eddc209f">

