### PR TITLE
fix: makers 페이지 멘트 오타 수정

### DIFF
--- a/src/components/makers/Notifier.tsx
+++ b/src/components/makers/Notifier.tsx
@@ -21,7 +21,7 @@ const Notifier: FC<NotifierProps> = ({ className }) => {
       {/* <Title>makers 5기 지원이 시작되었어요.</Title> */}
       {/* <Title>현재 35기 SOPT makers 팀 모집이 진행 중이에요!</Title> */}
       <Title>현재 makers 35기 진행 중이에요. 36기에서 만나요!</Title>
-      <SubTitle>35기 모집은 2025년 1-2월 중에 진행될 예정이에요.</SubTitle>
+      <SubTitle>36기 모집은 2025년 1-2월 중에 진행될 예정이에요.</SubTitle>
       {/* <SubTitle>35기 모집은 2024년 7월 31일 수요일부터 8월 7일 수요일 23:59까지 진행될 예정이에요.</SubTitle> */}
       <ButtonGroup>
         {/* MEMO: 5기 모집 알림 신청시에 다시 주석 해제 */}


### PR DESCRIPTION
### 🤫 쉿, 나한테만 말해줘요. 이슈넘버
- close #1550

### 🧐 어떤 것을 변경했어요~?
<!-- 실제로 변경한 사항을 설명해주세요.-->
35기 모집은 2025년 1-2월 중에 진행될 예정이에요.
-> 36기 모집은~ 으로 수정했어요 

### 🤔 그렇다면, 어떻게 구현했어요~?
<!-- 실제로 구현한 로직에 대해 설명해주세요.-->

### ❤️‍🔥 당신이 생각하는 PR포인트, 내겐 매력포인트.
<!-- 해당 PR에서 논의가 필요한 사항을 적어주세요. -->

사소한 내용으로 PR 두번 올려서 죄송합니다!!!!! 머지 전에 한번 더 확인하기 ㅠ_ㅎ

### 📸 스크린샷, 없으면 이것 참,, 섭섭한데요?
