### PR TITLE
fix: 끝말잇기 max-width 변경

### DIFF
--- a/src/components/feed/page/layout/DesktopCommunityLayout.tsx
+++ b/src/components/feed/page/layout/DesktopCommunityLayout.tsx
@@ -41,7 +41,7 @@ export default DesktopCommunityLayout;
 const WordChainWrapper = styled.div`
   margin: 0 auto;
   min-width: 0;
-  max-width: 560px;
+  max-width: 912px;
 `;
 
 const Container = styled.div`


### PR DESCRIPTION
### 🤫 쉿, 나한테만 말해줘요. 이슈넘버
- close #1497

### 🧐 어떤 것을 변경했어요~?
<!-- 실제로 변경한 사항을 설명해주세요.-->
- home에서 끝말잇기 진입점의 max-width 변경

### 🤔 그렇다면, 어떻게 구현했어요~?
<!-- 실제로 구현한 로직에 대해 설명해주세요.-->
![image](https://github.com/user-attachments/assets/d2370114-09be-493e-92a6-0f8998338a5f)

이렇게 들어가야하는데

![image](https://github.com/user-attachments/assets/afc21468-9535-4447-aeb8-5a45e5ba617f)

이렇게 되어있는 것이 문제였어요.

지난번에 다짐 메시지 배너를 넣으면서, 끝말잇기 진입점의 max-width를 변경해야 했거든요..!
해당 부분을 되돌리는 작업을 했습니다.

### ❤️‍🔥 당신이 생각하는 PR포인트, 내겐 매력포인트.
<!-- 해당 PR에서 논의가 필요한 사항을 적어주세요. -->

### 📸 스크린샷, 없으면 이것 참,, 섭섭한데요?
