### PR TITLE
fix: 커뮤니티 임원진 파트 표기 수정

### DIFF
--- a/src/components/feed/common/utils.ts
+++ b/src/components/feed/common/utils.ts
@@ -45,6 +45,7 @@ export const CategoryList = {
 
 const 특수임원List = [
   '메이커스 리드',
+  '메이커스 팀장',
   '기획 파트장',
   '디자인 파트장',
   '웹 파트장',


### PR DESCRIPTION
### 🤫 쉿, 나한테만 말해줘요. 이슈넘버
- close #1580 

### 🧐 어떤 것을 변경했어요~?
<!-- 실제로 변경한 사항을 설명해주세요.-->

특수임원List를 업데이트해서, 현재 발생하고 있는 메이커스 임원진 표기 오류에 대해서 수정을 진행했습니다.

관련 쓰레드 링크: https://sopt-makers.slack.com/archives/C042T81PW80/p1727615461338179?thread_ts=1727614217.483179&cid=C042T81PW80

### 🤔 그렇다면, 어떻게 구현했어요~?
<!-- 실제로 구현한 로직에 대해 설명해주세요.-->

```
const 특수임원List = [
  '메이커스 리드',
  '메이커스 팀장',
  '기획 파트장',
  '디자인 파트장',
  '웹 파트장',
  '서버 파트장',
  '안드로이드 파트장',
  'iOS 파트장',
  '운영 팀장',
  '미디어 팀장',
  '회장',
  '부회장',
  '총무',
] as const;
```
메이커스 팀장 직책을 추가했습니당

### ❤️‍🔥 당신이 생각하는 PR포인트, 내겐 매력포인트.
<!-- 해당 PR에서 논의가 필요한 사항을 적어주세요. -->

### 📸 스크린샷, 없으면 이것 참,, 섭섭한데요?
