### PR TITLE
fix: mds 와의 스타일 충돌 해결

### DIFF
--- a/src/components/debug/SideBar.tsx
+++ b/src/components/debug/SideBar.tsx
@@ -1,4 +1,5 @@
 import styled from '@emotion/styled';
+import { colors } from '@sopt-makers/colors';
 import { forwardRef, ReactNode } from 'react';
 
 import { useEscapeCallback } from '@/hooks/useEscapeCallback';
@@ -90,7 +91,7 @@ const CloseButton = styled.button`
   cursor: pointer;
   width: 40px;
   height: 40px;
-  color: white;
+  color: ${colors.white};
 
   &:hover {
     background-color: rgb(200 200 200 / 30%);

--- a/src/components/projects/upload/form/fields/LinkField.tsx
+++ b/src/components/projects/upload/form/fields/LinkField.tsx
@@ -206,7 +206,7 @@ const StyledEditCompleteButton = styled.button`
   background-color: ${colors.gray600};
   padding: 16px 36px;
   white-space: nowrap;
-  color: ${colors.gray600};
+  color: ${colors.gray200};
 
   ${textStyles.SUIT_14_M};
 

--- a/src/styles/reset.ts
+++ b/src/styles/reset.ts
@@ -247,7 +247,8 @@ export const reset = css`
   [type='reset'],
   [type='submit'] {
     appearance: button;
-    color: ${colors.gray10};
+
+    /* color: ${colors.gray10}; */
   }
 
   /**


### PR DESCRIPTION
### 🤫 쉿, 나한테만 말해줘요. 이슈넘버
- close #1567 

### 🧐 어떤 것을 변경했어요~?
<!-- 실제로 변경한 사항을 설명해주세요.-->
- 버튼에 적용되어있던 color 스타일을 지워주었어요. 
```
button,
  [type='button'],
  [type='reset'],
  [type='submit'] {
    appearance: button;

    /* color: ${colors.gray10}; */
  }
```


### 🤔 그렇다면, 어떻게 구현했어요~?
<!-- 실제로 구현한 로직에 대해 설명해주세요.-->
- reset.ts 의 스타일을 삭제 후 발생할 사이드 이펙트가 없는지, button 태그를 사용한 모든 컴포넌트를 훑었어요!

### ❤️‍🔥 당신이 생각하는 PR포인트, 내겐 매력포인트.
<!-- 해당 PR에서 논의가 필요한 사항을 적어주세요. -->
- 거의 다 버튼에 color값을 한 번 더 부여하여서, 큰 사이드 이펙트는 없더라구요..!

### 📸 스크린샷, 없으면 이것 참,, 섭섭한데요?
