### PR TITLE
feat: 게시글 신고 Toast mds로 변경 및 멤버 신고/차단 기능 추가

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "@radix-ui/react-tooltip": "^1.0.5",
     "@sopt-makers/colors": "^3.0.0",
     "@sopt-makers/fonts": "^1.0.0",
+    "@sopt-makers/icons": "^1.0.5",
     "@sopt-makers/ui": "^2.0.5",
     "@tanstack/react-query": "^5.4.3",
     "@toss/emotion-utils": "^1.1.10",

--- a/public/icons/icon-dots-vertical.svg
+++ b/public/icons/icon-dots-vertical.svg
@@ -1,0 +1,8 @@
+<svg width="18" height="4" viewBox="0 0 18 4" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M8 2C8 2.55228 8.44772 3 9 3C9.55228 3 10 2.55228 10 2C10 1.44771 9.55228 1 9 1C8.44772 1 8 1.44771 8 2Z" fill="white"/>
+<path d="M15 2C15 2.55228 15.4477 3 16 3C16.5523 3 17 2.55228 17 2C17 1.44772 16.5523 1 16 1C15.4477 1 15 1.44772 15 2Z" fill="white"/>
+<path d="M1 2C1 2.55228 1.44772 3 2 3C2.55229 3 3 2.55228 3 2C3 1.44771 2.55229 0.999999 2 0.999999C1.44772 0.999999 1 1.44771 1 2Z" fill="white"/>
+<path d="M8 2C8 2.55228 8.44772 3 9 3C9.55228 3 10 2.55228 10 2C10 1.44771 9.55228 1 9 1C8.44772 1 8 1.44771 8 2Z" stroke="white" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M15 2C15 2.55228 15.4477 3 16 3C16.5523 3 17 2.55228 17 2C17 1.44772 16.5523 1 16 1C15.4477 1 15 1.44772 15 2Z" stroke="white" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M1 2C1 2.55228 1.44772 3 2 3C2.55229 3 3 2.55228 3 2C3 1.44771 2.55229 0.999999 2 0.999999C1.44772 0.999999 1 1.44771 1 2Z" stroke="white" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/src/api/endpoint/members/postBlockMember.ts
+++ b/src/api/endpoint/members/postBlockMember.ts
@@ -1,0 +1,24 @@
+import { useMutation } from '@tanstack/react-query';
+import { z } from 'zod';
+
+import { createEndpoint } from '@/api/typedAxios';
+
+interface RequestBody {
+  blockedMemberId: number;
+}
+
+export const postBlockMember = createEndpoint({
+  request: (requestBody: RequestBody) => ({
+    method: 'PATCH',
+    url: `api/v1/members/block/activate`,
+    data: requestBody,
+  }),
+  serverResponseScheme: z.unknown(),
+});
+
+export const usePostBlockMemberMutation = () => {
+  console.log('in hook');
+  return useMutation({
+    mutationFn: (requestBody: RequestBody) => postBlockMember.request(requestBody),
+  });
+};

