### PR TITLE
fix: 프로젝트 검색값이 비어있을시 파라미터 제거 및 empty 뷰 추가

### DIFF
--- a/src/components/projects/main/ProjectList.tsx
+++ b/src/components/projects/main/ProjectList.tsx
@@ -1,25 +1,25 @@
 import styled from '@emotion/styled';
 import { colors } from '@sopt-makers/colors';
+import { fonts } from '@sopt-makers/fonts';
+import { Flex, width100 } from '@toss/emotion-utils';
 import { ImpressionArea } from '@toss/impression-area';
+import { useDebounce } from '@toss/react';
 import { uniqBy as _uniqBy } from 'lodash-es';
 import Link from 'next/link';
+import { useEffect, useState } from 'react';
+import { BooleanParam, createEnumParam, StringParam, useQueryParams, withDefault } from 'use-query-params';
 
+import Responsive from '@/components/common/Responsive';
 import Text from '@/components/common/Text';
+import MobileProjectCard from '@/components/projects/main/card/MobileProjectCard';
 import ProjectCard from '@/components/projects/main/card/ProjectCard';
+import ProjectCategorySelect from '@/components/projects/main/ProjectCategorySelect';
+import ProjectFilterChip from '@/components/projects/main/ProjectFilterChip';
+import ProjectSearch from '@/components/projects/main/ProjectSearch';
 import useGetProjectListQuery from '@/components/projects/upload/hooks/useGetProjectListQuery';
 import { playgroundLink } from '@/constants/links';
 import { MOBILE_MEDIA_QUERY } from '@/styles/mediaQuery';
 import { textStyles } from '@/styles/typography';
-import ProjectSearch from '@/components/projects/main/ProjectSearch';
-import { BooleanParam, createEnumParam, StringParam, useQueryParams, withDefault } from 'use-query-params';
-import { useDebounce } from '@toss/react';
-import { fonts } from '@sopt-makers/fonts';
-import { useEffect, useState } from 'react';
-import { Flex, width100 } from '@toss/emotion-utils';
-import ProjectFilterChip from '@/components/projects/main/ProjectFilterChip';
-import Responsive from '@/components/common/Responsive';
-import ProjectCategorySelect from '@/components/projects/main/ProjectCategorySelect';
-import MobileProjectCard from '@/components/projects/main/card/MobileProjectCard';
 
 type ProjectCategory = 'APPJAM' | 'SOPKATHON' | 'SOPTERM' | 'STUDY' | 'ETC';
 
@@ -40,7 +40,7 @@ const ProjectList = () => {
   });
   const [value, setValue] = useState(queryParams.name);
   const [totalCount, setTotalCount] = useState<number>();
