### PR TITLE
feat: 커피챗 오픈 뷰 헤더 구현

### DIFF
--- a/src/components/coffeechat/mediaQuery.ts
+++ b/src/components/coffeechat/mediaQuery.ts
@@ -1,0 +1,5 @@
+export const TABLET_MAX_WIDTH = 1260;
+export const MOBILE_MAX_WIDTH = 430;
+
+export const COFFEECHAT_TABLET_MEDIA_QUERY = `screen and (max-width: ${TABLET_MAX_WIDTH}px)`;
+export const COFFEECHAT_MOBILE_MEDIA_QUERY = `screen and (max-width: ${MOBILE_MAX_WIDTH}px)`;

--- a/src/components/coffeechat/upload/UploadHeader/index.stories.tsx
+++ b/src/components/coffeechat/upload/UploadHeader/index.stories.tsx
@@ -1,0 +1,12 @@
+import { Meta } from '@storybook/react';
+
+import UploadHeader from '@/components/coffeechat/upload/UploadHeader';
+
+export default {
+  component: UploadHeader,
+} as Meta<typeof UploadHeader>;
+
+export const Default = {
+  args: { uploadType: '오픈' },
+  name: '커피챗 헤더',
+};

--- a/src/components/coffeechat/upload/UploadHeader/index.tsx
+++ b/src/components/coffeechat/upload/UploadHeader/index.tsx
@@ -1,0 +1,29 @@
+import styled from '@emotion/styled';
+import { colors } from '@sopt-makers/colors';
+import { fonts } from '@sopt-makers/fonts';
+import { Callout } from '@sopt-makers/ui';
+
+import { COFFEECHAT_MOBILE_MEDIA_QUERY } from '@/components/coffeechat/mediaQuery';
+
+interface UploadHeaderProp {
+  uploadType: string;
+}
+
+export default function UploadHeader({ uploadType }: UploadHeaderProp) {
+  return (
+    <header>
+      <Title>커피챗 {uploadType}</Title>
+      <Callout type='information'>커피챗 오픈에 필요한 필수 항목이 모두 입력 되었는지 꼼꼼하게 확인해주세요!</Callout>
+    </header>
+  );
+}
+
+const Title = styled.h1`
+  margin-bottom: 20px;
+  color: ${colors.gray10};
+  ${fonts.HEADING_32_B};
+
+  @media ${COFFEECHAT_MOBILE_MEDIA_QUERY} {
+    ${fonts.HEADING_24_B};
+  }
+`;


### PR DESCRIPTION
### 🤫 쉿, 나한테만 말해줘요. 이슈넘버
- close #

### 🧐 어떤 것을 변경했어요~?
<!-- 실제로 변경한 사항을 설명해주세요.-->
- 커피챗 오픈/수정 뷰의 헤더를 구현했어요.

### 🤔 그렇다면, 어떻게 구현했어요~?
<!-- 실제로 구현한 로직에 대해 설명해주세요.-->
- 오픈인지 수정인지를 props로 받도록 구현했어요.

### ❤️‍🔥 당신이 생각하는 PR포인트, 내겐 매력포인트.
<!-- 해당 PR에서 논의가 필요한 사항을 적어주세요. -->
- mds callout 처음 써봤는데 편리하네요!
- 커피챗 뷰의 반응형 break point가 기존 뷰의 break point와는 좀 달라서, 따로 mediaQuery라는 파일을 만들어서 선언해주었습니다!

### 📸 스크린샷, 없으면 이것 참,, 섭섭한데요?

<img width="804" alt="스크린샷 2024-10-16 오후 6 47 23" src="https://github.com/user-attachments/assets/c74c13e2-9e9b-443d-8bb9-9c521eafa3ce">