--- a/src/api/endpoint/members/postBlockMember.ts
+++ b/src/api/endpoint/members/postBlockMember.ts
@@ -17,7 +17,6 @@ export const postBlockMember = createEndpoint({
 });
 
 export const usePostBlockMemberMutation = () => {
-  console.log('in hook');
   return useMutation({
     mutationFn: (requestBody: RequestBody) => postBlockMember.request(requestBody),
   });

--- a/src/api/endpoint/members/postReportMember.ts
+++ b/src/api/endpoint/members/postReportMember.ts
@@ -1,0 +1,23 @@
+import { useMutation } from '@tanstack/react-query';
+import { z } from 'zod';
+
+import { createEndpoint } from '@/api/typedAxios';
+
+interface RequestBody {
+  reportMemberId: number;
+}
+
+export const postReportMember = createEndpoint({
+  request: (requestBody: RequestBody) => ({
+    method: 'POST',
+    url: `api/v1/members/report`,
+    data: requestBody,
+  }),
+  serverResponseScheme: z.unknown(),
+});
+
+export const usePostReportMemberMutation = () => {
+  return useMutation({
+    mutationFn: (requestBody: RequestBody) => postReportMember.request(requestBody),
+  });
+};

--- a/src/components/common/Modal/parts/index.tsx
+++ b/src/components/common/Modal/parts/index.tsx
@@ -1,5 +1,6 @@
 import { css } from '@emotion/react';
 import styled from '@emotion/styled';
+import { fonts } from '@sopt-makers/fonts';
 
 import { MOBILE_MEDIA_QUERY } from '@/styles/mediaQuery';
 import { textStyles } from '@/styles/typography';
@@ -16,7 +17,11 @@ export const ModalTitle = styled.h1`
   margin-bottom: 12px;
   line-height: 24px;
 
-  ${textStyles.SUIT_18_B}
+  ${fonts.TITLE_20_SB}
+
+  @media ${MOBILE_MEDIA_QUERY} {
+    ${fonts.TITLE_18_SB}
+  }
 `;
 
 export const ModalDescription = styled.div`

--- a/src/components/common/Modal/useConfirm.tsx
+++ b/src/components/common/Modal/useConfirm.tsx
@@ -75,4 +75,8 @@ const StyleModalDescription = styled.div`
   line-height: 26px;
   white-space: pre-wrap;
   color: ${colors.gray100};
+
+  @media ${MOBILE_MEDIA_QUERY} {
+    ${fonts.BODY_14_R}
+  }
 `;

--- a/src/components/feed/common/FeedDropdown.tsx
+++ b/src/components/feed/common/FeedDropdown.tsx
@@ -1,3 +1,4 @@
+import { css } from '@emotion/react';
 import styled from '@emotion/styled';
 import * as DropdownMenu from '@radix-ui/react-dropdown-menu';
 import { m } from 'framer-motion';
@@ -10,14 +11,20 @@ const DropdownPortal = dynamic(() => import('@radix-ui/react-dropdown-menu').the
 
 interface FeedDropdownProps {
   trigger?: ReactNode;
+  style?: React.CSSProperties;
 }
 
-const Base = ({ trigger, children }: PropsWithChildren<FeedDropdownProps>) => {
+const Base = ({ trigger, style, children }: PropsWithChildren<FeedDropdownProps>) => {
   return (
     <DropdownMenu.Root>
       <DropdownMenu.Trigger>{trigger}</DropdownMenu.Trigger>
       <DropdownPortal>
-        <StyledContent initial={{ opacity: 0, y: -4 }} animate={{ opacity: 1, y: 0 }} transition={{ duration: 0.3 }}>
+        <StyledContent
+          initial={{ opacity: 0, y: -4 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={{ duration: 0.3 }}
+          style={style}
+        >
           {children}
         </StyledContent>
       </DropdownPortal>

--- a/src/components/feed/common/FeedDropdown.tsx
+++ b/src/components/feed/common/FeedDropdown.tsx
@@ -1,4 +1,3 @@
-import { css } from '@emotion/react';
 import styled from '@emotion/styled';
 import * as DropdownMenu from '@radix-ui/react-dropdown-menu';
 import { m } from 'framer-motion';

--- a/src/components/feed/common/hooks/useReportFeed.ts
+++ b/src/components/feed/common/hooks/useReportFeed.ts
@@ -3,6 +3,7 @@ import { useCallback } from 'react';
 
 import { usePostReportPostMutation } from '@/api/endpoint/feed/postReportPost';
 import useConfirm from '@/components/common/Modal/useConfirm';
+import { zIndex } from '@/styles/zIndex';
 
 interface Options {
   postId: string;
@@ -22,6 +23,7 @@ export const useReportFeed = () => {
         okButtonText: '신고하기',
         cancelButtonText: '취소',
         maxWidth: 324,
+        zIndex: zIndex.헤더,
       });
 
       if (result) {

--- a/src/components/feed/common/hooks/useReportFeed.ts
+++ b/src/components/feed/common/hooks/useReportFeed.ts
@@ -22,7 +22,7 @@ export const useReportFeed = () => {
         description: '글을 신고할 경우, 메이커스에서 검토를 거쳐 적절한 조치 및 게시자 제재를 취할 예정이에요.',
         okButtonText: '신고하기',
         cancelButtonText: '취소',
-        maxWidth: 324,
+        maxWidth: 400,
         zIndex: zIndex.헤더,
       });
 

--- a/src/components/feed/common/hooks/useReportFeed.ts
+++ b/src/components/feed/common/hooks/useReportFeed.ts
@@ -1,9 +1,8 @@
+import { useToast } from '@sopt-makers/ui';
 import { useCallback } from 'react';
 
 import { usePostReportPostMutation } from '@/api/endpoint/feed/postReportPost';
-import useAlert from '@/components/common/Modal/useAlert';
 import useConfirm from '@/components/common/Modal/useConfirm';
-import usePopup from '@/components/common/Modal/usePopup';
 
 interface Options {
   postId: string;
@@ -12,15 +11,14 @@ interface Options {
 
 export const useReportFeed = () => {
   const { confirm } = useConfirm();
-  const { alert } = useAlert();
   const { mutate } = usePostReportPostMutation();
-  const { popup } = usePopup();
+  const { open } = useToast();
 
   const handleReport = useCallback(
     async (options: Options) => {
       const result = await confirm({
         title: '이 글을 신고하시겠습니까?',
-        description: '글을 신고할 경우, 메이커스에서 검토를 거쳐 적절한 조치 및 게시자 제재를 취해요.',
+        description: '글을 신고할 경우, 메이커스에서 검토를 거쳐 적절한 조치 및 게시자 제재를 취할 예정이에요.',
         okButtonText: '신고하기',
         cancelButtonText: '취소',
         maxWidth: 324,
@@ -29,19 +27,22 @@ export const useReportFeed = () => {
       if (result) {
         mutate(options.postId, {
           onSuccess: () => {
-            popup({
-              icon: '/icons/check_box_field.svg',
-              title: '신고해주셔서 감사해요',
-              description:
-                '메이커스에서 빠르게 검토 후 적절한 조치를 취할게요 :) 건전한 커뮤니티를 만드는데 기여해주셔서 감사해요!',
-              maxWidth: 324,
+            open({
+              icon: 'success',
+              content: '신고가 완료되었어요.\n건전한 커뮤니티를 함께 만들어주셔서 감사해요!',
+              style: {
+                content: {
+                  whiteSpace: 'pre-wrap',
+                },
+              },
             });
+
             options.onSuccess?.();
           },
         });
       }
     },
-    [confirm, alert, mutate],
+    [confirm, open, mutate],
   );
 
   return { handleReport };

--- a/src/components/feed/detail/FeedDetail.tsx
+++ b/src/components/feed/detail/FeedDetail.tsx
@@ -1,4 +1,7 @@
+import { colors } from '@sopt-makers/colors';
+import { IconAlertTriangle, IconTrash, IconWrite } from '@sopt-makers/icons';
 import { useQueryClient } from '@tanstack/react-query';
+import { Flex } from '@toss/emotion-utils';
 import { ErrorBoundary } from '@toss/error-boundary';
 import Link from 'next/link';
 import { playgroundLink } from 'playground-common/export';
@@ -75,30 +78,43 @@ const FeedDetail = ({ postId, renderCategoryLink, renderBackLink }: FeedDetailPr
               }
             >
               {postData.isMine ? (
-                <Link href={playgroundLink.feedEdit(postId)}>
-                  <FeedDropdown.Item>수정</FeedDropdown.Item>
-                </Link>
-              ) : null}
-              {postData.isMine ? (
+                <>
+                  <Link href={playgroundLink.feedEdit(postId)}>
+                    <FeedDropdown.Item>
+                      <Flex align='center' css={{ gap: '10px', color: `${colors.gray10} ` }}>
+                        <IconWrite css={{ width: '16px', height: '16px' }} />
+                        수정
+                      </Flex>
+                    </FeedDropdown.Item>
+                  </Link>
+
+                  <FeedDropdown.Item
+                    type='danger'
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      handleDeleteFeed({ postId });
+                    }}
+                  >
+                    <Flex align='center' css={{ gap: '10px' }}>
+                      <IconTrash css={{ width: '16px', height: '16px' }} />
+                      삭제
+                    </Flex>
+                  </FeedDropdown.Item>
+                </>
+              ) : (
                 <FeedDropdown.Item
                   type='danger'
                   onClick={(e) => {
                     e.stopPropagation();
-                    handleDeleteFeed({ postId });
+                    handleReportFeed({ postId });
                   }}
                 >
-                  삭제
+                  <Flex align='center' css={{ gap: '10px', color: `${colors.gray10}` }}>
+                    <IconAlertTriangle css={{ width: '16px', height: '16px' }} />
+                    신고
+                  </Flex>
                 </FeedDropdown.Item>
-              ) : null}
-              <FeedDropdown.Item
-                type='danger'
-                onClick={(e) => {
-                  e.stopPropagation();
-                  handleReportFeed({ postId });
-                }}
-              >
-                신고
-              </FeedDropdown.Item>
+              )}
             </FeedDropdown>
           </>
         }

--- a/src/components/feed/list/FeedListItems.tsx
+++ b/src/components/feed/list/FeedListItems.tsx
@@ -1,5 +1,6 @@
 import styled from '@emotion/styled';
 import { colors } from '@sopt-makers/colors';
+import { IconAlertTriangle, IconShare, IconTrash, IconWrite } from '@sopt-makers/icons';
 import { useQuery } from '@tanstack/react-query';
 import { Flex } from '@toss/emotion-utils';
 import Link from 'next/link';
@@ -160,10 +161,16 @@ const FeedListItems: FC<FeedListItemsProps> = ({ categoryId, renderFeedDetailLin
                         <FeedCard.Icon name='moreHorizon' />
                       </Flex>
                     }
+                    style={{ minWidth: '133px', position: 'relative', top: '10px', right: '52px' }}
                   >
                     {post.isMine ? (
                       <Link href={playgroundLink.feedEdit(post.id)}>
-                        <FeedDropdown.Item>수정</FeedDropdown.Item>
+                        <FeedDropdown.Item>
+                          <Flex align='center' css={{ gap: '10px', color: `${colors.gray10} ` }}>
+                            <IconWrite css={{ width: '16px', height: '16px' }} />
+                            수정
+                          </Flex>
+                        </FeedDropdown.Item>
                       </Link>
                     ) : null}
                     <LoggingClick eventKey='feedShareButton' param={{ feedId: String(post.id), referral: 'list' }}>
@@ -173,7 +180,10 @@ const FeedListItems: FC<FeedListItemsProps> = ({ categoryId, renderFeedDetailLin
                           handleShareFeed(`${post.id}`);
                         }}
                       >
-                        공유
+                        <Flex align='center' css={{ gap: '10px', color: `${colors.gray10}` }}>
+                          <IconShare css={{ width: '16px', height: '16px' }} />
+                          공유
+                        </Flex>
                       </FeedDropdown.Item>
                     </LoggingClick>
                     {post.isMine ? (
@@ -189,18 +199,23 @@ const FeedListItems: FC<FeedListItemsProps> = ({ categoryId, renderFeedDetailLin
                         }}
                         type='danger'
                       >
-                        삭제
+                        <Flex align='center' css={{ gap: '10px' }}>
+                          <IconTrash css={{ width: '16px', height: '16px' }} />
+                          삭제
+                        </Flex>
                       </FeedDropdown.Item>
                     ) : null}
                     {!post.isMine ? (
                       <FeedDropdown.Item
-                        type='danger'
                         onClick={(e) => {
                           e.stopPropagation();
                           handleReport({ postId: `${post.id}` });
                         }}
                       >
-                        신고
+                        <Flex align='center' css={{ gap: '10px', color: `${colors.gray10}` }}>
+                          <IconAlertTriangle css={{ width: '16px', height: '16px' }} />
+                          신고
+                        </Flex>
                       </FeedDropdown.Item>
                     ) : null}
                   </FeedDropdown>

--- a/src/components/members/detail/ActivitySection/MemberDetail.tsx
+++ b/src/components/members/detail/ActivitySection/MemberDetail.tsx
@@ -9,7 +9,6 @@ import CallIcon from 'public/icons/icon-call.svg';
 import EditIcon from 'public/icons/icon-edit.svg';
 import MailIcon from 'public/icons/icon-mail.svg';
 import ProfileIcon from 'public/icons/icon-profile.svg';
-import IconCoffee from '@/public/icons/icon-coffee.svg';
 import { FC, useMemo } from 'react';
 
 import { useGetMemberCrewInfiniteQuery } from '@/api/endpoint/members/getMemberCrew';
@@ -31,6 +30,8 @@ import { DEFAULT_DATE } from '@/components/members/upload/constants';
 import { playgroundLink } from '@/constants/links';
 import useEnterScreen from '@/hooks/useEnterScreen';
 import { useRunOnce } from '@/hooks/useRunOnce';
+import IconCoffee from '@/public/icons/icon-coffee.svg';
+import IconMore from '@/public/icons/icon-dots-vertical.svg';
 import { MOBILE_MEDIA_QUERY } from '@/styles/mediaQuery';
 import { textStyles } from '@/styles/typography';
 import { safeParseInt } from '@/utils';
@@ -147,7 +148,7 @@ const MemberDetail: FC<MemberDetailProps> = ({ memberId }) => {
             </ContactWrapper>
           </ProfileContents>
 
-          {profile.isMine && (
+          {profile.isMine ? (
             <EditButton
               onClick={() => {
                 router.push(playgroundLink.memberEdit());
@@ -156,6 +157,10 @@ const MemberDetail: FC<MemberDetailProps> = ({ memberId }) => {
             >
               <EditIcon />
             </EditButton>
+          ) : (
+            <MoreIconContainer>
+              <StyledIconMore />
+            </MoreIconContainer>
           )}
         </ProfileContainer>
 
@@ -423,7 +428,7 @@ const EditButton = styled.div`
 const NameWrapper = styled.div`
   display: flex;
   gap: 12px;
-  align-items: flex-end;
+  align-items: center;
 
   .name {
     line-height: 100%;
@@ -624,5 +629,26 @@ const IconContainer = styled.div`
       width: 19px;
       height: 19px;
     }
