### PR TITLE
fix: 프로필 수정 페이지에서 skill 항목 null safety 처리

### DIFF
--- a/src/pages/members/edit.tsx
+++ b/src/pages/members/edit.tsx
@@ -28,6 +28,7 @@ import MemberForm from '@/components/members/upload/forms/Form';
 import MemberFormHeader from '@/components/members/upload/forms/FormHeader';
 import BasicFormSection from '@/components/members/upload/FormSection/Basic';
 import CareerFormSection from '@/components/members/upload/FormSection/Career';
+import CoffeeChatFormSection from '@/components/members/upload/FormSection/CoffeeChat';
 import SoptActivityFormSection from '@/components/members/upload/FormSection/SoptActivity';
 import TmiFormSection from '@/components/members/upload/FormSection/Tmi';
 import { memberFormSchema } from '@/components/members/upload/schema';
@@ -36,7 +37,6 @@ import { playgroundLink } from '@/constants/links';
 import { setLayout } from '@/utils/layout';
 
 import { useGetMemberOfMe } from '../../api/endpoint/members/getMemberOfMe';
-import CoffeeChatFormSection from '@/components/members/upload/FormSection/CoffeeChat';
 
 export default function MemberEditPage() {
   const { logSubmitEvent } = useEventLogger();
@@ -161,7 +161,7 @@ export default function MemberEditPage() {
         university: myProfile.university,
         major: myProfile.major,
         introduction: myProfile.introduction,
-        skill: myProfile.skill,
+        skill: myProfile.skill ?? '',
         links: myProfile.links.length ? myProfile.links : [DEFAULT_LINK],
         activities: myProfile.soptActivities
           .sort((a, b) => a.generation - b.generation)


### PR DESCRIPTION
### 🤫 쉿, 나한테만 말해줘요. 이슈넘버
- close #1525 

### 🧐 어떤 것을 변경했어요~?
<!-- 실제로 변경한 사항을 설명해주세요.-->
skill 값이 null이나 undefined일시 빈 문자열로 초기화하도록 처리했습니다.

### 🤔 그렇다면, 어떻게 구현했어요~?
<!-- 실제로 구현한 로직에 대해 설명해주세요.-->
`skill: myProfile.skill ?? '',`

edit 페이지에 들어가면 useEffect로 작성된 프로필 항목들을 초기화하는데, 그 과정에서 skill이 null일 때 문제가 발생하고 있었습니다. 따라서 null이라면 빈 문자열로 들어가도록 처리했습니다.

### ❤️‍🔥 당신이 생각하는 PR포인트, 내겐 매력포인트.
<!-- 해당 PR에서 논의가 필요한 사항을 적어주세요. -->

### 📸 스크린샷, 없으면 이것 참,, 섭섭한데요?
