### PR TITLE
fix: '만든 사람들' 페이지에서 35기 모집 멘트 내리기

### DIFF
--- a/src/components/makers/Notifier.tsx
+++ b/src/components/makers/Notifier.tsx
@@ -2,7 +2,6 @@ import styled from '@emotion/styled';
 import { colors } from '@sopt-makers/colors';
 import { FC } from 'react';
 
-// import IconBell from '@/public/icons/icon-bell.svg';
 import IconOutgoing from '@/public/icons/icon-link-outgoing.svg';
 import { MOBILE_MEDIA_QUERY } from '@/styles/mediaQuery';
 import { textStyles } from '@/styles/typography';
@@ -20,26 +19,25 @@ const Notifier: FC<NotifierProps> = ({ className }) => {
       {/* MEMO: 5기 모집 시작 시 주석 해제 */}
       {/* <Title>makers 5기 지원이 곧 시작될 예정이에요.</Title> */}
       {/* <Title>makers 5기 지원이 시작되었어요.</Title> */}
-      <Title>현재 35기 SOPT makers 팀 모집이 진행 중이에요!</Title>
-      {/* <Title>현재 makers 4기 진행 중이에요. 5기에서 만나요!</Title>
-      <SubTitle>5기 모집은 2024년 8-9월 중에 진행될 예정이에요.</SubTitle> */}
-      {/* MEMO: 5기 모집 시작 시 주석 해제 */}
-      <SubTitle>35기 모집은 2024년 7월 31일 수요일부터 8월 7일 수요일 23:59까지 진행될 예정이에요.</SubTitle>
+      {/* <Title>현재 35기 SOPT makers 팀 모집이 진행 중이에요!</Title> */}
+      <Title>현재 makers 35기 진행 중이에요. 36기에서 만나요!</Title>
+      <SubTitle>35기 모집은 2025년 1-2월 중에 진행될 예정이에요.</SubTitle>
+      {/* <SubTitle>35기 모집은 2024년 7월 31일 수요일부터 8월 7일 수요일 23:59까지 진행될 예정이에요.</SubTitle> */}
       <ButtonGroup>
         {/* MEMO: 5기 모집 알림 신청시에 다시 주석 해제 */}
         {/* <SubscribeButton href={RECRUIT_NOTIFY_GENERATION_URL} target='_blank'>
           <StyledBellIcon />
           5기 모집 알림 신청
         </SubscribeButton> */}
-        <ExpiredButton href='https://makers.sopt.org' target='_blank'>
+        {/* <ExpiredButton href='https://makers.sopt.org' target='_blank'>
           <StyledOutgoingIcon />
           35기 메이커스팀 모집글 보기
-          {/* 모집 페이지 가기 */}
-        </ExpiredButton>
-        {/* <ExpiredButton href={RECRUITING_URL} target='_blank'>
-          <StyledOutgoingIcon />
-          4기 모집글 보기
+          {/* 모집 페이지 가기 
         </ExpiredButton> */}
+        <ExpiredButton href={RECRUITING_URL} target='_blank'>
+          <StyledOutgoingIcon />
+          35기 모집글 보기
+        </ExpiredButton>
       </ButtonGroup>
     </StyledJoinNotifier>
   );


### PR DESCRIPTION
### 🤫 쉿, 나한테만 말해줘요. 이슈넘버
- close #1548

### 🧐 어떤 것을 변경했어요~?
<!-- 실제로 변경한 사항을 설명해주세요.-->
- '35기 모집 중'멘트를 내리고, 진행 중 멘트를 추가했어요.

### 🤔 그렇다면, 어떻게 구현했어요~?
<!-- 실제로 구현한 로직에 대해 설명해주세요.-->

### ❤️‍🔥 당신이 생각하는 PR포인트, 내겐 매력포인트.
<!-- 해당 PR에서 논의가 필요한 사항을 적어주세요. -->
- '만든 사람들' 페이지에 5기 목록을 추가하는 작업이 필요해보입니다.

### 📸 스크린샷, 없으면 이것 참,, 섭섭한데요?
![image](https://github.com/user-attachments/assets/3b1555f2-4272-4c09-9189-9b453c3d3fb6)
