### PR TITLE
fix: 다짐메시지 배너 내리기

### DIFF
--- a/src/components/common/Banner/ActiveBannerSlot.tsx
+++ b/src/components/common/Banner/ActiveBannerSlot.tsx
@@ -1,4 +1,3 @@
-import { ClosingCeremonyBanner } from '@/components/common/Banner/ClosingCeremonyBanner';
 import styled from '@emotion/styled';
 import { FC } from 'react';
 
@@ -8,7 +7,6 @@ const ActiveBannerSlot: FC<ActiveBannerSlotProps> = ({}) => {
   return (
     <StyledActiveBanner>
       {/* 이 밑에 노출할 배너를 넣으세요. */}
-      <ClosingCeremonyBanner />
       {/* ==== */}
     </StyledActiveBanner>
   );

--- a/src/components/wordchain/WordchainEntry/WordChainEntry.tsx
+++ b/src/components/wordchain/WordchainEntry/WordChainEntry.tsx
@@ -10,17 +10,17 @@ import Loading from '@/components/common/Loading';
 import Responsive from '@/components/common/Responsive';
 import Text from '@/components/common/Text';
 import useEventLogger from '@/components/eventLogger/hooks/useEventLogger';
+import WordchainMessage from '@/components/wordchain/WordchainEntry/WordchainMessage';
 import { useWordchainWinnersQuery } from '@/components/wordchain/WordchainWinners/hooks/useWordchainWinnersQuery';
 import { playgroundLink } from '@/constants/links';
 import IconMessageChat from '@/public/icons/icon-message-chat.svg';
+import { MOBILE_MEDIA_QUERY } from '@/styles/mediaQuery';
 import { textStyles } from '@/styles/typography';
 import { SwitchCase } from '@/utils/components/switch-case/SwitchCase';
 
 interface WordChainEntryProps {
   className?: string;
 }
-
-const TEMPORARY_MEDIA_QUERY = 'screen and (min-width: 0px)';
 
 const WordChainEntry: FC<WordChainEntryProps> = ({ className }) => {
   const { data, isLoading } = useGetEntryWordchain();
@@ -44,9 +44,9 @@ const WordChainEntry: FC<WordChainEntryProps> = ({ className }) => {
       {wordList && (
         <>
           <LeftSection>
-            {/* <Responsive only='desktop'>
+            <Responsive only='desktop'>
               <StyledIconMessageChat />
-            </Responsive> */}
+            </Responsive>
             <div style={{ width: '100%' }}>
               <TitleWrapper>
                 <SwitchCase
@@ -54,7 +54,7 @@ const WordChainEntry: FC<WordChainEntryProps> = ({ className }) => {
                   caseBy={{
                     start: (
                       <>
-                        {/* <Responsive only='desktop'>
+                        <Responsive only='desktop'>
                           {lastWinner ? (
                             <StyledTitle>
                               {lastWinner?.roomId}번째 우승자는
@@ -69,76 +69,76 @@ const WordChainEntry: FC<WordChainEntryProps> = ({ className }) => {
                             </StyledTitle>
                           )}
                         </Responsive>
-                        <MobileResponsive only='mobile'> */}
-                        <GotoWordChainWrapper>
-                          <GotoWordChainContents>
-                            <Flex align='center' style={{ gap: 4 }}>
-                              <StyledIconMessageChat />
-                              <GotoWordChainTitle>끝말잇기</GotoWordChainTitle>
-                            </Flex>
-                            {lastWinner ? (
-                              <GotoWordChainSub>
-                                이번 우승자는 <LastWord>{lastWinner?.winner.name}</LastWord>님 입니다! '
-                                {data.nextSyllable}'(으)로 시작하는 단어는?
-                              </GotoWordChainSub>
-                            ) : (
-                              <GotoWordChainSub>우승하고 명예의 전당에 올라가보세요!</GotoWordChainSub>
-                            )}
-                          </GotoWordChainContents>
-                          <div style={{ minWidth: 20 }}>
-                            <ArrowIcon width={20} height={20} />
-                          </div>
-                        </GotoWordChainWrapper>
-                        {/* </MobileResponsive> */}
+                        <MobileResponsive only='mobile'>
+                          <GotoWordChainWrapper>
+                            <GotoWordChainContents>
+                              <Flex align='center' style={{ gap: 4 }}>
+                                <StyledIconMessageChat />
+                                <GotoWordChainTitle>끝말잇기</GotoWordChainTitle>
+                              </Flex>
+                              {lastWinner ? (
+                                <GotoWordChainSub>
+                                  이번 우승자는 <LastWord>{lastWinner?.winner.name}</LastWord>님 입니다! '
+                                  {data.nextSyllable}'(으)로 시작하는 단어는?
+                                </GotoWordChainSub>
+                              ) : (
+                                <GotoWordChainSub>우승하고 명예의 전당에 올라가보세요!</GotoWordChainSub>
+                              )}
+                            </GotoWordChainContents>
+                            <div style={{ minWidth: 20 }}>
+                              <ArrowIcon width={20} height={20} />
+                            </div>
+                          </GotoWordChainWrapper>
+                        </MobileResponsive>
                       </>
                     ),
                     progress: (
                       <>
-                        {/* <Responsive only='desktop'>
+                        <Responsive only='desktop'>
                           <StyledTitle>
                             현재 {`'${data?.currentWinner?.name}'`}님이 <br />
                             끝말잇기를 이기고 있어요!
                           </StyledTitle>
                         </Responsive>
-                        <MobileResponsive only='mobile'> */}
-                        <GotoWordChainWrapper>
-                          <GotoWordChainContents>
-                            <Flex align='center' style={{ gap: 4 }}>
-                              <StyledIconMessageChat />
-                              <GotoWordChainTitle>끝말잇기</GotoWordChainTitle>
-                            </Flex>
-                            {lastWord != null && (
-                              <GotoWordChainSub>
-                                {`${data?.currentWinner?.name}`}님이 <LastWord>{data.nextSyllable}</LastWord>(으)로
-                                끝냈어요. 끝말을 이어주세요!
-                              </GotoWordChainSub>
-                            )}
-                          </GotoWordChainContents>
-                          <div style={{ minWidth: 20 }}>
-                            <ArrowIcon width={20} height={20} />
-                          </div>
-                        </GotoWordChainWrapper>
-                        {/* </MobileResponsive> */}
+                        <MobileResponsive only='mobile'>
+                          <GotoWordChainWrapper>
+                            <GotoWordChainContents>
+                              <Flex align='center' style={{ gap: 4 }}>
+                                <StyledIconMessageChat />
+                                <GotoWordChainTitle>끝말잇기</GotoWordChainTitle>
+                              </Flex>
+                              {lastWord != null && (
+                                <GotoWordChainSub>
+                                  {`${data?.currentWinner?.name}`}님이 <LastWord>{data.nextSyllable}</LastWord>(으)로
+                                  끝냈어요. 끝말을 이어주세요!
+                                </GotoWordChainSub>
+                              )}
+                            </GotoWordChainContents>
+                            <div style={{ minWidth: 20 }}>
+                              <ArrowIcon width={20} height={20} />
+                            </div>
+                          </GotoWordChainWrapper>
+                        </MobileResponsive>
                       </>
                     ),
                   }}
                 />
               </TitleWrapper>
-              {/* <Responsive only='desktop'>
+              <Responsive only='desktop'>
                 <WordchainText>
                   {(lastWinner?.roomId ?? 0) + 1}번째 끝말잇기 우승자 도전하러 가기
                   <ArrowIcon />
                 </WordchainText>
-              </Responsive> */}
+              </Responsive>
             </div>
           </LeftSection>
           <RightSection isStart={status === 'start'}>
-            {/* <Responsive only='desktop'>
+            <Responsive only='desktop'>
               <WordWrapper>
                 {status === 'start' && <WordchainMessage type='startWord' word={data.nextSyllable} />}
                 {lastUser && <WordchainMessage type='word' word={data.nextSyllable} user={lastUser} />}
               </WordWrapper>
-            </Responsive> */}
+            </Responsive>
           </RightSection>
         </>
       )}
@@ -155,7 +155,7 @@ const LoadingContainer = styled.div`
   width: 100%;
   height: 92px;
 
-  @media ${TEMPORARY_MEDIA_QUERY} {
+  @media ${MOBILE_MEDIA_QUERY} {
     height: 91.5px;
   }
 `;
@@ -175,7 +175,7 @@ const Container = styled(Link)`
     background-color: ${colors.gray800};
   }
 
-  @media ${TEMPORARY_MEDIA_QUERY} {
+  @media ${MOBILE_MEDIA_QUERY} {
     flex-direction: column;
     align-items: center;
     justify-content: center;
@@ -194,7 +194,7 @@ const Container = styled(Link)`
 
 const TitleWrapper = styled.div`
   white-space: nowrap;
-  @media ${TEMPORARY_MEDIA_QUERY} {
+  @media ${MOBILE_MEDIA_QUERY} {
     display: flex;
     gap: 4px;
     align-items: center;
@@ -202,7 +202,7 @@ const TitleWrapper = styled.div`
 `;
 
 const StyledIconMessageChat = styled(IconMessageChat)`
-  @media ${TEMPORARY_MEDIA_QUERY} {
+  @media ${MOBILE_MEDIA_QUERY} {
     width: 20px;
     height: 20px;
   }
@@ -212,7 +212,7 @@ const LeftSection = styled.div`
   display: flex;
   gap: 12px;
   width: 100%;
-  @media ${TEMPORARY_MEDIA_QUERY} {
+  @media ${MOBILE_MEDIA_QUERY} {
     display: contents;
     gap: 0;
   }
@@ -222,7 +222,7 @@ const StyledTitle = styled(Text)`
   display: block;
   ${fonts.HEADING_18_B}
 
-  @media ${TEMPORARY_MEDIA_QUERY} {
+  @media ${MOBILE_MEDIA_QUERY} {
     margin: 0;
     ${textStyles.SUIT_20_B};
   }
@@ -236,7 +236,7 @@ const WordchainText = styled(Text)`
   white-space: nowrap;
   ${fonts.LABEL_12_SB}
 
-  @media ${TEMPORARY_MEDIA_QUERY} {
+  @media ${MOBILE_MEDIA_QUERY} {
     display: flex;
     align-items: center;
     justify-content: center;
@@ -260,7 +260,7 @@ const RightSection = styled.div<{ isStart: boolean }>`
   justify-content: ${({ isStart }) => (isStart ? 'flex-start' : 'flex-end')};
   width: 100%;
 
-  @media ${TEMPORARY_MEDIA_QUERY} {
+  @media ${MOBILE_MEDIA_QUERY} {
     gap: 10px;
     margin-top: 16px;
   }
@@ -284,7 +284,7 @@ const GotoWordChainWrapper = styled.aside`
   padding: 16px;
   width: 100%;
 
-  @media ${TEMPORARY_MEDIA_QUERY} {
+  @media ${MOBILE_MEDIA_QUERY} {
     gap: 8px;
     border-radius: 14px;
     padding: 18px 17px;
@@ -300,7 +300,7 @@ const GotoWordChainContents = styled.div`
   display: flex;
   gap: 20px;
 
-  @media ${TEMPORARY_MEDIA_QUERY} {
+  @media ${MOBILE_MEDIA_QUERY} {
     gap: 16px;
   }
 `;


### PR DESCRIPTION
### 🤫 쉿, 나한테만 말해줘요. 이슈넘버
- close #1495 

### 🧐 어떤 것을 변경했어요~?
<!-- 실제로 변경한 사항을 설명해주세요.-->
- 배너 노출부에서 다짐메시지 배너 제거
- 끝말잇기를 원래 상태로 되돌림

### 🤔 그렇다면, 어떻게 구현했어요~?
<!-- 실제로 구현한 로직에 대해 설명해주세요.-->
- ActiveBannerSlot에 넣어놨던 다짐메시지 배너를 제거했어요.
- 끝말잇기 배너에서 desktop 반응형을 제거했던 것을 원래대로 되돌렸어요.

### ❤️‍🔥 당신이 생각하는 PR포인트, 내겐 매력포인트.
<!-- 해당 PR에서 논의가 필요한 사항을 적어주세요. -->
8/4->8/5로 넘어가는 자정에 prod 배포 예정입니다!

### 📸 스크린샷, 없으면 이것 참,, 섭섭한데요?
![image](https://github.com/user-attachments/assets/00eedcad-c571-41d5-a3e2-d6b03fdd9219)