+  }
+`;
+
+const MoreIconContainer = styled.div`
+  width: 100%;
+  height: 171px;
+  text-align: right;
+
+  @media ${MOBILE_MEDIA_QUERY} {
+    height: auto;
+  }
+`;
+
+const StyledIconMore = styled(IconMore)`
+  cursor: pointer;
+  padding-top: 12px;
+  width: 24px;
+  height: 24px;
+
+  @media ${MOBILE_MEDIA_QUERY} {
+    padding-top: 4px;
   }
 `;

--- a/src/components/members/detail/ActivitySection/MemberDetail.tsx
+++ b/src/components/members/detail/ActivitySection/MemberDetail.tsx
@@ -27,6 +27,7 @@ import EmptyProfile from '@/components/members/detail/EmptyProfile';
 import InfoItem from '@/components/members/detail/InfoItem';
 import InterestSection from '@/components/members/detail/InterestSection';
 import SoptActivitySection from '@/components/members/detail/SoptActivitySection';
+import { useBlockMember } from '@/components/members/hooks/useBlockMember';
 import { useReportMember } from '@/components/members/hooks/useReportMember';
 import { DEFAULT_DATE } from '@/components/members/upload/constants';
 import { playgroundLink } from '@/constants/links';
@@ -114,6 +115,7 @@ const MemberDetail: FC<MemberDetailProps> = ({ memberId }) => {
   }, []);
 
   const { handleReportMember } = useReportMember();
+  const { handleBlockMember } = useBlockMember();
 
   if (profileError?.response?.status === 400 || (axios.isAxiosError(crewError) && crewError.response?.status === 400)) {
     return <EmptyProfile />;
@@ -191,7 +193,14 @@ const MemberDetail: FC<MemberDetailProps> = ({ memberId }) => {
                 >
                   신고
                 </FeedDropdown.Item>
-                <FeedDropdown.Item type='danger'>차단</FeedDropdown.Item>
+                <FeedDropdown.Item
+                  type='danger'
+                  onClick={() => {
+                    handleBlockMember(safeParseInt(memberId) ?? undefined);
+                  }}
+                >
+                  차단
+                </FeedDropdown.Item>
               </FeedDropdown>
             </MoreIconContainer>
           )}

--- a/src/components/members/detail/ActivitySection/MemberDetail.tsx
+++ b/src/components/members/detail/ActivitySection/MemberDetail.tsx
@@ -1,5 +1,7 @@
 import styled from '@emotion/styled';
 import { colors } from '@sopt-makers/colors';
+import { IconAlertTriangle, IconUserX } from '@sopt-makers/icons';
+import { Flex } from '@toss/emotion-utils';
 import axios from 'axios';
 import dayjs from 'dayjs';
 import { uniq } from 'lodash-es';
@@ -191,7 +193,10 @@ const MemberDetail: FC<MemberDetailProps> = ({ memberId }) => {
                     handleReportMember(safeParseInt(memberId) ?? undefined);
                   }}
                 >
-                  신고
+                  <Flex align='center' css={{ gap: '4px', color: `${colors.gray10}` }}>
+                    <IconAlertTriangle css={{ width: '16px', height: '16px' }} />
+                    신고
+                  </Flex>
                 </FeedDropdown.Item>
                 <FeedDropdown.Item
                   type='danger'
@@ -199,7 +204,9 @@ const MemberDetail: FC<MemberDetailProps> = ({ memberId }) => {
                     handleBlockMember(safeParseInt(memberId) ?? undefined);
                   }}
                 >
-                  차단
+                  <Flex align='center' css={{ gap: '4px' }}>
+                    <IconUserX css={{ width: '16px', height: '16px' }} /> 차단
+                  </Flex>
                 </FeedDropdown.Item>
               </FeedDropdown>
             </MoreIconContainer>

--- a/src/components/members/detail/ActivitySection/MemberDetail.tsx
+++ b/src/components/members/detail/ActivitySection/MemberDetail.tsx
@@ -9,7 +9,7 @@ import CallIcon from 'public/icons/icon-call.svg';
 import EditIcon from 'public/icons/icon-edit.svg';
 import MailIcon from 'public/icons/icon-mail.svg';
 import ProfileIcon from 'public/icons/icon-profile.svg';
-import { FC, useMemo } from 'react';
+import { CSSProperties, FC, useEffect, useMemo, useState } from 'react';
 
 import { useGetMemberCrewInfiniteQuery } from '@/api/endpoint/members/getMemberCrew';
 import { useGetMemberOfMe } from '@/api/endpoint/members/getMemberOfMe';
@@ -18,6 +18,7 @@ import Loading from '@/components/common/Loading';
 import ResizedImage from '@/components/common/ResizedImage';
 import Text from '@/components/common/Text';
 import useEventLogger from '@/components/eventLogger/hooks/useEventLogger';
+import FeedDropdown from '@/components/feed/common/FeedDropdown';
 import MemberDetailSection from '@/components/members/detail/ActivitySection/MemberDetailSection';
 import MemberMeetingCard from '@/components/members/detail/ActivitySection/MemberMeetingCard';
 import MemberProjectCard from '@/components/members/detail/ActivitySection/MemberProjectCard';
@@ -60,6 +61,13 @@ const MemberDetail: FC<MemberDetailProps> = ({ memberId }) => {
     },
   });
 
+  const [dropdownOpenStyle, setDropdownOpenStyle] = useState<CSSProperties>({
+    position: 'absolute',
+    right: '-12px',
+    top: '10px',
+    minWidth: '133px',
+  });
+
   const {
     data: profile,
     isLoading,
@@ -90,6 +98,19 @@ const MemberDetail: FC<MemberDetailProps> = ({ memberId }) => {
       });
     }
   }, [profile, memberId]);
+
+  useEffect(() => {
+    const resizeMenuWidth = () => {
+      setDropdownOpenStyle((prevStyle) => ({
+        ...prevStyle,
+        minWidth: window.innerWidth <= 768 ? '100px' : '133px',
+      }));
+    };
+
+    resizeMenuWidth();
+
+    window.addEventListener('resize', resizeMenuWidth);
+  }, []);
 
   if (profileError?.response?.status === 400 || (axios.isAxiosError(crewError) && crewError.response?.status === 400)) {
     return <EmptyProfile />;
@@ -159,7 +180,10 @@ const MemberDetail: FC<MemberDetailProps> = ({ memberId }) => {
             </EditButton>
           ) : (
             <MoreIconContainer>
-              <StyledIconMore />
+              <FeedDropdown trigger={<StyledIconMore />} style={dropdownOpenStyle}>
+                <FeedDropdown.Item>신고</FeedDropdown.Item>
+                <FeedDropdown.Item type='danger'>차단</FeedDropdown.Item>
+              </FeedDropdown>
             </MoreIconContainer>
           )}
         </ProfileContainer>
@@ -633,6 +657,7 @@ const IconContainer = styled.div`
 `;
 
 const MoreIconContainer = styled.div`
