### PR TITLE
fix: 프로젝트 필터링 결과 없을때 예외처리 및 반응형 작업

### DIFF
--- a/src/api/endpoint_LEGACY/projects/type.ts
+++ b/src/api/endpoint_LEGACY/projects/type.ts
@@ -3,10 +3,10 @@ import { PROJECT_CATEGORY } from '@/components/projects/constants';
 export interface ProjectsRequestParams {
   limit?: number;
   cursor?: number;
-  name?: string;
-  isAvailable?: boolean;
-  isFounding?: boolean;
-  category?: string;
+  name?: string | null;
+  isAvailable?: boolean | null;
+  isFounding?: boolean | null;
+  category?: string | null;
 }
 
 export type ProjectDetail = {

--- a/src/components/projects/main/ProjectList.tsx
+++ b/src/components/projects/main/ProjectList.tsx
@@ -81,7 +81,9 @@ const ProjectList = () => {
                 </ProjectFilterChip>
                 <ProjectFilterChip
                   checked={queryParams.isFounding ?? false}
-                  onCheckedChange={(checked) => setQueryParams({ isFounding: checked })}
+                  onCheckedChange={(checked) => {
+                    return setQueryParams({ isFounding: checked ? true : undefined });
+                  }}
                 >
                   창업 중
                 </ProjectFilterChip>

--- a/src/components/projects/main/ProjectList.tsx
+++ b/src/components/projects/main/ProjectList.tsx
@@ -6,7 +6,7 @@ import { ImpressionArea } from '@toss/impression-area';
 import { useDebounce } from '@toss/react';
 import { uniqBy as _uniqBy } from 'lodash-es';
 import Link from 'next/link';
-import { useMemo, useState } from 'react';
+import React, { useMemo, useState } from 'react';
 import { BooleanParam, createEnumParam, StringParam, useQueryParams, withDefault } from 'use-query-params';
 
 import Loading from '@/components/common/Loading';
@@ -47,8 +47,6 @@ const ProjectList = () => {
     isFounding: queryParams.isFounding,
     category: queryParams.category ?? undefined,
   });
-
-  console.log('data', data);
 
   /* eslint-disable react-hooks/exhaustive-deps */
   const totalCount = useMemo(() => data?.pages[0].totalCount, [data?.pages[0].totalCount]);
@@ -155,7 +153,7 @@ const ProjectList = () => {
                   profileImage: member.memberProfileImage,
                 }));
                 return (
-                  <>
+                  <React.Fragment key={project.id}>
                     <Responsive only='desktop' asChild>
                       <Link href={playgroundLink.projectDetail(project.id)}>
                         <ProjectCard
@@ -185,7 +183,7 @@ const ProjectList = () => {
                         <div css={{ width: '100%', height: '1px', background: colors.gray700 }} />
                       </Link>
                     </Responsive>
-                  </>
+                  </React.Fragment>
                 );
               }),
             )}

--- a/src/components/projects/main/ProjectList.tsx
+++ b/src/components/projects/main/ProjectList.tsx
@@ -75,7 +75,7 @@ const ProjectList = () => {
               <Flex css={{ gap: 6 }} align='center'>
                 <ProjectFilterChip
                   checked={queryParams.isAvailable ?? false}
-                  onCheckedChange={(checked) => setQueryParams({ isAvailable: checked })}
+                  onCheckedChange={(checked) => setQueryParams({ isAvailable: checked ? true : undefined })}
                 >
                   이용 가능한 서비스
                 </ProjectFilterChip>

--- a/src/components/projects/main/ProjectList.tsx
+++ b/src/components/projects/main/ProjectList.tsx
@@ -48,8 +48,7 @@ const ProjectList = () => {
     category: queryParams.category,
   });
 
