### PR TITLE
feat: 홈 로딩 스켈레톤 적용

### DIFF
--- a/src/components/common/Banner/WelcomeBanner/Welcome35.tsx
+++ b/src/components/common/Banner/WelcomeBanner/Welcome35.tsx
@@ -1,12 +1,13 @@
 import { useGetMemberOfMe } from '@/api/endpoint/members/getMemberOfMe';
 import WelcomeBanner from '@/components/common/Banner/WelcomeBanner';
+import Skeleton from '@/components/common/Skeleton';
 import { LATEST_GENERATION } from '@/constants/generation';
 
 const Welcome35 = () => {
   const { data: myData, isPending } = useGetMemberOfMe();
   const is35 = myData?.generation === LATEST_GENERATION;
 
-  if (isPending) return <></>;
+  if (isPending) return <Skeleton height={168} />;
 
   return <WelcomeBanner is35={is35} />;
 };

--- a/src/components/common/Banner/WelcomeBanner/Welcome35.tsx
+++ b/src/components/common/Banner/WelcomeBanner/Welcome35.tsx
@@ -7,7 +7,7 @@ const Welcome35 = () => {
   const { data: myData, isPending } = useGetMemberOfMe();
   const is35 = myData?.generation === LATEST_GENERATION;
 
-  if (!isPending) return <Skeleton height={168} margin='0 0 16px 0' />;
+  if (isPending) return <Skeleton height={168} margin='0 0 16px 0' />;
 
   return <WelcomeBanner is35={is35} />;
 };

--- a/src/components/common/Banner/WelcomeBanner/Welcome35.tsx
+++ b/src/components/common/Banner/WelcomeBanner/Welcome35.tsx
@@ -7,7 +7,7 @@ const Welcome35 = () => {
   const { data: myData, isPending } = useGetMemberOfMe();
   const is35 = myData?.generation === LATEST_GENERATION;
 
-  if (isPending) return <Skeleton height={168} margin='0 0 16px 0' />;
+  if (!isPending) return <Skeleton height={168} margin='0 0 16px 0' />;
 
   return <WelcomeBanner is35={is35} />;
 };

--- a/src/components/common/Banner/WelcomeBanner/Welcome35.tsx
+++ b/src/components/common/Banner/WelcomeBanner/Welcome35.tsx
@@ -7,7 +7,7 @@ const Welcome35 = () => {
   const { data: myData, isPending } = useGetMemberOfMe();
   const is35 = myData?.generation === LATEST_GENERATION;
 
-  if (isPending) return <Skeleton height={168} />;
+  if (isPending) return <Skeleton height={168} margin='0 0 16px 0' />;
 
   return <WelcomeBanner is35={is35} />;
 };

--- a/src/components/common/Banner/WelcomeBanner/index.tsx
+++ b/src/components/common/Banner/WelcomeBanner/index.tsx
@@ -1,9 +1,7 @@
 import styled from '@emotion/styled';
 import { colors } from '@sopt-makers/colors';
-import { IconChevronRight } from '@sopt-makers/icons';
 import { useEffect, useLayoutEffect, useState } from 'react';
 
-import Loading from '@/components/common/Loading';
 import Responsive from '@/components/common/Responsive';
 import Text from '@/components/common/Text';
 import { LoggingClick } from '@/components/eventLogger/components/LoggingClick';
