### PR TITLE
feat: 커피챗 업로드 뷰 데스크탑, 모바일 레이아웃 구현

### DIFF
--- a/src/components/coffeechat/page/CoffeechatUploadPage.tsx
+++ b/src/components/coffeechat/page/CoffeechatUploadPage.tsx
@@ -2,11 +2,13 @@ import { yupResolver } from '@hookform/resolvers/yup';
 import { FormProvider, useForm } from 'react-hook-form';
 
 import DesktopCoffeechatUploadLayout from '@/components/coffeechat/page/layout/DesktopCoffeechatUploadLayout';
+import MobileCoffeechatUploadLayout from '@/components/coffeechat/page/layout/MobileCoffeechatUploadLayout';
 import CoffeechatForm from '@/components/coffeechat/upload/CoffeechatForm';
 import { coffeChatchema } from '@/components/coffeechat/upload/CoffeechatForm/schema';
 import { CoffeechatFormContent } from '@/components/coffeechat/upload/CoffeechatForm/types';
 import UploadButton from '@/components/coffeechat/upload/CoffeechatForm/UploadButton';
 import ProgressBox from '@/components/coffeechat/upload/ProgressBox';
+import Responsive from '@/components/common/Responsive';
 
 interface CoffeechatUploadPageProps {
   uploadType: '오픈' | '수정';
@@ -21,13 +23,16 @@ export default function CoffeechatUploadPage({ uploadType, form, onSubmit }: Cof
   return (
     <FormProvider {...methods}>
       <form onSubmit={handleSubmit(onSubmit)}>
-        {/* <Responsive only='desktop'> */}
-        <DesktopCoffeechatUploadLayout
-          main={<CoffeechatForm />}
-          aside={<ProgressBox uploadType={uploadType} myInfoInprogress={false} coffeechatInfoInprogress={false} />}
-          submitButton={<UploadButton />}
-        />
-        {/* </Responsive> */}
+        <Responsive only='desktop'>
+          <DesktopCoffeechatUploadLayout
+            main={<CoffeechatForm />}
+            aside={<ProgressBox uploadType={uploadType} myInfoInprogress={false} coffeechatInfoInprogress={false} />}
+            submitButton={<UploadButton />}
+          />
+        </Responsive>
+        <Responsive only='mobile'>
+          <MobileCoffeechatUploadLayout main={<CoffeechatForm />} submitButton={<UploadButton />} />
+        </Responsive>
       </form>
     </FormProvider>
   );

--- a/src/components/coffeechat/page/CoffeechatUploadPage.tsx
+++ b/src/components/coffeechat/page/CoffeechatUploadPage.tsx
@@ -1,22 +1,33 @@
-import CoffeechatForm from '@/components/coffeechat/upload/CoffeechatForm';
-import { coffeChatchema } from '@/components/coffeechat/upload/CoffeechatForm/schema';
-import { CoffeechatFormContent } from '@/components/coffeechat/upload/CoffeechatForm/types';
 import { yupResolver } from '@hookform/resolvers/yup';
 import { FormProvider, useForm } from 'react-hook-form';
 
+import DesktopCoffeechatUploadLayout from '@/components/coffeechat/page/layout/DesktopCoffeechatUploadLayout';
+import CoffeechatForm from '@/components/coffeechat/upload/CoffeechatForm';
+import { coffeChatchema } from '@/components/coffeechat/upload/CoffeechatForm/schema';
+import { CoffeechatFormContent } from '@/components/coffeechat/upload/CoffeechatForm/types';
+import UploadButton from '@/components/coffeechat/upload/CoffeechatForm/UploadButton';
+import ProgressBox from '@/components/coffeechat/upload/ProgressBox';
+
 interface CoffeechatUploadPageProps {
+  uploadType: '오픈' | '수정';
   form: CoffeechatFormContent;
   onSubmit: () => void;
 }
 
-export default function CoffeechatUploadPage({ form, onSubmit }: CoffeechatUploadPageProps) {
+export default function CoffeechatUploadPage({ uploadType, form, onSubmit }: CoffeechatUploadPageProps) {
   const methods = useForm<CoffeechatFormContent>({ resolver: yupResolver(coffeChatchema), defaultValues: form });
   const { handleSubmit } = methods;
 
   return (
     <FormProvider {...methods}>
       <form onSubmit={handleSubmit(onSubmit)}>
-        <CoffeechatForm />
+        {/* <Responsive only='desktop'> */}
+        <DesktopCoffeechatUploadLayout
+          main={<CoffeechatForm />}
+          aside={<ProgressBox uploadType={uploadType} myInfoInprogress={false} coffeechatInfoInprogress={false} />}
+          submitButton={<UploadButton />}
+        />
+        {/* </Responsive> */}
       </form>
     </FormProvider>
   );

--- a/src/components/coffeechat/page/layout/DesktopCoffeechatUploadLayout.tsx
+++ b/src/components/coffeechat/page/layout/DesktopCoffeechatUploadLayout.tsx
@@ -1,0 +1,49 @@
+import styled from '@emotion/styled';
+import { ReactNode } from 'react';
+
+interface DesktopCoffeechatUploadLayoutProps {
+  main: ReactNode;
+  aside: ReactNode;
+  submitButton: ReactNode;
+}
+
+export default function DesktopCoffeechatUploadLayout({
+  main,
+  aside,
+  submitButton,
+}: DesktopCoffeechatUploadLayoutProps) {
+  return (
+    <Layout>
+      <Main>
+        <Body>{main}</Body>
+        <Footer>{submitButton}</Footer>
+      </Main>
+      <Aside>{aside}</Aside>
+    </Layout>
+  );
+}
+
+const Footer = styled.footer`
+  margin: 62px 0 50px;
+`;
+
+const Layout = styled.div`
+  display: flex;
+  gap: 30px;
+  justify-content: center;
+  margin: 0 30px;
+`;
+
+const Body = styled.section`
+  display: flex;
+  flex-direction: column;
+`;
+
+const Main = styled.main`
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  margin: 0 40px;
+`;
+
+const Aside = styled.aside``;

--- a/src/components/coffeechat/page/layout/MobileCoffeechatUploadLayout.tsx
+++ b/src/components/coffeechat/page/layout/MobileCoffeechatUploadLayout.tsx
@@ -1,0 +1,27 @@
+import styled from '@emotion/styled';
+import { ReactNode } from 'react';
+
+interface MobileCoffeechatUploadLayoutProps {
+  main: ReactNode;
+  submitButton: ReactNode;
+}
+
+export default function MobileCoffeechatUploadLayout({ main, submitButton }: MobileCoffeechatUploadLayoutProps) {
+  return (
+    <Layout>
+      <>{main}</>
+      <Footer>{submitButton}</Footer>
+    </Layout>
+  );
+}
+
+const Layout = styled.div`
+  display: flex;
+  flex-direction: column;
+  margin: 0 20px;
+`;
+
+const Footer = styled.footer`
+  margin: 40px 0 56px;
+  width: 100%;
+`;

--- a/src/components/coffeechat/upload/CoffeechatForm/UploadButton/index.tsx
+++ b/src/components/coffeechat/upload/CoffeechatForm/UploadButton/index.tsx
@@ -1,3 +1,4 @@
+import styled from '@emotion/styled';
 import { IconPlus } from '@sopt-makers/icons';
 import { Button } from '@sopt-makers/ui';
 
@@ -16,10 +17,14 @@ export default function UploadButton({ onClick }: UploadButtonProps) {
         </Button>
       </Responsive>
       <Responsive only='mobile'>
-        <Button size='lg' LeftIcon={IconPlus} type='submit'>
+        <MobileButton size='lg' LeftIcon={IconPlus} type='submit'>
           커피챗 오픈하기
-        </Button>
+        </MobileButton>
       </Responsive>
     </div>
   );
 }
+
+const MobileButton = styled(Button)`
+  width: 100%;
+`;

--- a/src/components/coffeechat/upload/ProgressBox/index.tsx
+++ b/src/components/coffeechat/upload/ProgressBox/index.tsx
@@ -30,16 +30,17 @@ export default function ProgressBox({ uploadType, myInfoInprogress, coffeechatIn
   );
 }
 
-const Box = styled.aside`
+const Box = styled.div`
   display: flex;
-  position: fixed;
+  position: sticky;
+  top: 80px;
   flex-direction: column;
   gap: 36px;
   align-items: flex-start;
   border: 1px solid ${colors.gray800};
   border-radius: 15px;
   padding: 50px 40px 60px;
-  width: 100%;
+  width: 290px;
   color: ${colors.gray10};
 `;
 

--- a/src/components/common/form/TextFieldLineBreak/index.tsx
+++ b/src/components/common/form/TextFieldLineBreak/index.tsx
@@ -49,6 +49,8 @@ const TextAreaWrapper = styled.div`
 const Placeholder = styled.div`
   position: absolute;
   top: 8px;
+  right: 16px;
+  bottom: 8px;
   left: 16px;
   white-space: pre-wrap;
   color: ${colors.gray300};

--- a/src/pages/coffeechat/upload.tsx
+++ b/src/pages/coffeechat/upload.tsx
@@ -2,7 +2,7 @@ import AuthRequired from '@/components/auth/AuthRequired';
 import CoffeechatUploadPage from '@/components/coffeechat/page/CoffeechatUploadPage';
 import { setLayout } from '@/utils/layout';
 
-export default function CoffeechatUpload() {
+const CoffeechatUpload = () => {
   const defaultForm = {
     memberInfo: {
       career: '주니어',
@@ -23,6 +23,8 @@ export default function CoffeechatUpload() {
       <CoffeechatUploadPage uploadType='오픈' form={defaultForm} onSubmit={() => console.log('클릭')} />
     </AuthRequired>
   );
-}
+};
 
 setLayout(CoffeechatUpload, 'header');
+
+export default CoffeechatUpload;

--- a/src/pages/coffeechat/upload.tsx
+++ b/src/pages/coffeechat/upload.tsx
@@ -1,0 +1,28 @@
+import AuthRequired from '@/components/auth/AuthRequired';
+import CoffeechatUploadPage from '@/components/coffeechat/page/CoffeechatUploadPage';
+import { setLayout } from '@/utils/layout';
+
+export default function CoffeechatUpload() {
+  const defaultForm = {
+    memberInfo: {
+      career: '주니어',
+      introduction: '안녕하세요! 저는 프론트엔드 개발자로 다양한 프로젝트 경험을 쌓고 있습니다.',
+    },
+    coffeeChatInfo: {
+      sections: ['프론트엔드', '디자인'], // 다중 선택 가능 (전체, 기획, 디자인, 웹, 서버, 안드로이드, iOS)
+      bio: '프론트엔드 커리어 상담',
+      topicTypes: ['커리어', '포트폴리오'], // 창업, 네트워킹, 프로젝트, 커리어 등 다중 선택 가능
+      topic: '프론트엔드 개발자로서의 커리어에 대해 상담하고 싶습니다.\n포트폴리오 제작과 인터뷰 팁도 나누고자 합니다.',
+      meetingType: '온라인', // 무관, 온라인, 오프라인 중 하나 선택
+      guideline: '시간 약속을 꼭 지켜주세요.\n질문은 미리 준비해 오시면 더욱 좋습니다.',
+    },
+  };
+
+  return (
+    <AuthRequired>
+      <CoffeechatUploadPage uploadType='오픈' form={defaultForm} onSubmit={() => console.log('클릭')} />
+    </AuthRequired>
+  );
+}
+
+setLayout(CoffeechatUpload, 'header');


### PR DESCRIPTION
### 🤫 쉿, 나한테만 말해줘요. 이슈넘버
- close #

### 🧐 어떤 것을 변경했어요~?
<!-- 실제로 변경한 사항을 설명해주세요.-->
- 업로드 페이지의 레이아웃을 구현했어요. 

### 🤔 그렇다면, 어떻게 구현했어요~?
<!-- 실제로 구현한 로직에 대해 설명해주세요.-->
- layout 폴더 안에 컴포넌트를 구현했고, main, aside, submitButton 각 컴포넌트를 children으로 받아서 구현했어요.

### ❤️‍🔥 당신이 생각하는 PR포인트, 내겐 매력포인트.
<!-- 해당 PR에서 논의가 필요한 사항을 적어주세요. -->
- 이제 업로드 쪽 로직 구현할 예정입니다! 로직 구현하면서 임시로 넣어둔 defaultForm은 지울게요!

### 📸 스크린샷, 없으면 이것 참,, 섭섭한데요?

<img width="512" alt="스크린샷 2024-10-21 오후 10 49 39" src="https://github.com/user-attachments/assets/28539b85-412f-471b-be93-061e6df6586d">


<img width="887" alt="스크린샷 2024-10-21 오후 10 49 15" src="https://github.com/user-attachments/assets/4bb89da0-dda1-4152-bcb3-7464892f7ea0">