+  position: relative;
   width: 100%;
   height: 171px;
   text-align: right;

--- a/src/components/members/detail/ActivitySection/MemberDetail.tsx
+++ b/src/components/members/detail/ActivitySection/MemberDetail.tsx
@@ -193,7 +193,7 @@ const MemberDetail: FC<MemberDetailProps> = ({ memberId }) => {
                     handleReportMember(safeParseInt(memberId) ?? undefined);
                   }}
                 >
-                  <Flex align='center' css={{ gap: '4px', color: `${colors.gray10}` }}>
+                  <Flex align='center' css={{ gap: '10px', color: `${colors.gray10}` }}>
                     <IconAlertTriangle css={{ width: '16px', height: '16px' }} />
                     신고
                   </Flex>
@@ -204,7 +204,7 @@ const MemberDetail: FC<MemberDetailProps> = ({ memberId }) => {
                     handleBlockMember(safeParseInt(memberId) ?? undefined);
                   }}
                 >
-                  <Flex align='center' css={{ gap: '4px' }}>
+                  <Flex align='center' css={{ gap: '10px' }}>
                     <IconUserX css={{ width: '16px', height: '16px' }} /> 차단
                   </Flex>
                 </FeedDropdown.Item>

--- a/src/components/members/detail/ActivitySection/MemberDetail.tsx
+++ b/src/components/members/detail/ActivitySection/MemberDetail.tsx
@@ -27,6 +27,7 @@ import EmptyProfile from '@/components/members/detail/EmptyProfile';
 import InfoItem from '@/components/members/detail/InfoItem';
 import InterestSection from '@/components/members/detail/InterestSection';
 import SoptActivitySection from '@/components/members/detail/SoptActivitySection';
