### PR TITLE
feat: 광고 배너 유무에 따른 끝말잇기 배너 변경

### DIFF
--- a/src/components/common/Banner/AdsBanner/constants/ads.ts
+++ b/src/components/common/Banner/AdsBanner/constants/ads.ts
@@ -1,12 +1,12 @@
 export const ADS = [
-  {
-    id: 1,
-    image: 'https://i.pinimg.com/564x/e5/ee/96/e5ee9675e45a21da9033bb82f634dc19.jpg',
-    url: 'https://www.naver.com',
-  },
-  {
-    id: 2,
-    image: 'https://i.pinimg.com/564x/69/06/5d/69065d550af6693ee3ad267836f78de0.jpg',
-    url: 'https://www.naver.com',
-  },
+  // {
+  //   id: 1,
+  //   image: 'https://i.pinimg.com/564x/e5/ee/96/e5ee9675e45a21da9033bb82f634dc19.jpg',
+  //   url: 'https://www.naver.com',
+  // },
+  // {
+  //   id: 2,
+  //   image: 'https://i.pinimg.com/564x/69/06/5d/69065d550af6693ee3ad267836f78de0.jpg',
+  //   url: 'https://www.naver.com',
+  // },
 ];

--- a/src/components/feed/page/layout/DesktopCommunityLayout.tsx
+++ b/src/components/feed/page/layout/DesktopCommunityLayout.tsx
@@ -3,9 +3,10 @@ import { colors } from '@sopt-makers/colors';
 import { m } from 'framer-motion';
 import { FC, ReactNode } from 'react';
 
+import { ADS } from '@/components/common/Banner/AdsBanner/constants/ads';
 import { layoutCSSVariable } from '@/components/layout/utils';
 import WordChainEntry from '@/components/wordchain/WordchainEntry/WordChainEntry';