-  const debouncedChangeName = useDebounce((value: string) => setQueryParams({ name: value }), 300);
+  const debouncedChangeName = useDebounce((value: string | undefined) => setQueryParams({ name: value }), 300);
   const { data, isLoading, fetchNextPage } = useGetProjectListQuery({
     limit: 20,
     name: queryParams.name,
@@ -63,7 +63,7 @@ const ProjectList = () => {
           value={value ?? queryParams.name}
           onValueChange={(value) => {
             setValue(value);
-            debouncedChangeName(value);
+            debouncedChangeName(value || undefined);
           }}
           placeholder='프로젝트 검색'
         />
@@ -74,13 +74,13 @@ const ProjectList = () => {
               <Flex css={{ gap: 6 }} align='center'>
                 <ProjectFilterChip
                   checked={queryParams.isAvailable ?? false}
-                  onCheckedChange={(checked) => setQueryParams({ isAvailable: checked })}
+                  onCheckedChange={(checked) => setQueryParams({ isAvailable: checked || undefined })}
                 >
                   이용 가능한 서비스
                 </ProjectFilterChip>
                 <ProjectFilterChip
                   checked={queryParams.isFounding ?? false}
-                  onCheckedChange={(checked) => setQueryParams({ isFounding: checked })}
+                  onCheckedChange={(checked) => setQueryParams({ isFounding: checked || undefined })}
                 >
                   창업 중
                 </ProjectFilterChip>
@@ -106,14 +106,14 @@ const ProjectList = () => {
                   <ProjectFilterChip
                     size='small'
                     checked={queryParams.isAvailable ?? false}
-                    onCheckedChange={(checked) => setQueryParams({ isAvailable: checked })}
+                    onCheckedChange={(checked) => setQueryParams({ isAvailable: checked || undefined })}
                   >
                     이용 가능한 서비스
                   </ProjectFilterChip>
                   <ProjectFilterChip
                     size='small'
                     checked={queryParams.isFounding ?? false}
-                    onCheckedChange={(checked) => setQueryParams({ isFounding: checked })}
+                    onCheckedChange={(checked) => setQueryParams({ isFounding: checked || undefined })}
                   >
                     창업 중
                   </ProjectFilterChip>

--- a/src/components/projects/main/ProjectList.tsx
+++ b/src/components/projects/main/ProjectList.tsx
@@ -41,7 +41,7 @@ const ProjectList = () => {
   const [value, setValue] = useState(queryParams.name);
   const [totalCount, setTotalCount] = useState<number>();
   const debouncedChangeName = useDebounce((value: string | undefined) => setQueryParams({ name: value }), 300);
-  const { data, fetchNextPage, isLoading } = useGetProjectListQuery({
+  const { data, fetchNextPage } = useGetProjectListQuery({
     limit: 20,
     name: queryParams.name,
     isAvailable: queryParams.isAvailable,

--- a/src/components/projects/main/ProjectList.tsx
+++ b/src/components/projects/main/ProjectList.tsx
@@ -213,6 +213,7 @@ const StyledContent = styled.div`
   gap: 20px;
   align-items: center;
   margin: 64px 0;
+  min-width: ${CONTAINER_MAX_WIDTH}px;
   min-height: 100vh;
 
   @media screen and (max-width: ${CONTAINER_MAX_WIDTH}px) {


### PR DESCRIPTION
### 🤫 쉿, 나한테만 말해줘요. 이슈넘버
- close #1506

### 🧐 어떤 것을 변경했어요~?
<!-- 실제로 변경한 사항을 설명해주세요.-->
- [x] 검색 파라미터의 value가 비어있다면 파라미터 key,value를 아예 제거합니다.
- [x] 검색 결과값이 없을 때 보여줄 empty 뷰를 추가합니다.

### 🤔 그렇다면, 어떻게 구현했어요~?
<!-- 실제로 구현한 로직에 대해 설명해주세요.-->
- 디바운싱에 넘겨주는 검색값이 빈 문자열이라면, undefined을 넘겨주어 해당 쿼리파라미터(?name=)를 삭제합니다
- '이용가능한 서비스', '창업 중' 필터링 뱃지에 대해서도 마찬가지로, 필터링 값이 false라면 undefined를 넘겨주어 해당 쿼리파라미터(?isAvailable=, ?isFounding=)를 삭제합니다.
- 검색 결과가 없을 시 '멤버' 뷰에서 사용하는 empty 뷰와 동일하게 보여줍니다.

### ❤️‍🔥 당신이 생각하는 PR포인트, 내겐 매력포인트.
<!-- 해당 PR에서 논의가 필요한 사항을 적어주세요. -->
#### 결과값 없을 시 empty 뷰 관련
프로젝트 탭에서 결과값이 없을 때 어떻게 보여주는지에 대한 내용을 지난 기수 히스토리에서 찾지 못하여... 멤버탭과 동일하게 넣게 되었습니다. 멤버탭과 동일하게 넣는것이 기존의 없었던 뷰를 대체하는 걸로는 충분하다고 생각해서 이렇게 작업하였습니다!

### 📸 스크린샷, 없으면 이것 참,, 섭섭한데요?


#### 전

https://github.com/user-attachments/assets/449944f9-b3f5-4009-823d-6e7b78125c3c

url에 주목해서 보시면, 필터링 뱃지를 클릭했다가 해제하면 쿼리 파라미터의 value가 0인채로 남아있으며, 이름을 검색했다가 모두 지웠을 때는 쿼리 파라미터의 value가 빈 문자열로 남아있어서 아무것도 결과값이 뜨지 않는 문제가 발생합니다. 결과값이 없을 때의 예외 뷰도 없습니다.

#### 후

https://github.com/user-attachments/assets/ec885c4e-b390-48f2-935f-6f4aab58c618

필터링 뱃지를 클릭했다가 해제했을 때는 해당 쿼리 파라미터(?isFounding=, ?isAvailable=)를 굳이 url에 가지고있을 필요가 없으므로 아예 삭제하는 걸 볼 수 있습니다.
이름 검색도 마찬가지로 빈 문자열일 경우에는 해당 쿼리 파라미터(?name=)를 제거합니다.
결과값이 없을 때는 empty 뷰를 추가했으며 반응형을 고려했습니다.