-  /* eslint-disable react-hooks/exhaustive-deps */
-  const totalCount = useMemo(() => data?.pages[0].totalCount, [data?.pages[0].totalCount]);
+  const totalCount = data?.pages[0].totalCount;
 
   return (
     <StyledContainer>

--- a/src/components/projects/main/ProjectList.tsx
+++ b/src/components/projects/main/ProjectList.tsx
@@ -9,6 +9,7 @@ import Link from 'next/link';
 import { useMemo, useState } from 'react';
 import { BooleanParam, createEnumParam, StringParam, useQueryParams, withDefault } from 'use-query-params';
 
+import Loading from '@/components/common/Loading';
 import Responsive from '@/components/common/Responsive';
 import Text from '@/components/common/Text';
 import MobileProjectCard from '@/components/projects/main/card/MobileProjectCard';
@@ -47,6 +48,8 @@ const ProjectList = () => {
     category: queryParams.category ?? undefined,
   });
 
+  console.log('data', data);
+
   /* eslint-disable react-hooks/exhaustive-deps */
   const totalCount = useMemo(() => data?.pages[0].totalCount, [data?.pages[0].totalCount]);
 
@@ -62,7 +65,11 @@ const ProjectList = () => {
           }}
           placeholder='프로젝트 검색'
         />