@@ -63,7 +61,7 @@ const WelcomeBanner = ({ is35 }: WelcomeBannerProp) => {
   return (
     <WelcomeBannerContainer>
       <WelcomeBannerWrapper>
-        {isMounted ? (
+        {isMounted && (
           <>
             {is35 ? (
               <>
@@ -102,8 +100,6 @@ const WelcomeBanner = ({ is35 }: WelcomeBannerProp) => {
               </BannerWrapper>
             )}
           </>
-        ) : (
-          <Loading />
         )}
       </WelcomeBannerWrapper>
     </WelcomeBannerContainer>

--- a/src/components/common/Skeleton/index.tsx
+++ b/src/components/common/Skeleton/index.tsx
@@ -1,0 +1,22 @@
+import styled from '@emotion/styled';
+import { colors } from '@sopt-makers/colors';
+
+interface SkeletonProps {
+  width?: number;
+  height?: number;
+  borderRadius?: number;
+  color?: string;
+}
+
+const Skeleton = ({ width, height, borderRadius, color }: SkeletonProps) => {
+  return <StyledSkeleton width={width} height={height} borderRadius={borderRadius} color={color} />;
+};
+
+export default Skeleton;
+
+const StyledSkeleton = styled.div<{ width?: number; height?: number; borderRadius?: number; color?: string }>`
+  border-radius: ${({ borderRadius }) => borderRadius && `${borderRadius}%`};
+  background-color: ${({ color }) => color ?? colors.gray900};
+  width: ${({ width }) => (width ? `${width}px` : '100%')};
+  height: ${({ height }) => (height ? `${height}px` : '100%')};
+`;

--- a/src/components/common/Skeleton/index.tsx
+++ b/src/components/common/Skeleton/index.tsx
@@ -1,21 +1,35 @@
 import styled from '@emotion/styled';
 import { colors } from '@sopt-makers/colors';
+import { ReactNode } from 'react';
 
 interface SkeletonProps {
   width?: number;
   height?: number;
   borderRadius?: number;
+  margin?: string;
   color?: string;
+  children?: ReactNode;
 }
 
-const Skeleton = ({ width, height, borderRadius, color }: SkeletonProps) => {
-  return <StyledSkeleton width={width} height={height} borderRadius={borderRadius} color={color} />;
+const Skeleton = ({ width, height, borderRadius, color, margin, children, ...props }: SkeletonProps) => {
+  return (
+    <StyledSkeleton width={width} height={height} borderRadius={borderRadius} margin={margin} color={color} {...props}>
+      {children}
+    </StyledSkeleton>
+  );
 };
 
 export default Skeleton;
 
-const StyledSkeleton = styled.div<{ width?: number; height?: number; borderRadius?: number; color?: string }>`
-  border-radius: ${({ borderRadius }) => borderRadius && `${borderRadius}%`};
+const StyledSkeleton = styled.div<{
+  width?: number;
+  height?: number;
+  borderRadius?: number;
+  margin?: string;
+  color?: string;
+}>`
+  margin: ${({ margin }) => margin && margin};
+  border-radius: ${({ borderRadius }) => borderRadius && `${borderRadius}px`};
   background-color: ${({ color }) => color ?? colors.gray900};
   width: ${({ width }) => (width ? `${width}px` : '100%')};
   height: ${({ height }) => (height ? `${height}px` : '100%')};

--- a/src/components/feed/list/CategorySkeleton.tsx
+++ b/src/components/feed/list/CategorySkeleton.tsx
@@ -1,0 +1,28 @@
+import styled from '@emotion/styled';
+import { colors } from '@sopt-makers/colors';
+
+import Skeleton from '@/components/common/Skeleton';
+
+const CategorySkeleton = () => {
+  return (
+    <CategorySkeletonWrapper>
+      <Skeleton width={28} height={20} borderRadius={8} color={colors.gray700} />
+      <Skeleton width={28} height={20} borderRadius={8} color={colors.gray700} />
+      <Skeleton width={28} height={20} borderRadius={8} color={colors.gray700} />
+      <Skeleton width={72} height={20} borderRadius={8} color={colors.gray700} />
+      <Skeleton width={28} height={20} borderRadius={8} color={colors.gray700} />
+      <Skeleton width={64} height={20} borderRadius={8} color={colors.gray700} />
+    </CategorySkeletonWrapper>
+  );
+};
+
+export default CategorySkeleton;
+
+const CategorySkeletonWrapper = styled.div`
+  display: flex;
+  gap: 16px;
+  border-bottom: 1px solid ${colors.gray800};
+  padding: 14px 16px;
+  width: 100%;
+  height: 100%;
+`;

--- a/src/components/feed/list/FeedList.tsx
+++ b/src/components/feed/list/FeedList.tsx
@@ -11,6 +11,7 @@ import Text from '@/components/common/Text';
 import { LoggingClick } from '@/components/eventLogger/components/LoggingClick';
 import { useCategoryParam } from '@/components/feed/common/queryParam';
 import CategorySelect from '@/components/feed/list/CategorySelect';
+import CategorySkeleton from '@/components/feed/list/CategorySkeleton';
 import FeedListItems from '@/components/feed/list/FeedListItems';
 import { layoutCSSVariable } from '@/components/layout/utils';
 import { playgroundLink } from '@/constants/links';
@@ -24,7 +25,7 @@ interface FeedListProps {
 const FeedList: FC<FeedListProps> = ({ renderFeedDetailLink, onScrollChange }) => {
   const queryClient = useQueryClient();
   const [categoryId] = useCategoryParam({ defaultValue: '' });
-  const { data: categoryData } = useQuery({
+  const { data: categoryData, isLoading } = useQuery({
     queryKey: getCategory.cacheKey(),
     queryFn: getCategory.request,
   });
@@ -46,9 +47,16 @@ const FeedList: FC<FeedListProps> = ({ renderFeedDetailLink, onScrollChange }) =
 
   return (
     <Container>
-      <CategoryArea>
-        {categories && <CategorySelect categories={categories} onCategoryChange={handleCategoryChange} />}
-      </CategoryArea>
+      {isLoading ? (
+        <CategorySkeleton />
+      ) : (
+        categories && (
+          <CategoryArea>
+            <CategorySelect categories={categories} onCategoryChange={handleCategoryChange} />
+          </CategoryArea>
+        )
+      )}
+
       <HeightSpacer>
         <ErrorBoundary
           renderFallback={(error) => (
@@ -121,4 +129,10 @@ const UploadLink = styled(Link)`
 const UploadIcon = styled.img`
   width: 24px;
   height: 24px;
+`;
+
+const Test = styled.div`
+  background-color: white;
+  width: 100px;
+  height: 100px;
 `;

--- a/src/components/feed/list/FeedListItems.tsx
+++ b/src/components/feed/list/FeedListItems.tsx
@@ -24,6 +24,7 @@ import { useShareFeed } from '@/components/feed/common/hooks/useShareFeed';
 import { useToggleLike } from '@/components/feed/common/hooks/useToggleLike';
 import { CategoryList, getMemberInfo } from '@/components/feed/common/utils';
 import FeedCard from '@/components/feed/list/FeedCard';
+import FeedSkeleton from '@/components/feed/list/FeedSkeleton';
 import { useNavigateBack } from '@/components/navigation/useNavigateBack';
 import { textStyles } from '@/styles/typography';
 
@@ -95,6 +96,8 @@ const FeedListItems: FC<FeedListItemsProps> = ({ categoryId, renderFeedDetailLin
       });
     }
   });
+
+  if (!isLoading) return <FeedSkeleton />;
 
   return (
     <>
@@ -255,7 +258,7 @@ const FeedListItems: FC<FeedListItemsProps> = ({ categoryId, renderFeedDetailLin
       <div css={{ display: 'flex', justifyContent: 'center', padding: '30px 0' }}>
         {isError ? <AlertText>오류가 발생했어요.</AlertText> : null}
         {data != null && flattenData.length === 0 ? <AlertText>아직 작성된 글이 없어요(ㅠ_ㅠ)</AlertText> : null}
-        {isLoading ? <Loading /> : null}
+        {isLoading ? <div>hi</div> : null}
       </div>
     </>
   );

--- a/src/components/feed/list/FeedListItems.tsx
+++ b/src/components/feed/list/FeedListItems.tsx
@@ -97,7 +97,7 @@ const FeedListItems: FC<FeedListItemsProps> = ({ categoryId, renderFeedDetailLin
     }
   });
 
-  if (!isLoading) return <FeedSkeleton />;
+  if (isLoading) return <FeedSkeleton />;
 
   return (
     <>
@@ -258,7 +258,6 @@ const FeedListItems: FC<FeedListItemsProps> = ({ categoryId, renderFeedDetailLin
       <div css={{ display: 'flex', justifyContent: 'center', padding: '30px 0' }}>
         {isError ? <AlertText>오류가 발생했어요.</AlertText> : null}
         {data != null && flattenData.length === 0 ? <AlertText>아직 작성된 글이 없어요(ㅠ_ㅠ)</AlertText> : null}
-        {isLoading ? <div>hi</div> : null}
       </div>
     </>
   );

--- a/src/components/feed/list/FeedSkeleton.tsx
+++ b/src/components/feed/list/FeedSkeleton.tsx
@@ -1,0 +1,65 @@
+import styled from '@emotion/styled';
+import { colors } from '@sopt-makers/colors';
+
+import Skeleton from '@/components/common/Skeleton';
+import { MOBILE_MEDIA_QUERY } from '@/styles/mediaQuery';
+
+const FeedSkeleton = () => {
+  return (
+    <>
+      {[1, 2, 3, 4].map((key) => (
+        <FeedSkeletonWrapper key={key}>
+          <SkeletonResponsive1 width={32} height={32} borderRadius={16} color={colors.gray700} />
+          <RightWrapper>
+            <Skeleton width={184} height={16} borderRadius={8} color={colors.gray700} margin='0 0 24px 0' />
+            <Skeleton height={20} borderRadius={8} color={colors.gray700} margin='0 0 8px 0' />
+            <SkeletonResponsive2 width={307} height={20} borderRadius={8} color={colors.gray700} margin='0 0 28px 0' />
+            <BottomWrapper>
+              <Skeleton width={74} height={20} borderRadius={8} color={colors.gray700} margin='0 0 28px 0' />
+              <Skeleton width={48} height={20} borderRadius={8} color={colors.gray700} margin='0 0 28px 0' />
+            </BottomWrapper>
+          </RightWrapper>
+        </FeedSkeletonWrapper>
+      ))}
+    </>
+  );
+};
+
+export default FeedSkeleton;
+
+const FeedSkeletonWrapper = styled.div`
+  display: flex;
+  justify-content: space-between;
+  padding: 16px;
+  width: 100%;
+  height: 100%;
+
+  @media ${MOBILE_MEDIA_QUERY} {
+    gap: 12px;
+    justify-content: flex-start;
+  }
+`;
+const RightWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  margin-top: 8px;
+  margin-right: 24px;
+  width: 100%;
+  max-width: 460px;
+`;
+const BottomWrapper = styled.div`
+  display: flex;
+  justify-content: space-between;
+`;
+
+const SkeletonResponsive1 = styled(Skeleton)`
+  @media ${MOBILE_MEDIA_QUERY} {
+    flex-shrink: 0;
+  }
+`;
+
+const SkeletonResponsive2 = styled(Skeleton)`
+  @media ${MOBILE_MEDIA_QUERY} {
+    width: 184px;
+  }
+`;

--- a/src/components/wordchain/WordchainEntry/WordChainEntry.tsx
+++ b/src/components/wordchain/WordchainEntry/WordChainEntry.tsx
@@ -12,10 +12,7 @@ import Responsive from '@/components/common/Responsive';
 import Text from '@/components/common/Text';
 import useEventLogger from '@/components/eventLogger/hooks/useEventLogger';
 import WordchainMessage from '@/components/wordchain/WordchainEntry/WordchainMessage';
-import WordchainSkeleton, {
-  WordchainSkeletonDesktop,
-  WordchainSkeletonMobile,
-} from '@/components/wordchain/WordchainEntry/WordchainSkeleton';
+import WordchainSkeleton from '@/components/wordchain/WordchainEntry/WordchainSkeleton';
 import { useWordchainWinnersQuery } from '@/components/wordchain/WordchainWinners/hooks/useWordchainWinnersQuery';
 import { playgroundLink } from '@/constants/links';
 import IconMessageChat from '@/public/icons/icon-message-chat.svg';
@@ -47,7 +44,7 @@ const WordChainEntry: FC<WordChainEntryProps> = ({ className }) => {
       onClick={() => logClickEvent('wordchainEntry')}
       isBanner={isBanner}
     >
-      {!isLoading || !wordList ? (
+      {isLoading || !wordList ? (
         <WordchainSkeleton />
       ) : (
         <>

--- a/src/components/wordchain/WordchainEntry/WordChainEntry.tsx
+++ b/src/components/wordchain/WordchainEntry/WordChainEntry.tsx
@@ -1,3 +1,4 @@
+import { css } from '@emotion/react';
 import styled from '@emotion/styled';
 import { colors } from '@sopt-makers/colors';
 import { fonts } from '@sopt-makers/fonts';
@@ -7,18 +8,20 @@ import { FC } from 'react';
 
 import { useGetEntryWordchain } from '@/api/endpoint/wordchain/getWordchain';
 import { ADS } from '@/components/common/Banner/AdsBanner/constants/ads';
-import Loading from '@/components/common/Loading';
 import Responsive from '@/components/common/Responsive';
 import Text from '@/components/common/Text';
 import useEventLogger from '@/components/eventLogger/hooks/useEventLogger';
 import WordchainMessage from '@/components/wordchain/WordchainEntry/WordchainMessage';
+import {
+  WordchainSkeletonDesktop,
+  WordchainSkeletonMobile,
+} from '@/components/wordchain/WordchainEntry/WordchainSkeleton';
 import { useWordchainWinnersQuery } from '@/components/wordchain/WordchainWinners/hooks/useWordchainWinnersQuery';
 import { playgroundLink } from '@/constants/links';
 import IconMessageChat from '@/public/icons/icon-message-chat.svg';
 import { MOBILE_MEDIA_QUERY } from '@/styles/mediaQuery';
 import { textStyles } from '@/styles/typography';
 import { SwitchCase } from '@/utils/components/switch-case/SwitchCase';
-import { css } from '@emotion/react';
 
 interface WordChainEntryProps {
   className?: string;
@@ -44,12 +47,16 @@ const WordChainEntry: FC<WordChainEntryProps> = ({ className }) => {
       onClick={() => logClickEvent('wordchainEntry')}
       isBanner={isBanner}
     >
-      {(isLoading || !wordList) && (
-        <LoadingContainer isBanner={isBanner}>
-          <Loading />
-        </LoadingContainer>
-      )}
-      {wordList && (
+      {isLoading || !wordList ? (
+        <>
+          <Responsive only='desktop' asChild>
+            <WordchainSkeletonDesktop />
+          </Responsive>
+          <Responsive only='mobile' asChild>
+            <WordchainSkeletonMobile />
+          </Responsive>
+        </>
+      ) : (
         <>
           <LeftSection>
             {!isBanner && (

--- a/src/components/wordchain/WordchainEntry/WordChainEntry.tsx
+++ b/src/components/wordchain/WordchainEntry/WordChainEntry.tsx
@@ -12,7 +12,7 @@ import Responsive from '@/components/common/Responsive';
 import Text from '@/components/common/Text';
 import useEventLogger from '@/components/eventLogger/hooks/useEventLogger';
 import WordchainMessage from '@/components/wordchain/WordchainEntry/WordchainMessage';
-import {
+import WordchainSkeleton, {
   WordchainSkeletonDesktop,
   WordchainSkeletonMobile,
 } from '@/components/wordchain/WordchainEntry/WordchainSkeleton';
@@ -48,14 +48,7 @@ const WordChainEntry: FC<WordChainEntryProps> = ({ className }) => {
       isBanner={isBanner}
     >
       {isLoading || !wordList ? (
-        <>
-          <Responsive only='desktop' asChild>
-            <WordchainSkeletonDesktop />
-          </Responsive>
-          <Responsive only='mobile' asChild>
-            <WordchainSkeletonMobile />
-          </Responsive>
-        </>
+        <WordchainSkeleton />
       ) : (
         <>
           <LeftSection>

--- a/src/components/wordchain/WordchainEntry/WordChainEntry.tsx
+++ b/src/components/wordchain/WordchainEntry/WordChainEntry.tsx
@@ -47,7 +47,7 @@ const WordChainEntry: FC<WordChainEntryProps> = ({ className }) => {
       onClick={() => logClickEvent('wordchainEntry')}
       isBanner={isBanner}
     >
-      {isLoading || !wordList ? (
+      {!isLoading || !wordList ? (
         <WordchainSkeleton />
       ) : (
         <>

--- a/src/components/wordchain/WordchainEntry/WordchainSkeleton.tsx
+++ b/src/components/wordchain/WordchainEntry/WordchainSkeleton.tsx
@@ -2,54 +2,66 @@ import styled from '@emotion/styled';
 import { colors } from '@sopt-makers/colors';
 
 import Skeleton from '@/components/common/Skeleton';
+import { MOBILE_MEDIA_QUERY } from '@/styles/mediaQuery';
 
-const WordchainSkeletonDesktop = () => {
+const WordchainSkeleton = () => {
   return (
-    <SkeletonWrapperDesktop borderRadius={14} height={60}>
-      <LeftWrapper>
-        <Skeleton width={28} height={28} borderRadius={8} color={colors.gray700} margin='0 8px 0 0' />
-        <Skeleton width={47} height={20} borderRadius={8} color={colors.gray700} margin='0 16px 0 0' />
-        <Skeleton width={286} height={20} borderRadius={8} color={colors.gray700} />
-      </LeftWrapper>
-      <Skeleton width={28} height={28} borderRadius={8} color={colors.gray700} />
-    </SkeletonWrapperDesktop>
+    <SkeletonWrapper borderRadius={14} height={60}>
+      <Skeleton1 width={28} height={28} borderRadius={8} color={colors.gray700} margin='0 8px 0 0' />
+      <MiddleWrapper>
+        <Skeleton2 width={47} height={20} borderRadius={8} color={colors.gray700} margin='0 16px 0 0' />
+        <Skeleton3 width={286} height={20} borderRadius={8} color={colors.gray700} />
+      </MiddleWrapper>
+      <Skeleton4 width={28} height={28} borderRadius={8} color={colors.gray700} margin='0 0 0 115px' />
+    </SkeletonWrapper>
   );
 };
 
-const WordchainSkeletonMobile = () => {
-  return (
-    <SkeletonWrapperMobile borderRadius={14} height={80}>
-      <Skeleton width={80} height={28} borderRadius={8} color={colors.gray700} margin='0 16px 0 0' />
-      <RightWrapper>
-        <Skeleton width={193} height={16} borderRadius={8} color={colors.gray700} />
-        <Skeleton width={150} height={16} borderRadius={8} color={colors.gray700} />
-      </RightWrapper>
-    </SkeletonWrapperMobile>
-  );
-};
+export default WordchainSkeleton;
 
-export { WordchainSkeletonDesktop, WordchainSkeletonMobile };
-
-const SkeletonWrapperDesktop = styled(Skeleton)`
+const SkeletonWrapper = styled(Skeleton)`
   display: flex;
   align-items: center;
-  justify-content: space-between;
   padding: 16px;
+
+  @media ${MOBILE_MEDIA_QUERY} {
+    padding: 20px 16px;
+    height: 80px;
+  }
 `;
 
-const SkeletonWrapperMobile = styled(Skeleton)`
+const MiddleWrapper = styled.div`
   display: flex;
-  align-items: center;
-  padding: 26px 16px;
+
+  @media ${MOBILE_MEDIA_QUERY} {
+    flex-direction: column;
+    gap: 8px;
+  }
 `;
 
-const LeftWrapper = styled.div`
-  display: flex;
-  align-items: center;
+const Skeleton1 = styled(Skeleton)`
+  @media ${MOBILE_MEDIA_QUERY} {
+    width: 80px;
+  }
 `;
 
-const RightWrapper = styled.div`
-  display: flex;
-  flex-direction: column;
-  gap: 8px;
+const Skeleton2 = styled(Skeleton)`
+  @media ${MOBILE_MEDIA_QUERY} {
+    margin-left: 16px;
+    width: 193px;
+    height: 16px;
+  }
+`;
+const Skeleton3 = styled(Skeleton)`
+  @media ${MOBILE_MEDIA_QUERY} {
+    margin-left: 16px;
+    width: 150px;
+    height: 16px;
+  }
+`;
+
+const Skeleton4 = styled(Skeleton)`
+  @media ${MOBILE_MEDIA_QUERY} {
+    display: none;
+  }
 `;

--- a/src/components/wordchain/WordchainEntry/WordchainSkeleton.tsx
+++ b/src/components/wordchain/WordchainEntry/WordchainSkeleton.tsx
@@ -7,12 +7,12 @@ import { MOBILE_MEDIA_QUERY } from '@/styles/mediaQuery';
 const WordchainSkeleton = () => {
   return (
     <SkeletonWrapper borderRadius={14} height={60}>
-      <Skeleton1 width={28} height={28} borderRadius={8} color={colors.gray700} margin='0 8px 0 0' />
+      <SkeletonResponsive1 width={28} height={28} borderRadius={8} color={colors.gray700} margin='0 8px 0 0' />
       <MiddleWrapper>
-        <Skeleton2 width={47} height={20} borderRadius={8} color={colors.gray700} margin='0 16px 0 0' />
-        <Skeleton3 width={286} height={20} borderRadius={8} color={colors.gray700} />
+        <SkeletonResponsive2 width={47} height={20} borderRadius={8} color={colors.gray700} margin='0 16px 0 0' />
+        <SkeletonResponsive3 width={286} height={20} borderRadius={8} color={colors.gray700} />
       </MiddleWrapper>
-      <Skeleton4 width={28} height={28} borderRadius={8} color={colors.gray700} margin='0 0 0 115px' />
+      <SkeletonResponsive4 width={28} height={28} borderRadius={8} color={colors.gray700} margin='0 0 0 115px' />
     </SkeletonWrapper>
   );
 };
@@ -39,20 +39,20 @@ const MiddleWrapper = styled.div`
   }
 `;
 
-const Skeleton1 = styled(Skeleton)`
+const SkeletonResponsive1 = styled(Skeleton)`
   @media ${MOBILE_MEDIA_QUERY} {
     width: 80px;
   }
 `;
 
-const Skeleton2 = styled(Skeleton)`
+const SkeletonResponsive2 = styled(Skeleton)`
   @media ${MOBILE_MEDIA_QUERY} {
     margin-left: 16px;
     width: 193px;
     height: 16px;
   }
 `;
-const Skeleton3 = styled(Skeleton)`
+const SkeletonResponsive3 = styled(Skeleton)`
   @media ${MOBILE_MEDIA_QUERY} {
     margin-left: 16px;
     width: 150px;
@@ -60,7 +60,7 @@ const Skeleton3 = styled(Skeleton)`
   }
 `;
 
-const Skeleton4 = styled(Skeleton)`
+const SkeletonResponsive4 = styled(Skeleton)`
   @media ${MOBILE_MEDIA_QUERY} {
     display: none;
   }

--- a/src/components/wordchain/WordchainEntry/WordchainSkeleton.tsx
+++ b/src/components/wordchain/WordchainEntry/WordchainSkeleton.tsx
@@ -1,0 +1,55 @@
+import styled from '@emotion/styled';
+import { colors } from '@sopt-makers/colors';
+
+import Skeleton from '@/components/common/Skeleton';
+
+const WordchainSkeletonDesktop = () => {
+  return (
+    <SkeletonWrapperDesktop borderRadius={14} height={60}>
+      <LeftWrapper>
+        <Skeleton width={28} height={28} borderRadius={8} color={colors.gray700} margin='0 8px 0 0' />
+        <Skeleton width={47} height={20} borderRadius={8} color={colors.gray700} margin='0 16px 0 0' />
+        <Skeleton width={286} height={20} borderRadius={8} color={colors.gray700} />
+      </LeftWrapper>
+      <Skeleton width={28} height={28} borderRadius={8} color={colors.gray700} />
+    </SkeletonWrapperDesktop>
+  );
+};
+
+const WordchainSkeletonMobile = () => {
+  return (
+    <SkeletonWrapperMobile borderRadius={14} height={80}>
+      <Skeleton width={80} height={28} borderRadius={8} color={colors.gray700} margin='0 16px 0 0' />
+      <RightWrapper>
+        <Skeleton width={193} height={16} borderRadius={8} color={colors.gray700} />
+        <Skeleton width={150} height={16} borderRadius={8} color={colors.gray700} />
+      </RightWrapper>
+    </SkeletonWrapperMobile>
+  );
+};
+
+export { WordchainSkeletonDesktop, WordchainSkeletonMobile };
+
+const SkeletonWrapperDesktop = styled(Skeleton)`
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 16px;
+`;
+
+const SkeletonWrapperMobile = styled(Skeleton)`
+  display: flex;
+  align-items: center;
+  padding: 26px 16px;
+`;
+
+const LeftWrapper = styled.div`
+  display: flex;
+  align-items: center;
+`;
+
+const RightWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+`;

--- a/src/components/wordchain/WordchainEntry/WordchainSkeleton.tsx
+++ b/src/components/wordchain/WordchainEntry/WordchainSkeleton.tsx
@@ -25,6 +25,7 @@ const SkeletonWrapper = styled(Skeleton)`
   padding: 16px;
 
   @media ${MOBILE_MEDIA_QUERY} {
+    margin-bottom: 16px;
     padding: 20px 16px;
     height: 80px;
   }


### PR DESCRIPTION
### 🤫 쉿, 나한테만 말해줘요. 이슈넘버
- close #1569

### 🧐 어떤 것을 변경했어요~?
<!-- 실제로 변경한 사항을 설명해주세요.-->
 - [x] 환영배너 스켈레톤 (모바일/데탑)
 - [x] 끝말잇기 스켈레톤 (모바일/데탑)
 - [x] 카테고리 스켈레톤 (모바일/데탑) 
 - [x] 커뮤니티 스켈레톤 (모바일/데탑)

### 🤔 그렇다면, 어떻게 구현했어요~?
<!-- 실제로 구현한 로직에 대해 설명해주세요.-->
Skeleton 공통 컴포넌트를 만들고, 이걸 조합해서 사용했습니다.
```ts
//Skeleton/index.ts
const Skeleton = ({ width, height, borderRadius, color, margin, children, ...props }: SkeletonProps) => {
  return (
    <StyledSkeleton width={width} height={height} borderRadius={borderRadius} margin={margin} color={color} {...props}>
      {children}
    </StyledSkeleton>
  );
};

export default Skeleton;

const StyledSkeleton = styled.div<{
  width?: number;
  height?: number;
  borderRadius?: number;
  margin?: string;
  color?: string;
}>`
  margin: ${({ margin }) => margin && margin};
  border-radius: ${({ borderRadius }) => borderRadius && `${borderRadius}px`};
  background-color: ${({ color }) => color ?? colors.gray900};
  width: ${({ width }) => (width ? `${width}px` : '100%')};
  height: ${({ height }) => (height ? `${height}px` : '100%')};
`;

```

### ❤️‍🔥 당신이 생각하는 PR포인트, 내겐 매력포인트.
<!-- 해당 PR에서 논의가 필요한 사항을 적어주세요. -->

#### 반응형 관련 이슈
끝말잇기의 경우 모바일과 데탑버전의 스켈레톤 UI의 레이아웃이 많이 다르기 때문에, 처음에는 <Responsive> 컴포넌트로 분기를 처리해줬습니다.
그런데 `<Responsive>` 내부 로직을 보면, 서버사이드에서는 뷰포트를 확인할 수 없으므로 모바일버전과 데탑버전 둘다 렌더링을 시켜놓은 뒤 useEffect내에서 필요없는 버전을 제거하고 있습니다. [관련 PR](https://github.com/sopt-makers/sopt-playground-frontend/pull/430)
따라서 로딩상태에 있을 때 두 버전이 모두 화면에 보이게 되는 문제가 생겼습니다.

https://github.com/user-attachments/assets/44093493-cdac-44c7-b55f-341acb88c886

<img width="1434" alt="image" src="https://github.com/user-attachments/assets/a8493219-67d6-4a18-a0e4-f85e7fa13288">

초반 찰나에 위와같이 렌더링이 되는 걸 볼 수 있습니다.

일단 기한이 빡빡하다보니, 많은 곳에서 사용되고 있는 `<Responsive>` 로직을 수정하는 것보다는 다른 방식으로 우회를 하는 것이 좋겠다고 판단했습니다.
그래서 `<Responsive>`가 아닌 미디어 쿼리로 모바일/데탑 버전을 분기하게 되었습니다. 억지로 레이아웃을 맞추다보니 코드 네이밍이나 반응형처리가 조잡해진 감이 있습니다. 추후 mds로 교체할 것을 고려하여 이번 구현은 임시적인 조치라고 봐주시면 되겠습니다!

#### 광고 구좌 관련
마감이 급박 + mds 추후 적용 예정 이슈로 광고 구좌는 현재 처리하지 않았습니다!
따라서 환영배너 내리기 전에 광고 구좌에 관한 건은 추가 작업 필요합니다.

### 📸 스크린샷, 없으면 이것 참,, 섭섭한데요?


https://github.com/user-attachments/assets/4e293a6b-22cc-453d-85ce-621454b529fe

![image](https://github.com/user-attachments/assets/3cd817fd-0dea-4bc5-ae9d-7e73b810e2dc)


https://github.com/user-attachments/assets/41bd3d4d-79ec-4229-af82-77aa568047f7

![image](https://github.com/user-attachments/assets/8ec41498-e37b-40f0-b7b3-01c50e673e24)
