### PR TITLE
fix: makers 35기 -> 35기 makers로 표기 변경

### DIFF
--- a/src/components/makers/Notifier.tsx
+++ b/src/components/makers/Notifier.tsx
@@ -16,22 +16,22 @@ const RECRUITING_URL =
 const Notifier: FC<NotifierProps> = ({ className }) => {
   return (
     <StyledJoinNotifier className={className}>
-      {/* MEMO: 5기 모집 시작 시 주석 해제 */}
-      {/* <Title>makers 5기 지원이 곧 시작될 예정이에요.</Title> */}
-      {/* <Title>makers 5기 지원이 시작되었어요.</Title> */}
-      {/* <Title>현재 35기 SOPT makers 팀 모집이 진행 중이에요!</Title> */}
-      <Title>현재 makers 35기 진행 중이에요. 36기에서 만나요!</Title>
+      {/* MEMO: 36기 모집 시작 시 주석 해제 */}
+      {/* <Title>36기 makers 지원이 곧 시작될 예정이에요.</Title> */}
+      {/* <Title>36기 makers 지원이 시작되었어요.</Title> */}
+      {/* <Title>현재 36기 SOPT makers 팀 모집이 진행 중이에요!</Title> */}
+      <Title>현재 35기 makers 진행 중이에요. 36기에서 만나요!</Title>
       <SubTitle>36기 모집은 2025년 1-2월 중에 진행될 예정이에요.</SubTitle>
       {/* <SubTitle>35기 모집은 2024년 7월 31일 수요일부터 8월 7일 수요일 23:59까지 진행될 예정이에요.</SubTitle> */}
       <ButtonGroup>
-        {/* MEMO: 5기 모집 알림 신청시에 다시 주석 해제 */}
+        {/* MEMO: 36기 모집 알림 신청시에 다시 주석 해제 */}
         {/* <SubscribeButton href={RECRUIT_NOTIFY_GENERATION_URL} target='_blank'>
           <StyledBellIcon />
-          5기 모집 알림 신청
+          36기 모집 알림 신청
         </SubscribeButton> */}
         {/* <ExpiredButton href='https://makers.sopt.org' target='_blank'>
           <StyledOutgoingIcon />
-          35기 메이커스팀 모집글 보기
+          36기 메이커스팀 모집글 보기
           {/* 모집 페이지 가기 
         </ExpiredButton> */}
         <ExpiredButton href={RECRUITING_URL} target='_blank'>


### PR DESCRIPTION
### 🤫 쉿, 나한테만 말해줘요. 이슈넘버
- close #1582

### 🧐 어떤 것을 변경했어요~?
<!-- 실제로 변경한 사항을 설명해주세요.-->
[관련 스레드](https://sopt-makers.slack.com/archives/C042T81PW80/p1727785987100689?thread_ts=1726912132.305009&cid=C042T81PW80)

makers 35기 -> 35기 makers로 표기 변경

### 🤔 그렇다면, 어떻게 구현했어요~?
<!-- 실제로 구현한 로직에 대해 설명해주세요.-->

### ❤️‍🔥 당신이 생각하는 PR포인트, 내겐 매력포인트.
<!-- 해당 PR에서 논의가 필요한 사항을 적어주세요. -->

### 📸 스크린샷, 없으면 이것 참,, 섭섭한데요?
<img width="600" alt="image" src="https://github.com/user-attachments/assets/5fb8af96-89f0-42bc-904a-9ce93791ffa9">
