### PR TITLE
fix: 무한스크롤 수정

### DIFF
--- a/src/api/endpoint/remember/getReviews.ts
+++ b/src/api/endpoint/remember/getReviews.ts
@@ -31,8 +31,12 @@ export const useGetReviewsInfiniteQuery = () => {
       return response;
     },
     initialPageParam: 0,
-    getNextPageParam: (lastPage) => {
-      return lastPage.hasNext ? lastPage.reviews[lastPage.reviews.length - 1].id : null;
+    getNextPageParam: (lastPage, pages) => {
+      if (!lastPage.hasNext) {
+        return undefined;
+      }
+
+      return pages.length;
     },
   });
 };

--- a/src/components/remember/reviews/index.tsx
+++ b/src/components/remember/reviews/index.tsx
@@ -2,11 +2,17 @@ import { useGetReviewsInfiniteQuery } from '@/api/endpoint/remember/getReviews';
 import Loading from '@/components/common/Loading';
 import Responsive from '@/components/common/Responsive';
 import ReviewCard from '@/components/remember/reviews/ReviewCard';
+import useEnterScreen from '@/hooks/useEnterScreen';
 import { MasonryInfiniteGrid } from '@egjs/react-infinitegrid';
 import styled from '@emotion/styled';
 
 export default function Reviews() {
-  const { data, isPending } = useGetReviewsInfiniteQuery();
+  const { ref } = useEnterScreen({
+    onEnter: () => {
+      fetchNextPage();
+    },
+  });
+  const { data, fetchNextPage, isPending } = useGetReviewsInfiniteQuery();
 
   const reviewData = data?.pages.flatMap(({ reviews }) => reviews) ?? [];
 
@@ -39,11 +45,16 @@ export default function Reviews() {
               </ReviewCardDesktopWrapper>
             </ReviewDesktopContainer>
           </Responsive>
+          <Target ref={ref} />
         </ReviewsWrapper>
       )}
     </ReviewsContainer>
   );
 }
+
+const Target = styled.div`
+  width: 100%;
+`;
 
 const ReviewsWrapper = styled.div`
   width: 100%;


### PR DESCRIPTION
### 🤫 쉿, 나한테만 말해줘요. 이슈넘버
- close #

### 🧐 어떤 것을 변경했어요~?
<!-- 실제로 변경한 사항을 설명해주세요.-->
- 무한스크롤을 수정했어요!

### 🤔 그렇다면, 어떻게 구현했어요~?
<!-- 실제로 구현한 로직에 대해 설명해주세요.-->
- 20개씩 받아오도록 되어있어서, 값이 받아와질 때마다 pages에 들어가져요. 즉 page 0으로 부른 20개의 값은 pages의 인덱스0에 들어가기 때문에 다음에 부를 nextpage는 현재 pages 배열에 들어있는 길이값과 동일하다고 생각했고, 그래서 return pages.length해주었습니다!

### ❤️‍🔥 당신이 생각하는 PR포인트, 내겐 매력포인트.
<!-- 해당 PR에서 논의가 필요한 사항을 적어주세요. -->
- 믕서의 도움으로 옵저버를 세팅해주었어요!

### 📸 스크린샷, 없으면 이것 참,, 섭섭한데요?

https://github.com/user-attachments/assets/171faee3-ee83-4ef6-aff0-f6fe6d351d8a