+import { useReportMember } from '@/components/members/hooks/useReportMember';
 import { DEFAULT_DATE } from '@/components/members/upload/constants';
 import { playgroundLink } from '@/constants/links';
 import useEnterScreen from '@/hooks/useEnterScreen';
@@ -112,6 +113,8 @@ const MemberDetail: FC<MemberDetailProps> = ({ memberId }) => {
     window.addEventListener('resize', resizeMenuWidth);
   }, []);
 
+  const { handleReportMember } = useReportMember();
+
   if (profileError?.response?.status === 400 || (axios.isAxiosError(crewError) && crewError.response?.status === 400)) {
     return <EmptyProfile />;
   }
@@ -181,7 +184,13 @@ const MemberDetail: FC<MemberDetailProps> = ({ memberId }) => {
           ) : (
             <MoreIconContainer>
               <FeedDropdown trigger={<StyledIconMore />} style={dropdownOpenStyle}>
-                <FeedDropdown.Item>신고</FeedDropdown.Item>
+                <FeedDropdown.Item
+                  onClick={() => {
+                    handleReportMember(safeParseInt(memberId) ?? undefined);
+                  }}
+                >
+                  신고
+                </FeedDropdown.Item>
                 <FeedDropdown.Item type='danger'>차단</FeedDropdown.Item>
               </FeedDropdown>
             </MoreIconContainer>

--- a/src/components/members/hooks/useBlockMember.ts
+++ b/src/components/members/hooks/useBlockMember.ts
@@ -1,0 +1,53 @@
+import { colors } from '@sopt-makers/colors';
+import { useToast } from '@sopt-makers/ui';
+import { useQueryClient } from '@tanstack/react-query';
+import { useRouter } from 'next/router';
+import { playgroundLink } from 'playground-common/export';
+
+import { usePostBlockMemberMutation } from '@/api/endpoint/members/postBlockMember';
+import useConfirm from '@/components/common/Modal/useConfirm';
+
+export const useBlockMember = () => {
+  const router = useRouter();
+  const queryClient = useQueryClient();
+
+  const { confirm } = useConfirm();
+  const { open } = useToast();
+  const { mutate } = usePostBlockMemberMutation();
+
+  const handleBlockMember = async (memberId?: number) => {
+    if (!memberId) throw new Error('Invalid Member id');
+
+    const result = await confirm({
+      title: '이 멤버를 차단하시겠습니까?',
+      description:
+        '차단 시 멤버 리스트는 유지되지만, 이 멤버의 게시글과 댓글이 보이지 않게 돼요. 한 번 차단한 멤버는 다시 해제할 수 없어요.',
+      okButtonText: '차단하기',
+      okButtonColor: colors.error,
+      okButtonTextColor: colors.white,
+      cancelButtonText: '취소',
+      maxWidth: 400,
+    });
+
+    if (result) {
+      mutate(
+        { blockedMemberId: memberId },
+        {
+          onSuccess: async () => {
+            queryClient.invalidateQueries({
+              predicate: (query) => query.queryKey.some((key) => String(key).includes('community')),
+            });
+            await router.push(playgroundLink.memberList());
+
+            open({
+              icon: 'success',
+              content: '멤버가 차단되었어요.',
+            });
+          },
+        },
+      );
+    }
+  };
+
+  return { handleBlockMember };
+};

--- a/src/components/members/hooks/useReportMember.ts
+++ b/src/components/members/hooks/useReportMember.ts
@@ -1,0 +1,43 @@
+import { useToast } from '@sopt-makers/ui';
+
+import { usePostReportMemberMutation } from '@/api/endpoint/members/postReportMember';
+import useConfirm from '@/components/common/Modal/useConfirm';
+
+export const useReportMember = () => {
+  const { confirm } = useConfirm();
+  const { open } = useToast();
+  const { mutate } = usePostReportMemberMutation();
+
+  const handleReportMember = async (memberId?: number) => {
+    if (!memberId) throw new Error('Invalid Member id');
+
+    const result = await confirm({
+      title: '이 멤버를 신고하시겠습니까?',
+      description: '멤버를 신고할 경우, 메이커스에서 검토를 거쳐 적절한 조치 및 제재를 취할 예정이에요.',
+      okButtonText: '신고하기',
+      cancelButtonText: '취소',
+      maxWidth: 400,
+    });
+
+    if (result) {
+      mutate(
+        { reportMemberId: memberId },
+        {
+          onSuccess: () => {
+            open({
+              icon: 'success',
+              content: '신고가 완료되었어요.\n건전한 커뮤니티를 함께 만들어주셔서 감사해요!',
+              style: {
+                content: {
+                  whiteSpace: 'pre-wrap',
+                },
+              },
+            });
+          },
+        },
+      );
+    }
+  };
+
+  return { handleReportMember };
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -6247,6 +6247,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@sopt-makers/icons@npm:^1.0.5":
+  version: 1.0.5
+  resolution: "@sopt-makers/icons@npm:1.0.5"
+  peerDependencies:
+    react: ^18.2.0
+  checksum: 6dbaa9748508adb4fa21042789c0a2c3a3c1c586e45355b76280cba0e30d2da0414c288605fa841b76b71dec993a2d2fcec5b26aaf2fd4d0c8be8cd2c99f01db
+  languageName: node
+  linkType: hard
+
 "@sopt-makers/playground-common@workspace:playground-common":
   version: 0.0.0-use.local
   resolution: "@sopt-makers/playground-common@workspace:playground-common"
@@ -19737,6 +19746,7 @@ __metadata:
     "@radix-ui/react-tooltip": ^1.0.5
     "@sopt-makers/colors": ^3.0.0
     "@sopt-makers/fonts": ^1.0.0
+    "@sopt-makers/icons": ^1.0.5
     "@sopt-makers/ui": ^2.0.5
     "@storybook/addon-actions": ^7.0.23
     "@storybook/addon-docs": ^7.0.23


### PR DESCRIPTION
### 🤫 쉿, 나한테만 말해줘요. 이슈넘버
- close #1545 

### 🧐 어떤 것을 변경했어요~?
<!-- 실제로 변경한 사항을 설명해주세요.-->

- 게시글 신고 성공시, Toast mds로 변경
- 멤버 페이지의 드롭다운 메뉴로 신고/차단 UI 및 기능 추가 
- 신고/차단 API 및 hook 추가
- 모달의 Title, Descripction 을 반응형에 따라 font 수정
- FeedDropdown 컴포넌트에 커스텀 스타일링 가능하도록 style props 넣을 수 있도록 추가
- `@sopt-makers/icons` 패키지 추가

### 🤔 그렇다면, 어떻게 구현했어요~?
<!-- 실제로 구현한 로직에 대해 설명해주세요.-->
dropdownOpenStyle 상태를 추가해 반응형으로 모달 사이즈 수정

### ❤️‍🔥 당신이 생각하는 PR포인트, 내겐 매력포인트.
<!-- 해당 PR에서 논의가 필요한 사항을 적어주세요. -->
```typescript
 onSuccess: async () => {
  queryClient.invalidateQueries({
    predicate: (query) => query.queryKey.some((key) => String(key).includes('community')),
  });
```

차단 성공시 커뮤니티의 게시글, 댓글 등을 모두 다시 조회할 수 있도록 
위와 같은 로직을 통해서 `community`가 포함된 쿼리키들을 모두 `invalidate`해 다시 가져올 수 있도록 하였어요!
어떤 게시글이 차단된 멤버의 댓글이 포함되어 있는지를 모르고, 이를 다시 불러와야하기 때문에 이런 식으로 구현하였는데! 
혹시 더 효율적인 방법이 있는지 리뷰 부탁드립니다!


### 📸 스크린샷, 없으면 이것 참,, 섭섭한데요?

- 게시글 신고 성공
<img width="704" alt="image" src="https://github.com/user-attachments/assets/db6951f5-19d2-4fc7-a88b-a32234af14ef">

- 유저 신고
<img width="381" alt="image" src="https://github.com/user-attachments/assets/50fca362-6387-4954-adb7-d1257f8f9b08">

- 유저 신고 성공
<img width="629" alt="image" src="https://github.com/user-attachments/assets/46b620ee-c243-4882-b871-858461204283">

- 유저 차단
<img width="361" alt="image" src="https://github.com/user-attachments/assets/1e18f6d3-38af-470a-944a-63e21141c598">

- 유저 차단 성공
<img width="618" alt="image" src="https://github.com/user-attachments/assets/633e4141-4e6a-48ec-87d4-ad9e984c2a36">