-import { MOBILE_MAX_WIDTH } from '@/styles/mediaQuery';
+import { css } from '@emotion/react';
 
 interface DesktopCommunityLayoutProps {
   isDetailOpen: boolean;
@@ -16,9 +17,11 @@ interface DesktopCommunityLayoutProps {
 const DETAIL_SLOT_WIDTH = 560;
 
 const DesktopCommunityLayout: FC<DesktopCommunityLayoutProps> = ({ isDetailOpen, listSlot, detailSlot }) => {
+  const isBanner = ADS && ADS.length > 0;
+
   return (
     <div style={{ margin: '0 30px' }}>
-      <WordChainWrapper>
+      <WordChainWrapper isBanner={isBanner}>
         <WordChainEntry />
       </WordChainWrapper>
       <Container>
@@ -39,14 +42,17 @@ const DesktopCommunityLayout: FC<DesktopCommunityLayoutProps> = ({ isDetailOpen,
 
 export default DesktopCommunityLayout;
 
-const WordChainWrapper = styled.div`
+const WordChainWrapper = styled.div<{ isBanner: boolean }>`
   margin: 0 auto;
   min-width: 0;
-  max-width: 560px;
+  max-width: 912px;
 
-  @media ${MOBILE_MAX_WIDTH} {
-    max-width: 912px;
-  }
+  ${({ isBanner }) =>
+    isBanner &&
+    css`
+      margin-bottom: 16px;
+      max-width: 560px;
+    `}
 `;
 
 const Container = styled.div`

--- a/src/components/wordchain/WordchainEntry/WordChainEntry.tsx
+++ b/src/components/wordchain/WordchainEntry/WordChainEntry.tsx
@@ -269,10 +269,10 @@ const Container = styled(Link)<{ isBanner?: boolean }>`
     padding: 0;
     width: 100%;
 
-    &:hover {
+    /* &:hover {
       background-color: transparent;
       cursor: default;
-    }
+    } */
   }
 `;
 
@@ -439,10 +439,10 @@ const GotoWordChainWrapper = styled.aside<{ isBanner?: boolean }>`
     border-radius: 14px;
     padding: 18px 17px;
 
-    &:hover {
+    /* &:hover {
       background-color: ${colors.gray800};
       cursor: pointer;
-    }
+    } */
   }
 `;
 

--- a/src/components/wordchain/WordchainEntry/WordChainEntry.tsx
+++ b/src/components/wordchain/WordchainEntry/WordChainEntry.tsx
@@ -6,21 +6,23 @@ import Link from 'next/link';
 import { FC } from 'react';
 
 import { useGetEntryWordchain } from '@/api/endpoint/wordchain/getWordchain';
+import { ADS } from '@/components/common/Banner/AdsBanner/constants/ads';
 import Loading from '@/components/common/Loading';
 import Responsive from '@/components/common/Responsive';
 import Text from '@/components/common/Text';
 import useEventLogger from '@/components/eventLogger/hooks/useEventLogger';
+import WordchainMessage from '@/components/wordchain/WordchainEntry/WordchainMessage';
 import { useWordchainWinnersQuery } from '@/components/wordchain/WordchainWinners/hooks/useWordchainWinnersQuery';
 import { playgroundLink } from '@/constants/links';
 import IconMessageChat from '@/public/icons/icon-message-chat.svg';
+import { MOBILE_MEDIA_QUERY } from '@/styles/mediaQuery';
 import { textStyles } from '@/styles/typography';
 import { SwitchCase } from '@/utils/components/switch-case/SwitchCase';
+import { css } from '@emotion/react';
 
 interface WordChainEntryProps {
   className?: string;
 }
-
-const TEMPORARY_MEDIA_QUERY = 'screen and (min-width: 0px)';
 
 const WordChainEntry: FC<WordChainEntryProps> = ({ className }) => {
   const { data, isLoading } = useGetEntryWordchain();
@@ -33,113 +35,171 @@ const WordChainEntry: FC<WordChainEntryProps> = ({ className }) => {
   const isGameStart = wordList?.length === 0 && data?.currentWinner === null;
   const status = isGameStart ? 'start' : 'progress';
   const lastWinner = wordchainWinnersData?.pages[0].winners[0];
+  const isBanner = ADS && ADS.length > 0;
 
   return (
-    <Container className={className} href={playgroundLink.wordchain()} onClick={() => logClickEvent('wordchainEntry')}>
+    <Container
+      className={className}
+      href={playgroundLink.wordchain()}
+      onClick={() => logClickEvent('wordchainEntry')}
+      isBanner={isBanner}
+    >
       {(isLoading || !wordList) && (
-        <LoadingContainer>
+        <LoadingContainer isBanner={isBanner}>
           <Loading />
         </LoadingContainer>
       )}
       {wordList && (
         <>
           <LeftSection>
-            {/* <Responsive only='desktop'>
-              <StyledIconMessageChat />
-            </Responsive> */}
+            {!isBanner && (
+              <Responsive only='desktop'>
+                <StyledIconMessageChat />
+              </Responsive>
+            )}
             <div style={{ width: '100%' }}>
-              <TitleWrapper>
+              <TitleWrapper isBanner={isBanner}>
                 <SwitchCase
                   value={status}
                   caseBy={{
                     start: (
                       <>
-                        {/* <Responsive only='desktop'>
-                          {lastWinner ? (
-                            <StyledTitle>
-                              {lastWinner?.roomId}번째 우승자는
-                              <br />
-                              <LastWord>{lastWinner?.winner.name}</LastWord>님 입니다!
-                            </StyledTitle>
-                          ) : (
-                            <StyledTitle>
-                              SOPT 회원들과 끝말잇기 할 사람,
-                              <br />
-                              지금이 바로 명예의 전당에 오를 기회!
-                            </StyledTitle>
-                          )}
-                        </Responsive>
-                        <MobileResponsive only='mobile'> */}
-                        <GotoWordChainWrapper>
-                          <GotoWordChainContents>
-                            <Flex align='center' style={{ gap: 4 }}>
-                              <StyledIconMessageChat />
-                              <GotoWordChainTitle>끝말잇기</GotoWordChainTitle>
-                            </Flex>
-                            {lastWinner ? (
-                              <GotoWordChainSub>
-                                이번 우승자는 <LastWord>{lastWinner?.winner.name}</LastWord>님 입니다! '
-                                {data.nextSyllable}'(으)로 시작하는 단어는?
-                              </GotoWordChainSub>
-                            ) : (
-                              <GotoWordChainSub>우승하고 명예의 전당에 올라가보세요!</GotoWordChainSub>
-                            )}
-                          </GotoWordChainContents>
-                          <div style={{ minWidth: 20 }}>
-                            <ArrowIcon width={20} height={20} />
-                          </div>
-                        </GotoWordChainWrapper>
-                        {/* </MobileResponsive> */}
+                        {!isBanner ? (
+                          <>
+                            <Responsive only='desktop'>
+                              {lastWinner ? (
+                                <StyledTitle>
+                                  {lastWinner?.roomId}번째 우승자는
+                                  <br />
+                                  <LastWord>{lastWinner?.winner.name}</LastWord>님 입니다!
+                                </StyledTitle>
+                              ) : (
+                                <StyledTitle>
+                                  SOPT 회원들과 끝말잇기 할 사람,
+                                  <br />
+                                  지금이 바로 명예의 전당에 오를 기회!
+                                </StyledTitle>
+                              )}
+                            </Responsive>
+                            <MobileResponsive only='mobile'>
+                              <GotoWordChainWrapper>
+                                <GotoWordChainContents>
+                                  <Flex align='center' style={{ gap: 4 }}>
+                                    <StyledIconMessageChat />
+                                    <GotoWordChainTitle>끝말잇기</GotoWordChainTitle>
+                                  </Flex>
+                                  {lastWinner ? (
+                                    <GotoWordChainSub>
+                                      이번 우승자는 <LastWord>{lastWinner?.winner.name}</LastWord>님 입니다! '
+                                      {data.nextSyllable}'(으)로 시작하는 단어는?
+                                    </GotoWordChainSub>
+                                  ) : (
+                                    <GotoWordChainSub>우승하고 명예의 전당에 올라가보세요!</GotoWordChainSub>
+                                  )}
+                                </GotoWordChainContents>
+                                <div style={{ minWidth: 20 }}>
+                                  <ArrowIcon width={20} height={20} />
+                                </div>
+                              </GotoWordChainWrapper>
+                            </MobileResponsive>
+                          </>
+                        ) : (
+                          <GotoWordChainWrapper isBanner={isBanner}>
+                            <GotoWordChainContents isBanner={isBanner}>
+                              <Flex align='center' style={{ gap: 4 }}>
+                                <StyledIconMessageChat isBanner={isBanner} />
+                                <GotoWordChainTitle>끝말잇기</GotoWordChainTitle>
+                              </Flex>
+                              {lastWinner ? (
+                                <GotoWordChainSub>
+                                  이번 우승자는 <LastWord>{lastWinner?.winner.name}</LastWord>님 입니다! '
+                                  {data.nextSyllable}'(으)로 시작하는 단어는?
+                                </GotoWordChainSub>
+                              ) : (
+                                <GotoWordChainSub>우승하고 명예의 전당에 올라가보세요!</GotoWordChainSub>
+                              )}
+                            </GotoWordChainContents>
+                            <div style={{ minWidth: 20 }}>
+                              <ArrowIcon width={20} height={20} />
+                            </div>
+                          </GotoWordChainWrapper>
+                        )}
                       </>
                     ),
                     progress: (
                       <>
-                        {/* <Responsive only='desktop'>
-                          <StyledTitle>
-                            현재 {`'${data?.currentWinner?.name}'`}님이 <br />
-                            끝말잇기를 이기고 있어요!
-                          </StyledTitle>
-                        </Responsive>
-                        <MobileResponsive only='mobile'> */}
-                        <GotoWordChainWrapper>
-                          <GotoWordChainContents>
-                            <Flex align='center' style={{ gap: 4 }}>
-                              <StyledIconMessageChat />
-                              <GotoWordChainTitle>끝말잇기</GotoWordChainTitle>
-                            </Flex>
-                            {lastWord != null && (
-                              <GotoWordChainSub>
-                                {`${data?.currentWinner?.name}`}님이 <LastWord>{data.nextSyllable}</LastWord>(으)로
-                                끝냈어요. 끝말을 이어주세요!
-                              </GotoWordChainSub>
-                            )}
-                          </GotoWordChainContents>
-                          <div style={{ minWidth: 20 }}>
-                            <ArrowIcon width={20} height={20} />
-                          </div>
-                        </GotoWordChainWrapper>
-                        {/* </MobileResponsive> */}
+                        {!isBanner ? (
+                          <>
+                            <Responsive only='desktop'>
+                              <StyledTitle>
+                                현재 {`'${data?.currentWinner?.name}'`}님이 <br />
+                                끝말잇기를 이기고 있어요!
+                              </StyledTitle>
+                            </Responsive>
+                            <MobileResponsive only='mobile'>
+                              <GotoWordChainWrapper>
+                                <GotoWordChainContents>
+                                  <Flex align='center' style={{ gap: 4 }}>
+                                    <StyledIconMessageChat />
+                                    <GotoWordChainTitle>끝말잇기</GotoWordChainTitle>
+                                  </Flex>
+                                  {lastWord != null && (
+                                    <GotoWordChainSub>
+                                      {`${data?.currentWinner?.name}`}님이 <LastWord>{data.nextSyllable}</LastWord>
+                                      (으)로 끝냈어요. 끝말을 이어주세요!
+                                    </GotoWordChainSub>
+                                  )}
+                                </GotoWordChainContents>
+                                <div style={{ minWidth: 20 }}>
+                                  <ArrowIcon width={20} height={20} />
+                                </div>
+                              </GotoWordChainWrapper>
+                            </MobileResponsive>
+                          </>
+                        ) : (
+                          <GotoWordChainWrapper isBanner={isBanner}>
+                            <GotoWordChainContents isBanner={isBanner}>
+                              <Flex align='center' style={{ gap: 4 }}>
+                                <StyledIconMessageChat isBanner={isBanner} />
+                                <GotoWordChainTitle>끝말잇기</GotoWordChainTitle>
+                              </Flex>
+                              {lastWord != null && (
+                                <GotoWordChainSub>
+                                  {`${data?.currentWinner?.name}`}님이 <LastWord>{data.nextSyllable}</LastWord>(으)로
+                                  끝냈어요. 끝말을 이어주세요!
+                                </GotoWordChainSub>
+                              )}
+                            </GotoWordChainContents>
+                            <div style={{ minWidth: 20 }}>
+                              <ArrowIcon width={20} height={20} />
+                            </div>
+                          </GotoWordChainWrapper>
+                        )}
                       </>
                     ),
                   }}
                 />
               </TitleWrapper>
-              {/* <Responsive only='desktop'>
-                <WordchainText>
-                  {(lastWinner?.roomId ?? 0) + 1}번째 끝말잇기 우승자 도전하러 가기
-                  <ArrowIcon />
-                </WordchainText>
-              </Responsive> */}
+              {!isBanner && (
+                <Responsive only='desktop'>
+                  <WordchainText>
+                    {(lastWinner?.roomId ?? 0) + 1}번째 끝말잇기 우승자 도전하러 가기
+                    <ArrowIcon />
+                  </WordchainText>
+                </Responsive>
+              )}
             </div>
           </LeftSection>
-          <RightSection isStart={status === 'start'}>
-            {/* <Responsive only='desktop'>
-              <WordWrapper>
-                {status === 'start' && <WordchainMessage type='startWord' word={data.nextSyllable} />}
-                {lastUser && <WordchainMessage type='word' word={data.nextSyllable} user={lastUser} />}
-              </WordWrapper>
-            </Responsive> */}
-          </RightSection>
+          {!isBanner && (
+            <RightSection isStart={status === 'start'}>
+              <Responsive only='desktop'>
+                <WordWrapper>
+                  {status === 'start' && <WordchainMessage type='startWord' word={data.nextSyllable} />}
+                  {lastUser && <WordchainMessage type='word' word={data.nextSyllable} user={lastUser} />}
+                </WordWrapper>
+              </Responsive>
+            </RightSection>
+          )}
         </>
       )}
     </Container>
@@ -148,19 +208,25 @@ const WordChainEntry: FC<WordChainEntryProps> = ({ className }) => {
 
 export default WordChainEntry;
 
-const LoadingContainer = styled.div`
+const LoadingContainer = styled.div<{ isBanner?: boolean }>`
   display: flex;
   align-items: center;
   justify-content: center;
   width: 100%;
   height: 92px;
 
-  @media ${TEMPORARY_MEDIA_QUERY} {
+  ${({ isBanner }) =>
+    isBanner &&
+    css`
+      height: 91.5px;
+    `}
+
+  @media ${MOBILE_MEDIA_QUERY} {
     height: 91.5px;
   }
 `;
 
-const Container = styled(Link)`
+const Container = styled(Link)<{ isBanner?: boolean }>`
   display: flex;
   justify-content: space-between;
   transition: background-color 0.2s;
@@ -175,7 +241,25 @@ const Container = styled(Link)`
     background-color: ${colors.gray800};
   }
 
-  @media ${TEMPORARY_MEDIA_QUERY} {
+  ${({ isBanner }) =>
+    isBanner &&
+    css`
+      flex-direction: column;
+      align-items: center;
+      justify-content: center;
+      margin: 0;
+      border-radius: 0;
+      background-color: ${colors.gray950};
+      padding: 0;
+      width: 100%;
+
+      &:hover {
+        background-color: transparent;
+        cursor: default;
+      }
+    `}
+
+  @media ${MOBILE_MEDIA_QUERY} {
     flex-direction: column;
     align-items: center;
     justify-content: center;
@@ -192,43 +276,74 @@ const Container = styled(Link)`
   }
 `;
 
-const TitleWrapper = styled.div`
+const TitleWrapper = styled.div<{ isBanner?: boolean }>`
   white-space: nowrap;
-  @media ${TEMPORARY_MEDIA_QUERY} {
+
+  ${({ isBanner }) =>
+    isBanner &&
+    css`
+      display: flex;
+      gap: 4px;
+      align-items: center;
+    `}
+
+  @media ${MOBILE_MEDIA_QUERY} {
     display: flex;
     gap: 4px;
     align-items: center;
   }
 `;
 
-const StyledIconMessageChat = styled(IconMessageChat)`
-  @media ${TEMPORARY_MEDIA_QUERY} {
+const StyledIconMessageChat = styled(IconMessageChat)<{ isBanner?: boolean }>`
+  ${({ isBanner }) =>
+    isBanner &&
+    css`
+      width: 20px;
+      height: 20px;
+    `}
+
+  @media ${MOBILE_MEDIA_QUERY} {
     width: 20px;
     height: 20px;
   }
 `;
 
-const LeftSection = styled.div`
+const LeftSection = styled.div<{ isBanner?: boolean }>`
   display: flex;
   gap: 12px;
   width: 100%;
-  @media ${TEMPORARY_MEDIA_QUERY} {
+
+  ${({ isBanner }) =>
+    isBanner &&
+    css`
+      display: contents;
+      gap: 0;
+    `}
+
+  @media ${MOBILE_MEDIA_QUERY} {
     display: contents;
     gap: 0;
   }
 `;
 
-const StyledTitle = styled(Text)`
+const StyledTitle = styled(Text)<{ isBanner?: boolean }>`
   display: block;
   ${fonts.HEADING_18_B}
 
-  @media ${TEMPORARY_MEDIA_QUERY} {
+  ${({ isBanner }) =>
+    isBanner &&
+    css`
+      margin: 0;
+      ${textStyles.SUIT_20_B};
+    `}
+
+  @media ${MOBILE_MEDIA_QUERY} {
     margin: 0;
     ${textStyles.SUIT_20_B};
   }
 `;
 
-const WordchainText = styled(Text)`
+const WordchainText = styled(Text)<{ isBanner?: boolean }>`
   display: flex;
   column-gap: 2px;
   align-items: center;
@@ -236,7 +351,22 @@ const WordchainText = styled(Text)`
   white-space: nowrap;
   ${fonts.LABEL_12_SB}
 
-  @media ${TEMPORARY_MEDIA_QUERY} {
+  ${({ isBanner }) =>
+    isBanner &&
+    css`
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      border-radius: 12px;
+      background-color: ${colors.gray800};
+      padding: 14px 0;
+      width: 100%;
+
+      ${textStyles.SUIT_12_SB}
+    `}
+
+
+  @media ${MOBILE_MEDIA_QUERY} {
     display: flex;
     align-items: center;
     justify-content: center;
@@ -253,14 +383,21 @@ const MobileResponsive = styled(Responsive)`
   width: 100%;
 `;
 
-const RightSection = styled.div<{ isStart: boolean }>`
+const RightSection = styled.div<{ isStart: boolean; isBanner?: boolean }>`
   display: flex;
   flex-direction: column;
   gap: 8px;
   justify-content: ${({ isStart }) => (isStart ? 'flex-start' : 'flex-end')};
   width: 100%;
 
-  @media ${TEMPORARY_MEDIA_QUERY} {
+  ${({ isBanner }) =>
+    isBanner &&
+    css`
+      gap: 10px;
+      margin-top: 16px;
+    `}
+
+  @media ${MOBILE_MEDIA_QUERY} {
     gap: 10px;
     margin-top: 16px;
   }
@@ -273,7 +410,7 @@ const WordWrapper = styled.div`
   margin-bottom: 12px;
 `;
 
-const GotoWordChainWrapper = styled.aside`
+const GotoWordChainWrapper = styled.aside<{ isBanner?: boolean }>`
   display: flex;
   gap: 16px;
   align-items: center;
@@ -284,7 +421,20 @@ const GotoWordChainWrapper = styled.aside`
   padding: 16px;
   width: 100%;
 
-  @media ${TEMPORARY_MEDIA_QUERY} {
+  ${({ isBanner }) =>
+    isBanner &&
+    css`
+      gap: 8px;
+      border-radius: 14px;
+      padding: 18px 17px;
+
+      &:hover {
+        background-color: ${colors.gray800};
+        cursor: pointer;
+      }
+    `}
+
+  @media ${MOBILE_MEDIA_QUERY} {
     gap: 8px;
     border-radius: 14px;
     padding: 18px 17px;
@@ -296,11 +446,17 @@ const GotoWordChainWrapper = styled.aside`
   }
 `;
 
-const GotoWordChainContents = styled.div`
+const GotoWordChainContents = styled.div<{ isBanner?: boolean }>`
   display: flex;
   gap: 20px;
 
-  @media ${TEMPORARY_MEDIA_QUERY} {
+  ${({ isBanner }) =>
+    isBanner &&
+    css`
+      gap: 16px;
+    `}
+
+  @media ${MOBILE_MEDIA_QUERY} {
     gap: 16px;
   }
 `;


### PR DESCRIPTION
### 🤫 쉿, 나한테만 말해줘요. 이슈넘버
- close #1514

### 🧐 어떤 것을 변경했어요~?
<!-- 실제로 변경한 사항을 설명해주세요.-->
- 광고 배너 유무에 따라 끝말잇기 배너를 변경해주었어요.

### 🤔 그렇다면, 어떻게 구현했어요~?
<!-- 실제로 구현한 로직에 대해 설명해주세요.-->
- 광고 배너가 담긴 배열의 길이가 0보다 큰 경우를 배너가 있는 경우로 판단하여, isBanner를 props로 내려주었어요. 

### ❤️‍🔥 당신이 생각하는 PR포인트, 내겐 매력포인트.
<!-- 해당 PR에서 논의가 필요한 사항을 적어주세요. -->
- 미디어 쿼리랑 Responsive 태그가 중복으로 쓰이면서 반응형이 구현되어서, isBanner를 기점으로 분기처리가 많이 된 점이 아쉽구만요..
- ADS의 길이가 0이더라도, 다짐메시지 배너 등이 들어가게 되면 배너가 존재하는 상황이라서 이 경우에는 isBanner값에 
`const isBanner = ADS && ADS.length > 0||true;` 이런식으로 isBanner가 true값이 되도록 해주어야할 것 같아요

### 📸 스크린샷, 없으면 이것 참,, 섭섭한데요?
