### PR TITLE
feat: 환영배너 내리기 및 프로필 등록 완료 기존 버전으로 롤백

### DIFF
--- a/src/components/common/Banner/ActiveBannerSlot.tsx
+++ b/src/components/common/Banner/ActiveBannerSlot.tsx
@@ -1,7 +1,7 @@
 import styled from '@emotion/styled';
 import { FC } from 'react';
 
-import Welcome35 from '@/components/common/Banner/WelcomeBanner/Welcome35';
+import AdsBanner from '@/components/common/Banner/AdsBanner';
 
 interface ActiveBannerSlotProps {}
 
@@ -9,7 +9,7 @@ const ActiveBannerSlot: FC<ActiveBannerSlotProps> = ({}) => {
   return (
     <StyledActiveBanner>
       {/* 이 밑에 노출할 배너를 넣으세요. */}
-      <Welcome35 />
+      <AdsBanner />
       {/* ==== */}
     </StyledActiveBanner>
   );

--- a/src/components/common/Banner/WelcomeBanner/Welcome35.tsx
+++ b/src/components/common/Banner/WelcomeBanner/Welcome35.tsx
@@ -5,11 +5,11 @@ import { LATEST_GENERATION } from '@/constants/generation';
 
 const Welcome35 = () => {
   const { data: myData, isPending } = useGetMemberOfMe();
-  const is35 = myData?.generation === LATEST_GENERATION;
+  const isLastGeneration = myData?.generation === LATEST_GENERATION;
 
   if (isPending) return <Skeleton height={168} margin='0 0 16px 0' />;
 
-  return <WelcomeBanner is35={is35} />;
+  return <WelcomeBanner isLastGeneration={isLastGeneration} />;
 };
 
 export default Welcome35;

--- a/src/components/common/Banner/WelcomeBanner/index.tsx
+++ b/src/components/common/Banner/WelcomeBanner/index.tsx
@@ -25,10 +25,10 @@ type BannerOthersType = {
 };
 
 interface WelcomeBannerProp {
-  is35: boolean;
+  isLastGeneration: boolean;
 }
 
-const WelcomeBanner = ({ is35 }: WelcomeBannerProp) => {
+const WelcomeBanner = ({ isLastGeneration }: WelcomeBannerProp) => {
   // 이미지 랜덤 생성을 위한 코드
   const [bannerVersion, setBannerVersion] = useState(1);
   const [isMounted, setIsMounted] = useState(false);
@@ -60,10 +60,10 @@ const WelcomeBanner = ({ is35 }: WelcomeBannerProp) => {
 
   return (
     <WelcomeBannerContainer>
-      <WelcomeBannerWrapper is35={is35}>
+      <WelcomeBannerWrapper isLastGeneration={isLastGeneration}>
         {isMounted && (
           <>
-            {is35 ? (
+            {isLastGeneration ? (
               <>
                 <ButtonWrapper>
                   <LoggingClick
@@ -157,9 +157,9 @@ const WelcomeBannerContainer = styled.header`
   overflow: hidden;
 `;
 
-const WelcomeBannerWrapper = styled.div<{ is35: boolean }>`
+const WelcomeBannerWrapper = styled.div<{ isLastGeneration: boolean }>`
   display: flex;
-  position: ${({ is35 }) => (is35 ? 'fixed' : 'relative')};
+  position: ${({ isLastGeneration }) => (isLastGeneration ? 'fixed' : 'relative')};
   justify-content: center;
   z-index: 2;
   border-bottom: 1px solid ${colors.gray800};

--- a/src/components/members/upload/complete/CardBack.tsx
+++ b/src/components/members/upload/complete/CardBack.tsx
@@ -1,11 +1,11 @@
 import styled from '@emotion/styled';
 
 interface CardBackProps {
-  is35: boolean;
+  isLastGeneration: boolean;
 }
 
-const CardBack = ({ is35 }: CardBackProps) => {
-  const Logo = is35 ? <AndSoptLogo /> : <PlaygroundLogo />;
+const CardBack = ({ isLastGeneration }: CardBackProps) => {
+  const Logo = isLastGeneration ? <AndSoptLogo /> : <PlaygroundLogo />;
   return (
     <MemberCard>
       <ImageHolder>{Logo}</ImageHolder>

--- a/src/pages/members/complete.tsx
+++ b/src/pages/members/complete.tsx
@@ -18,7 +18,7 @@ import { useOpenResolutionModal } from '@/components/resolution/submit/useOpenRe
 import { LATEST_GENERATION } from '@/constants/generation';
 import { MOBILE_MEDIA_QUERY } from '@/styles/mediaQuery';
 /**
- * @desc 신규 프로필 등록 후 다짐 메시지를 유도하는 페이지입니다.
+ * @desc 신규 프로필 등록 후 다짐 메시지를 유도하는 페이지입니다. 다짐메시지 기간 이외에는 홈으로 가는 CTA만 존재합니다.
  */
 import { setLayout } from '@/utils/layout';
 
@@ -35,6 +35,7 @@ const CompletePage: FC = () => {
     }));
   const { data: myData } = useGetMemberOfMe();
   const is35 = myData?.generation === LATEST_GENERATION;
+  const isResolutionOpen = false; // 다짐메시지 오픈 기간에만 이 값을 true로 변경합니다.
 
   const { handleResolutionModalOpen, isOpenResolutionModal, onCloseResolutionModal, profileImage } =
     useOpenResolutionModal();
@@ -50,7 +51,7 @@ const CompletePage: FC = () => {
             <Text typography='SUIT_24_B'>프로필 등록 완료!</Text>
           </Responsive>
           <CardsWrapper>
-            <CardBack is35={is35} />
+            <CardBack is35={is35 && isResolutionOpen} />
             <MemberCardOfMe
               name={profile.name}
               belongs={belongs || ''}
@@ -59,7 +60,7 @@ const CompletePage: FC = () => {
               imageUrl={profile.profileImage}
             />
           </CardsWrapper>
-          {is35 ? (
+          {is35 && isResolutionOpen ? (
             <ButtonWrapper>
               <Button
                 onClick={() => {

--- a/src/pages/members/complete.tsx
+++ b/src/pages/members/complete.tsx
@@ -34,7 +34,7 @@ const CompletePage: FC = () => {
       isActive: activity.generation === LATEST_GENERATION,
     }));
   const { data: myData } = useGetMemberOfMe();
-  const is35 = myData?.generation === LATEST_GENERATION;
+  const isLastGeneration = myData?.generation === LATEST_GENERATION;
   const isResolutionOpen = false; // 다짐메시지 오픈 기간에만 이 값을 true로 변경합니다.
 
   const { handleResolutionModalOpen, isOpenResolutionModal, onCloseResolutionModal, profileImage } =
@@ -51,7 +51,7 @@ const CompletePage: FC = () => {
             <Text typography='SUIT_24_B'>프로필 등록 완료!</Text>
           </Responsive>
           <CardsWrapper>
-            <CardBack is35={is35 && isResolutionOpen} />
+            <CardBack isLastGeneration={isLastGeneration && isResolutionOpen} />
             <MemberCardOfMe
               name={profile.name}
               belongs={belongs || ''}
@@ -60,7 +60,7 @@ const CompletePage: FC = () => {
               imageUrl={profile.profileImage}
             />
           </CardsWrapper>
-          {is35 && isResolutionOpen ? (
+          {isLastGeneration && isResolutionOpen ? (
             <ButtonWrapper>
               <Button
                 onClick={() => {


### PR DESCRIPTION
### 🤫 쉿, 나한테만 말해줘요. 이슈넘버
- close #1588

### 🧐 어떤 것을 변경했어요~?
<!-- 실제로 변경한 사항을 설명해주세요.-->
- [x] 다짐메시지 내리기
- [x] 광고구좌 되살리기
- [ ] 광고구좌 스켈레톤 -> 현재 서버에서 내려받지 않고 constant를 활용하고 있으므로 스켈레톤이 필요하지 않습니다.
- [x] 프로필 등록 완료 기존 버전으로 롤백 

### 🤔 그렇다면, 어떻게 구현했어요~?
<!-- 실제로 구현한 로직에 대해 설명해주세요.-->
- ActiveBannerSlot에서 Welcome35 컴포넌트를 내리고, AdsBanner 컴포넌트를 삽입하였습니다.
- 환영 배너와 프로필 등록 완료 페이지에서 `is35`라는 변수를 반복적으로 사용하고 있었는데, 매번 워딩을 고쳐줘야하는게 불필요하다고 생각해서 `isLastGeneration`으로 변경하였습니다.

### ❤️‍🔥 당신이 생각하는 PR포인트, 내겐 매력포인트.
<!-- 해당 PR에서 논의가 필요한 사항을 적어주세요. -->
- 스켈레톤 작업시에 디자인 쪽에서 광고구좌까지 작업을 해주었었는데요! 광고구좌가 현재 서버에서 받아오는게 아니어서 스켈레톤이 불필요한 상황입니다. 혹시 나중에 서버에서 받아오는 방식으로 변경이 된다면 스켈레톤이 추가되어야 합니다.

### 📸 스크린샷, 없으면 이것 참,, 섭섭한데요?
<img width="1438" alt="스크린샷 2024-10-12 오후 4 37 01" src="https://github.com/user-attachments/assets/aff1280a-f2be-4640-a3cb-d2e9cae1fc69">

https://github.com/user-attachments/assets/46c77691-cde0-4d6e-9f45-0039c90f52dc

