### PR TITLE
feat: 커피챗 입력 progress 박스 구현

### DIFF
--- a/src/components/coffeechat/upload/ProgressBox/index.stories.tsx
+++ b/src/components/coffeechat/upload/ProgressBox/index.stories.tsx
@@ -1,0 +1,22 @@
+import { Meta } from '@storybook/react';
+
+import ProgressBox from '@/components/coffeechat/upload/ProgressBox';
+
+export default {
+  component: ProgressBox,
+} as Meta<typeof ProgressBox>;
+
+export const Default = {
+  args: { uploadType: '오픈', myInfoInprogress: false, coffeechatInfoInprogress: false },
+  name: 'progress 박스 default',
+};
+
+export const MyInfoInProgress = {
+  args: { uploadType: '오픈', myInfoInprogress: true, coffeechatInfoInprogress: false },
+  name: 'progress 박스 내 정보 입력',
+};
+
+export const CoffeeChatInProgress = {
+  args: { uploadType: '수정', myInfoInprogress: false, coffeechatInfoInprogress: true },
+  name: 'progress 박스 커피챗 정보 입력',
+};

--- a/src/components/coffeechat/upload/ProgressBox/index.tsx
+++ b/src/components/coffeechat/upload/ProgressBox/index.tsx
@@ -72,7 +72,7 @@ const ProgressWrapper = styled.div`
     top: 20px;
     bottom: 20px;
     left: 7px;
-    transform: translateX(-50%); /* 세로줄을 정확히 가운데로 이동 */
+    transform: translateX(-50%);
     background-color: ${colors.gray800};
     width: 1px;
     content: '';

--- a/src/components/coffeechat/upload/ProgressBox/index.tsx
+++ b/src/components/coffeechat/upload/ProgressBox/index.tsx
@@ -4,7 +4,7 @@ import { fonts } from '@sopt-makers/fonts';
 import { IconCheck } from '@sopt-makers/icons';
 
 interface ProgressBoxProps {
-  uploadType: string;
+  uploadType: '오픈' | '수정';
   myInfoInprogress: boolean;
   coffeechatInfoInprogress: boolean;
 }
@@ -90,13 +90,7 @@ const Content = styled.div`
 const ProgressCheck = ({ isInprogress }: { isInprogress: boolean }) => {
   return (
     <>
-      {isInprogress ? (
-        <IconCheckCircle isInprogress>
-          <IconCheck />
-        </IconCheckCircle>
-      ) : (
-        <IconCheckCircle isInprogress={isInprogress} />
-      )}
+      <IconCheckCircle isInprogress={isInprogress}>{isInprogress && <IconCheck />}</IconCheckCircle>
     </>
   );
 };

--- a/src/components/coffeechat/upload/ProgressBox/index.tsx
+++ b/src/components/coffeechat/upload/ProgressBox/index.tsx
@@ -1,0 +1,113 @@
+import styled from '@emotion/styled';
+import { colors } from '@sopt-makers/colors';
+import { fonts } from '@sopt-makers/fonts';
+import { IconCheck } from '@sopt-makers/icons';
+
+interface ProgressBoxProps {
+  uploadType: string;
+  myInfoInprogress: boolean;
+  coffeechatInfoInprogress: boolean;
+}
+
+export default function ProgressBox({ uploadType, myInfoInprogress, coffeechatInfoInprogress }: ProgressBoxProps) {
+  return (
+    <Box>
+      <SubTitle>커피챗 {uploadType}</SubTitle>
+      <Border />
+      <ProgressWrapper>
+        <Content>
+          <Label>
+            <ProgressCheck isInprogress={myInfoInprogress} />
+            <p>1. 내 정보</p>
+          </Label>
+          <Label>
+            <ProgressCheck isInprogress={coffeechatInfoInprogress} />
+            <p>2. 커피챗 정보</p>
+          </Label>
+        </Content>
+      </ProgressWrapper>
+    </Box>
+  );
+}
+
+const Box = styled.aside`
+  display: flex;
+  position: fixed;
+  flex-direction: column;
+  gap: 36px;
+  align-items: flex-start;
+  border: 1px solid ${colors.gray800};
+  border-radius: 15px;
+  padding: 50px 40px 60px;
+  width: 100%;
+  color: ${colors.gray10};
+`;
+
+const Border = styled.div`
+  border-bottom: 1px solid ${colors.gray800};
+  width: 100%;
+`;
+
+const SubTitle = styled.h2`
+  ${fonts.HEADING_24_B};
+`;
+
+const Label = styled.label`
+  display: flex;
+  gap: 24px;
+  align-items: center;
+
+  ${fonts.BODY_16_M};
+`;
+
+const ProgressWrapper = styled.div`
+  display: flex;
+  position: relative;
+  flex-direction: column;
+  align-items: center;
+  justify-content: space-between;
+
+  &::before {
+    position: absolute;
+    top: 20px;
+    bottom: 20px;
+    left: 7px;
+    transform: translateX(-50%); /* 세로줄을 정확히 가운데로 이동 */
+    background-color: ${colors.gray800};
+    width: 1px;
+    content: '';
+  }
+`;
+
+const Content = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 51px;
+  align-items: flex-start;
+  justify-content: flex-start;
+`;
+
+const ProgressCheck = ({ isInprogress }: { isInprogress: boolean }) => {
+  return (
+    <>
+      {isInprogress ? (
+        <IconCheckCircle isInprogress>
+          <IconCheck />
+        </IconCheckCircle>
+      ) : (
+        <IconCheckCircle isInprogress={isInprogress} />
+      )}
+    </>
+  );
+};
+
+const IconCheckCircle = styled.div<{ isInprogress: boolean }>`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 50%;
+  background-color: ${({ isInprogress }) => (isInprogress ? colors.blue400 : colors.gray600)};
+  padding: 3px;
+  width: 14px;
+  height: 14px;
+`;


### PR DESCRIPTION
### 🤫 쉿, 나한테만 말해줘요. 이슈넘버
- close #

### 🧐 어떤 것을 변경했어요~?
<!-- 실제로 변경한 사항을 설명해주세요.-->
- 커피챗 오픈/수정 뷰의 progress 박스를 구현했어요.

### 🤔 그렇다면, 어떻게 구현했어요~?
<!-- 실제로 구현한 로직에 대해 설명해주세요.-->
- 커피챗 오픈인지 수정인지, 내 정보 수정 중인지, 커피챗 정보 수정 중인지에 대한 정보를 props로 받았어요.

### ❤️‍🔥 당신이 생각하는 PR포인트, 내겐 매력포인트.
<!-- 해당 PR에서 논의가 필요한 사항을 적어주세요. -->
- width를 100%로 구현했둔 상태에요! 추후에 progress 박스가 자식으로 들어가는 Layout 컴포넌트를 구축할 예정이에요. 

### 📸 스크린샷, 없으면 이것 참,, 섭섭한데요?

<img width="352" alt="스크린샷 2024-10-16 오후 8 06 51" src="https://github.com/user-attachments/assets/a3561865-9914-431e-8989-c0c68e8c3cb1">