-        {data && (
+        {isLoading && !data ? (
+          <LoadingContainer>
+            <Loading />
+          </LoadingContainer>
+        ) : (
           <LengthWrapper>
             <StyledLength typography='SUIT_18_M'>전체 {totalCount}개</StyledLength>
             <Responsive only='desktop'>
@@ -334,5 +341,17 @@ const EmptyDescription = styled.span`
 
   @media ${MOBILE_MEDIA_QUERY} {
     ${fonts.BODY_14_M};
+  }
+`;
+
+const LoadingContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding: 290px 0;
+
+  @media ${MOBILE_MEDIA_QUERY} {
+    padding: 170px 0;
+    padding-bottom: 100px;
   }
 `;

--- a/src/components/projects/main/ProjectList.tsx
+++ b/src/components/projects/main/ProjectList.tsx
@@ -1,25 +1,25 @@
 import styled from '@emotion/styled';
 import { colors } from '@sopt-makers/colors';
+import { fonts } from '@sopt-makers/fonts';
+import { Flex, width100 } from '@toss/emotion-utils';
 import { ImpressionArea } from '@toss/impression-area';
+import { useDebounce } from '@toss/react';
 import { uniqBy as _uniqBy } from 'lodash-es';
 import Link from 'next/link';
+import { useEffect, useState } from 'react';
+import { BooleanParam, createEnumParam, StringParam, useQueryParams, withDefault } from 'use-query-params';
 
+import Responsive from '@/components/common/Responsive';
 import Text from '@/components/common/Text';
+import MobileProjectCard from '@/components/projects/main/card/MobileProjectCard';
 import ProjectCard from '@/components/projects/main/card/ProjectCard';
+import ProjectCategorySelect from '@/components/projects/main/ProjectCategorySelect';
+import ProjectFilterChip from '@/components/projects/main/ProjectFilterChip';
+import ProjectSearch from '@/components/projects/main/ProjectSearch';
 import useGetProjectListQuery from '@/components/projects/upload/hooks/useGetProjectListQuery';
 import { playgroundLink } from '@/constants/links';
 import { MOBILE_MEDIA_QUERY } from '@/styles/mediaQuery';
 import { textStyles } from '@/styles/typography';
-import ProjectSearch from '@/components/projects/main/ProjectSearch';
-import { BooleanParam, createEnumParam, StringParam, useQueryParams, withDefault } from 'use-query-params';
-import { useDebounce } from '@toss/react';
-import { fonts } from '@sopt-makers/fonts';
-import { useEffect, useState } from 'react';
-import { Flex, width100 } from '@toss/emotion-utils';
-import ProjectFilterChip from '@/components/projects/main/ProjectFilterChip';
-import Responsive from '@/components/common/Responsive';
-import ProjectCategorySelect from '@/components/projects/main/ProjectCategorySelect';
-import MobileProjectCard from '@/components/projects/main/card/MobileProjectCard';
 
 type ProjectCategory = 'APPJAM' | 'SOPKATHON' | 'SOPTERM' | 'STUDY' | 'ETC';
 

--- a/src/components/projects/main/ProjectList.tsx
+++ b/src/components/projects/main/ProjectList.tsx
@@ -48,7 +48,7 @@ const ProjectList = () => {
     category: queryParams.category,
   });
 
-  const totalCount = data?.pages[0].totalCount;
+  const totalCount = data?.pages && data.pages[0].totalCount;
 
   return (
     <StyledContainer>

--- a/src/components/projects/main/ProjectList.tsx
+++ b/src/components/projects/main/ProjectList.tsx
@@ -33,19 +33,19 @@ const PROJECT_CATEGORY_LIST: Array<{ value: ProjectCategory; label: string }> = 
 
 const ProjectList = () => {
   const [queryParams, setQueryParams] = useQueryParams({
-    name: withDefault(StringParam, undefined),
-    isAvailable: withDefault(BooleanParam, undefined),
-    isFounding: withDefault(BooleanParam, undefined),
+    name: withDefault(StringParam, null),
+    isAvailable: withDefault(BooleanParam, null),
+    isFounding: withDefault(BooleanParam, null),
     category: createEnumParam<ProjectCategory>(['APPJAM', 'SOPKATHON', 'SOPTERM', 'STUDY', 'ETC']),
   });
   const [value, setValue] = useState(queryParams.name);
-  const debouncedChangeName = useDebounce((value: string | undefined) => setQueryParams({ name: value }), 300);
+  const debouncedChangeName = useDebounce((value: string | null) => setQueryParams({ name: value }), 300);
   const { data, isLoading, fetchNextPage } = useGetProjectListQuery({
     limit: 20,
     name: queryParams.name,
     isAvailable: queryParams.isAvailable,
     isFounding: queryParams.isFounding,
-    category: queryParams.category ?? undefined,
+    category: queryParams.category,
   });
 
   /* eslint-disable react-hooks/exhaustive-deps */
@@ -55,15 +55,14 @@ const ProjectList = () => {
     <StyledContainer>
       <StyledContent>
         <ProjectSearch
-          value={value ?? queryParams.name}
+          value={value ?? ''}
           onValueChange={(value) => {
             setValue(value);
-            if (value === '') debouncedChangeName(undefined);
-            else debouncedChangeName(value);
+            debouncedChangeName(value === '' ? null : value);
           }}
           placeholder='프로젝트 검색'
         />
-        {isLoading && !data ? (
+        {isLoading ? (
           <LoadingContainer>
             <Loading />
           </LoadingContainer>
@@ -74,15 +73,13 @@ const ProjectList = () => {
               <Flex css={{ gap: 6 }} align='center'>
                 <ProjectFilterChip
                   checked={queryParams.isAvailable ?? false}
-                  onCheckedChange={(checked) => setQueryParams({ isAvailable: checked ? true : undefined })}
+                  onCheckedChange={(checked) => setQueryParams({ isAvailable: checked || null })}
                 >
                   이용 가능한 서비스
                 </ProjectFilterChip>
                 <ProjectFilterChip
                   checked={queryParams.isFounding ?? false}
-                  onCheckedChange={(checked) => {
-                    return setQueryParams({ isFounding: checked ? true : undefined });
-                  }}
+                  onCheckedChange={(checked) => setQueryParams({ isFounding: checked || null })}
                 >
                   창업 중
                 </ProjectFilterChip>
@@ -90,7 +87,7 @@ const ProjectList = () => {
                   css={{ marginLeft: 10 }}
                   placeholder='프로젝트 전체'
                   allowClear
-                  onClear={() => setQueryParams({ category: undefined })}
+                  onClear={() => setQueryParams({ category: null })}
                   value={queryParams.category ?? undefined}
                   onValueChange={(value) => setQueryParams({ category: value as ProjectCategory })}
                 >
@@ -124,7 +121,7 @@ const ProjectList = () => {
                   placeholder='프로젝트 전체'
                   size='small'
                   allowClear
-                  onClear={() => setQueryParams({ category: undefined })}
+                  onClear={() => setQueryParams({ category: null })}
                   value={queryParams.category ?? undefined}
                   onValueChange={(value) => setQueryParams({ category: value as ProjectCategory })}
                 >

--- a/src/components/projects/main/ProjectList.tsx
+++ b/src/components/projects/main/ProjectList.tsx
@@ -40,7 +40,7 @@ const ProjectList = () => {
   });
   const [value, setValue] = useState(queryParams.name);
   const [totalCount, setTotalCount] = useState<number>();
-  const debouncedChangeName = useDebounce((value: string) => setQueryParams({ name: value }), 300);
+  const debouncedChangeName = useDebounce((value: string | undefined) => setQueryParams({ name: value }), 300);
   const { data, isLoading, fetchNextPage } = useGetProjectListQuery({
     limit: 20,
     name: queryParams.name,
@@ -63,7 +63,8 @@ const ProjectList = () => {
           value={value ?? queryParams.name}
           onValueChange={(value) => {
             setValue(value);
-            debouncedChangeName(value);
+            if (value === '') debouncedChangeName(undefined);
+            else debouncedChangeName(value);
           }}
           placeholder='프로젝트 검색'
         />

--- a/src/components/projects/upload/hooks/useGetProjectListQuery.ts
+++ b/src/components/projects/upload/hooks/useGetProjectListQuery.ts
@@ -1,4 +1,4 @@
-import { useInfiniteQuery } from '@tanstack/react-query';
+import { keepPreviousData, useInfiniteQuery } from '@tanstack/react-query';
 
 import { getProjects } from '@/api/endpoint_LEGACY/projects';
 import { ProjectsRequestParams } from '@/api/endpoint_LEGACY/projects/type';
@@ -20,6 +20,7 @@ const useGetProjectListQuery = (params: ProjectsRequestParams = {}) => {
       }
       return lastPage.projectList[lastPage.projectList.length - 1].id;
     },
+    placeholderData: keepPreviousData,
   });
 };
 


### PR DESCRIPTION
### 🤫 쉿, 나한테만 말해줘요. 이슈넘버
- close #1533 

### 🧐 어떤 것을 변경했어요~?
<!-- 실제로 변경한 사항을 설명해주세요.-->
- 프로젝트 탭에서의 검색 결과가 없을 때 empty view 추가했어요.
- 검색값을 입력하거나 칩을 선택했다가 지우면 url에 query string이 남아있던 것을 제거했어요.
- 검색 결과가 없을 때도, 검색창 넓이가 반응형이 되도록 추가했어요.
- 페이지에 처음 들어오게 될 때, Loading 컴포넌트를 볼 수 있게 했어요.

### 🤔 그렇다면, 어떻게 구현했어요~?
<!-- 실제로 구현한 로직에 대해 설명해주세요.-->
- 입력값이 빈 string일 때, 칩을 선택하지 않은 경우에 대해서 조건문으로 undefined 처리를 추가했어요.


### ❤️‍🔥 당신이 생각하는 PR포인트, 내겐 매력포인트.
<!-- 해당 PR에서 논의가 필요한 사항을 적어주세요. -->
- 프로젝트 전체 조회 API에서 캐싱되지 않은 데이터를 가져올 때 마다, data가 undefined 상태가 되어서 깜박거리는 이슈가 있었어요!
따라서 UX를 개선하기 위해 `placeholderData: keepPreviousData` 를 추가했어요.

### 📸 스크린샷, 없으면 이것 참,, 섭섭한데요?
- empty view
<img width="1512" alt="Screenshot 2024-09-02 at 3 55 32 PM" src="https://github.com/user-attachments/assets/1dd7e44f-d2c0-4f3c-80a9-8fa5eb68ac7b">

- Loading 컴포넌트, url에 query string 제거, 검색창의 넓이 반응형이 되도록 추가
https://github.com/user-attachments/assets/a1072bcf-0056-4488-b25f-b5b2da908a6f
