### PR TITLE
feat: 멤버 탭 커피챗 관련 수정 + mds 적용

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "@sopt-makers/colors": "^3.0.0",
     "@sopt-makers/fonts": "^1.0.0",
     "@sopt-makers/icons": "^1.0.5",
-    "@sopt-makers/ui": "^2.0.5",
+    "@sopt-makers/ui": "2.4.4",
     "@tanstack/react-query": "^5.4.3",
     "@toss/emotion-utils": "^1.1.10",
     "@toss/error-boundary": "^1.4.6",

--- a/src/components/members/common/select/OrderBySelect.tsx
+++ b/src/components/members/common/select/OrderBySelect.tsx
@@ -22,11 +22,12 @@ interface OrderBySelectProps {
   onChange: (value: string) => void;
   options: { value: string; label: string }[];
   className?: string;
+  trigger?: ReactNode;
 }
 
-const OrderBySelect: FC<OrderBySelectProps> = ({ className, value, options, onChange }) => {
+const OrderBySelect: FC<OrderBySelectProps> = ({ className, value, options, onChange, trigger }) => {
   return (
-    <SelectComp className={className} value={value} onChange={onChange}>
+    <SelectComp className={className} value={value} onChange={onChange} trigger={trigger}>
       {options.map((option) => (
         <SelectItem key={option.value} value={option.value}>
           {option.label}
@@ -41,9 +42,10 @@ export default OrderBySelect;
 interface SelectCompProps extends Omit<Select.SelectProps, 'onValueChange'> {
   className?: string;
   onChange?: Select.SelectProps['onValueChange'];
+  trigger?: ReactNode;
 }
 
-const SelectComp: FC<PropsWithChildren<SelectCompProps>> = ({ onChange, children, ...props }) => {
+const SelectComp: FC<PropsWithChildren<SelectCompProps>> = ({ onChange, children, trigger, ...props }) => {
   const [open, onOpenChange] = useState<boolean>(false);
   const [label, onChangeLabel] = useState<ReactNode>();
 
@@ -56,12 +58,7 @@ const SelectComp: FC<PropsWithChildren<SelectCompProps>> = ({ onChange, children
       }}
     >
       <Select.Root onValueChange={onChange} {...props} open={open} onOpenChange={onOpenChange}>
-        <StyledTrigger>
-          <IconArrowUpDown />
-          <Text typography='SUIT_18_M' color={colors.gray400}>
-            {label}
-          </Text>
-        </StyledTrigger>
+        <StyledTrigger>{trigger}</StyledTrigger>
         <SelectPortal>
           <>
             <Overlay open={open} />

--- a/src/components/members/common/select/OrderBySelect.tsx
+++ b/src/components/members/common/select/OrderBySelect.tsx
@@ -84,7 +84,7 @@ const StyledContent = styled(Select.Content)`
   border-radius: 12px;
   background: ${colors.gray700};
   padding: 7px;
-  width: var(--radix-select-trigger-width);
+  width: 100%;
   max-height: 262px;
   overflow: scroll;
   scrollbar-width: none;

--- a/src/components/members/common/select/OrderBySelect.tsx
+++ b/src/components/members/common/select/OrderBySelect.tsx
@@ -76,7 +76,6 @@ const SelectComp: FC<PropsWithChildren<SelectCompProps>> = ({ onChange, children
 const StyledTrigger = styled(Select.Trigger)`
   display: flex;
   align-items: center;
-  width: 136px;
 
   :focus {
     outline: none;

--- a/src/components/members/main/MemberCard/CoffeeChatButton.tsx
+++ b/src/components/members/main/MemberCard/CoffeeChatButton.tsx
@@ -2,18 +2,19 @@ import styled from '@emotion/styled';
 import * as Tooltip from '@radix-ui/react-tooltip';
 import { colors } from '@sopt-makers/colors';
 import { fonts } from '@sopt-makers/fonts';
-import { IconSend } from '@sopt-makers/icons';
+import { Tag } from '@sopt-makers/ui';
+import { Flex } from '@toss/emotion-utils';
 import { FC, MouseEvent } from 'react';
 
 import useEventLogger from '@/components/eventLogger/hooks/useEventLogger';
+import IconCoffee from '@/public/icons/icon-coffee.svg';
 
-interface MessageButtonProps {
+interface CoffeeChatButtonProps {
   className?: string;
-  name: string;
   onClick?: (e: MouseEvent) => void;
 }
 
-const MessageButton: FC<MessageButtonProps> = ({ className, name, onClick }) => {
+const CoffeeChatButton: FC<CoffeeChatButtonProps> = ({ className, onClick }) => {
   const { logClickEvent } = useEventLogger();
 
   return (
@@ -24,15 +25,20 @@ const MessageButton: FC<MessageButtonProps> = ({ className, name, onClick }) => 
             className={className}
             onClick={(e) => {
               onClick && onClick(e);
-              logClickEvent('memberBadge');
+              logClickEvent('coffeechatBadge');
             }}
           >
-            <IconSend />
+            <IconCoffee />
           </Button>
         </Tooltip.Trigger>
         <Tooltip.Portal>
           <TooltipContent sideOffset={5}>
-            {`${name}님이 궁금하시다면\n쪽지를 보내보세요!`}
+            <Flex style={{ gap: 6 }} align='center'>
+              <Tag size='sm' shape='rect' variant='primary' type='solid'>
+                NEW
+              </Tag>
+              커피챗 기능이 오픈됐어요!
+            </Flex>
             <TooltipArrow />
           </TooltipContent>
         </Tooltip.Portal>
@@ -41,7 +47,7 @@ const MessageButton: FC<MessageButtonProps> = ({ className, name, onClick }) => 
   );
 };
 
-export default MessageButton;
+export default CoffeeChatButton;
 
 const Button = styled.button`
   display: flex;
@@ -49,22 +55,22 @@ const Button = styled.button`
   justify-content: center;
   transition: background-color 0.2s;
   border-radius: 50%;
-  background-color: ${colors.gray600};
+  background-color: ${colors.blue400};
   padding: 5px;
   width: 32px;
   height: 32px;
 
   &:hover {
-    background-color: ${colors.gray400};
+    background-color: ${colors.blue200};
   }
 `;
 
 const TooltipContent = styled(Tooltip.Content)`
   ${fonts.BODY_14_M};
 
-  border-radius: 14px;
+  border-radius: 12px;
   background-color: ${colors.gray600};
-  padding: 10px 20px;
+  padding: 10px 12px;
   animation-duration: 400ms;
   animation-timing-function: cubic-bezier(0.16, 1, 0.3, 1);
   text-align: center;

--- a/src/components/members/main/MemberCard/MessageButton.tsx
+++ b/src/components/members/main/MemberCard/MessageButton.tsx
@@ -27,7 +27,7 @@ const MessageButton: FC<MessageButtonProps> = ({ className, name, onClick }) => 
               logClickEvent('memberBadge');
             }}
           >
-            <IconSend />
+            <StyledIconSend />
           </Button>
         </Tooltip.Trigger>
         <Tooltip.Portal>
@@ -112,4 +112,9 @@ const TooltipArrow = styled(Tooltip.Arrow)`
   fill: ${colors.gray600};
   width: 11px;
   height: 11px;
+`;
+
+const StyledIconSend = styled(IconSend)`
+  width: 20px;
+  height: 20px;
 `;

--- a/src/components/members/main/MemberCard/index.tsx
+++ b/src/components/members/main/MemberCard/index.tsx
@@ -5,13 +5,13 @@ import { m } from 'framer-motion';
 import { FC, SyntheticEvent } from 'react';
 
 import ResizedImage from '@/components/common/ResizedImage';
+import Responsive from '@/components/common/Responsive';
 import Text from '@/components/common/Text';
 import { useVisibleBadges } from '@/components/members/main/hooks/useVisibleBadges';
 import CoffeeChatButton from '@/components/members/main/MemberCard/CoffeeChatButton';
 import MessageButton from '@/components/members/main/MemberCard/MessageButton';
-import { MOBILE_MEDIA_QUERY } from '@/styles/mediaQuery';
-import Responsive from '@/components/common/Responsive';
 import IconCoffee from '@/public/icons/icon-coffee.svg';
+import { MOBILE_MEDIA_QUERY } from '@/styles/mediaQuery';
 
 interface MemberCardProps {
   name: string;

--- a/src/components/members/main/MemberCard/index.tsx
+++ b/src/components/members/main/MemberCard/index.tsx
@@ -10,6 +10,8 @@ import { useVisibleBadges } from '@/components/members/main/hooks/useVisibleBadg
 import CoffeeChatButton from '@/components/members/main/MemberCard/CoffeeChatButton';
 import MessageButton from '@/components/members/main/MemberCard/MessageButton';
 import { MOBILE_MEDIA_QUERY } from '@/styles/mediaQuery';
+import Responsive from '@/components/common/Responsive';
+import IconCoffee from '@/public/icons/icon-coffee.svg';
 
 interface MemberCardProps {
   name: string;
@@ -66,7 +68,13 @@ const MemberCard: FC<MemberCardProps> = ({
           </StyledAspectRatio>
         </StyledImageArea>
       </ProfileImage>
-
+      <MobileCoffeeChatBadge only='mobile'>
+        {isCoffeeChatActivate && (
+          <IconCoffeeWrapper>
+            <IconCoffee />
+          </IconCoffeeWrapper>
+        )}
+      </MobileCoffeeChatBadge>
       <ContentArea>
         <TitleBox>
           <Name typography='SUIT_18_SB'>{name}</Name>
@@ -121,6 +129,7 @@ const MotionMemberCard = styled(m.div)`
   padding: 24px;
 
   @media ${MOBILE_MEDIA_QUERY} {
+    position: relative;
     grid:
       [row1-start] 'image content' 1fr [row1-end]
       / 80px 1fr;
@@ -274,4 +283,25 @@ const SideButtons = styled.aside`
   @media ${MOBILE_MEDIA_QUERY} {
     display: none;
   }
+`;
+
+const IconCoffeeWrapper = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 80px;
+  background-color: ${colors.success};
+  padding-left: 1px;
+  width: 24px;
+  height: 24px;
+
+  & > svg {
+    width: 15.7px;
+    height: 15.2px;
+  }
+`;
+
+const MobileCoffeeChatBadge = styled(Responsive)`
+  position: absolute;
+  top: 22px;
 `;

--- a/src/components/members/main/MemberCard/index.tsx
+++ b/src/components/members/main/MemberCard/index.tsx
@@ -32,7 +32,7 @@ const imageVariants = {
   },
 };
 
-const MAX_BADGE_WIDTH = 242;
+const ELLIPSIS_WIDTH = 26;
 const BADGE_GAP = 4;
 
 const MemberCard: FC<MemberCardProps> = ({
@@ -45,7 +45,11 @@ const MemberCard: FC<MemberCardProps> = ({
   isCoffeeChatActivate,
   onMessage,
 }) => {
-  const { visibleBadges, isBadgeOverflow, badgeRefs } = useVisibleBadges(badges, MAX_BADGE_WIDTH, BADGE_GAP);
+  const { visibleBadges, isBadgeOverflow, badgeRefs, badgeWrapperRef } = useVisibleBadges(
+    badges,
+    ELLIPSIS_WIDTH,
+    BADGE_GAP,
+  );
 
   return (
     <MotionMemberCard whileHover='hover'>
@@ -68,7 +72,7 @@ const MemberCard: FC<MemberCardProps> = ({
           <Name typography='SUIT_18_SB'>{name}</Name>
           <Belongs typography='SUIT_12_SB'>{belongs}</Belongs>
         </TitleBox>
-        <BadgesBox>
+        <BadgesBox ref={badgeWrapperRef}>
           <Badges>
             {visibleBadges.map((badge, idx) => (
               <Badge ref={(el: HTMLDivElement) => (badgeRefs.current[idx] = el)} isActive={badge.isActive} key={idx}>

--- a/src/components/members/main/MemberCard/index.tsx
+++ b/src/components/members/main/MemberCard/index.tsx
@@ -58,7 +58,7 @@ const MemberCard: FC<MemberCardProps> = ({
           <StyledAspectRatio ratio={1 / 1}>
             <ImageHolder variants={imageVariants}>
               {imageUrl ? (
-                <Image className='image' src={imageUrl} width={235} alt='member_image' />
+                <Image className='image' src={imageUrl} width={196} alt='member_image' />
               ) : (
                 <DefaultImage className='image' src='/icons/icon-member-default.svg' alt='default_member_image' />
               )}
@@ -77,19 +77,19 @@ const MemberCard: FC<MemberCardProps> = ({
             {visibleBadges.map((badge, idx) => (
               <Badge ref={(el: HTMLDivElement) => (badgeRefs.current[idx] = el)} isActive={badge.isActive} key={idx}>
                 {badge.isActive && <BadgeActiveDot />}
-                <Text typography='SUIT_12_SB' color={badge.isActive ? colors.secondary : colors.gray200}>
+                <Text typography='SUIT_11_SB' color={badge.isActive ? colors.secondary : colors.gray200}>
                   {badge.content}
                 </Text>
               </Badge>
             ))}
             {isBadgeOverflow && (
               <Badge isActive={false}>
-                <Text typography='SUIT_12_SB'>...</Text>
+                <Text typography='SUIT_11_SB'>...</Text>
               </Badge>
             )}
           </Badges>
         </BadgesBox>
-        <Intro typography='SUIT_14_SB' color={colors.gray200}>
+        <Intro typography='SUIT_13_M' color={colors.gray200}>
           {intro}
         </Intro>
       </ContentArea>
@@ -118,7 +118,7 @@ const MotionMemberCard = styled(m.div)`
   transition: box-shadow 0.3s;
   border-radius: 16px;
   background-color: ${colors.gray900};
-  padding: 29.5px 17.5px;
+  padding: 24px;
 
   @media ${MOBILE_MEDIA_QUERY} {
     grid:
@@ -150,7 +150,7 @@ const StyledImageArea = styled.div`
   border-radius: 50%;
   background-color: ${colors.gray700};
   width: 100%;
-  max-width: 180px;
+  max-width: 196px;
   overflow: hidden;
 `;
 
@@ -247,9 +247,9 @@ const BadgeActiveDot = styled.span`
 
 const Intro = styled(Text)`
   display: ${'-webkit-box'};
-  margin-top: 17px;
+  margin-top: 16px;
   width: 100%;
-  min-height: 32px;
+  min-height: 60px;
   overflow: hidden;
   -webkit-line-clamp: 2;
   -webkit-box-orient: vertical;

--- a/src/components/members/main/MemberCard/index.tsx
+++ b/src/components/members/main/MemberCard/index.tsx
@@ -5,9 +5,9 @@ import { m } from 'framer-motion';
 import { FC, SyntheticEvent } from 'react';
 
 import ResizedImage from '@/components/common/ResizedImage';
+import Text from '@/components/common/Text';
 import MessageButton from '@/components/members/main/MemberCard/MessageButton';
 import { MOBILE_MEDIA_QUERY } from '@/styles/mediaQuery';
-import { textStyles } from '@/styles/typography';
 
 interface MemberCardProps {
   name: string;
@@ -56,13 +56,13 @@ const MemberCard: FC<MemberCardProps> = ({
 
       <ContentArea>
         <TitleBox>
-          <Name>{name}</Name>
-          <Belongs>{belongs}</Belongs>
+          <Name typography='SUIT_18_SB'>{name}</Name>
+          <Belongs typography='SUIT_11_M'>{belongs}</Belongs>
         </TitleBox>
         <BadgesBox>
           <Badges>
             {badges.map((badge, idx) => (
-              <Badge key={idx}>
+              <Badge typography='SUIT_11_M' key={idx}>
                 {badge.isActive && <BadgeActiveDot />}
                 {badge.content}
               </Badge>
@@ -70,7 +70,7 @@ const MemberCard: FC<MemberCardProps> = ({
           </Badges>
           <DimShadow />
         </BadgesBox>
-        <Intro>{intro}</Intro>
+        <Intro typography='SUIT_12_M'>{intro}</Intro>
       </ContentArea>
       {email && email.length > 0 ? (
         <StyledTooltip name={name} isCoffeeChatActivate={isCoffeeChatActivate} onClick={onMessage} />
@@ -97,7 +97,7 @@ const MotionMemberCard = styled(m.div)`
   align-items: center;
   transition: box-shadow 0.3s;
   border-radius: 16px;
-  background-color: ${colors.gray800};
+  background-color: ${colors.gray900};
   padding: 29.5px 17.5px;
 
   @media ${MOBILE_MEDIA_QUERY} {
@@ -158,22 +158,18 @@ const TitleBox = styled(m.div)`
   align-items: center;
 `;
 
-const Name = styled.h3`
+const Name = styled(Text)`
   flex-shrink: 0;
   color: ${colors.gray30};
-
-  ${textStyles.SUIT_18_SB}
 `;
 
-const Belongs = styled.span`
+const Belongs = styled(Text)`
   flex-grow: 1;
   margin-left: 5px;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
   color: ${colors.gray300};
-
-  ${textStyles.SUIT_12_SB}
 `;
 
 const BadgesBox = styled.div`
@@ -200,7 +196,7 @@ const DimShadow = styled.span`
   }
 `;
 
-const Badge = styled.div`
+const Badge = styled(Text)`
   display: flex;
   flex-direction: row;
   flex-shrink: 0;
@@ -211,14 +207,10 @@ const Badge = styled.div`
   padding: 6px 8px;
   color: ${colors.gray100};
 
-  ${textStyles.SUIT_11_M};
-
   @media ${MOBILE_MEDIA_QUERY} {
     background-color: ${colors.gray800};
     padding: 4px 6px;
     color: ${colors.gray100};
-
-    ${textStyles.SUIT_11_M};
   }
 `;
 
@@ -229,7 +221,7 @@ const BadgeActiveDot = styled.span`
   height: 6px;
 `;
 
-const Intro = styled.p`
+const Intro = styled(Text)`
   display: ${'-webkit-box'};
   margin-top: 16px;
   width: 100%;
@@ -238,8 +230,6 @@ const Intro = styled.p`
   color: ${colors.gray300};
   -webkit-line-clamp: 2;
   -webkit-box-orient: vertical;
-
-  ${textStyles.SUIT_12_M};
 
   @media ${MOBILE_MEDIA_QUERY} {
     margin-top: 8px;

--- a/src/components/members/main/MemberCard/index.tsx
+++ b/src/components/members/main/MemberCard/index.tsx
@@ -17,7 +17,7 @@ interface MemberCardProps {
     content: string;
     isActive: boolean;
   }[];
-  email?:string,
+  email?: string;
   imageUrl?: string;
   isCoffeeChatActivate: boolean;
 
@@ -42,8 +42,8 @@ const MemberCard: FC<MemberCardProps> = ({
 }) => {
   return (
     <MotionMemberCard whileHover='hover'>
-      <StyledAspectRatio ratio={1 / 1}>
-        <StyledImageArea>
+      <StyledImageArea>
+        <StyledAspectRatio ratio={1 / 1}>
           <ImageHolder variants={imageVariants}>
             {imageUrl ? (
               <Image className='image' src={imageUrl} width={235} alt='member_image' />
@@ -51,8 +51,9 @@ const MemberCard: FC<MemberCardProps> = ({
               <DefaultImage className='image' src='/icons/icon-member-default.svg' alt='default_member_image' />
             )}
           </ImageHolder>
-        </StyledImageArea>
-      </StyledAspectRatio>
+        </StyledAspectRatio>
+      </StyledImageArea>
+
       <ContentArea>
         <TitleBox>
           <Name>{name}</Name>
@@ -71,9 +72,11 @@ const MemberCard: FC<MemberCardProps> = ({
         </BadgesBox>
         <Intro>{intro}</Intro>
       </ContentArea>
-      {email && email.length>0 ?( 
-      <StyledTooltip name={name} isCoffeeChatActivate={isCoffeeChatActivate} onClick={onMessage} />)
-      :<></>}
+      {email && email.length > 0 ? (
+        <StyledTooltip name={name} isCoffeeChatActivate={isCoffeeChatActivate} onClick={onMessage} />
+      ) : (
+        <></>
+      )}
     </MotionMemberCard>
   );
 };
@@ -82,7 +85,9 @@ export default MemberCard;
 
 const MotionMemberCard = styled(m.div)`
   display: grid;
+  display: flex;
   position: relative;
+  flex-direction: column;
   grid:
     [row1-start] 'image' auto [row1-end]
     [row2-start] 'content' auto [row2-end]
@@ -93,7 +98,7 @@ const MotionMemberCard = styled(m.div)`
   transition: box-shadow 0.3s;
   border-radius: 16px;
   background-color: ${colors.gray800};
-  padding: 24px;
+  padding: 29.5px 17.5px;
 
   @media ${MOBILE_MEDIA_QUERY} {
     grid:
@@ -117,8 +122,7 @@ const StyledImageArea = styled.div`
   transform: translateZ(0);
   border-radius: 50%;
   background-color: ${colors.gray700};
-  width: 100%;
-  height: 100%;
+  width: 180px;
   overflow: hidden;
 `;
 
@@ -132,8 +136,7 @@ const ImageHolder = styled(m.div)`
 
 const ContentArea = styled.div`
   grid-area: content;
-  min-width: 0;
-  min-height: 120px;
+  width: 100%;
 
   @media ${MOBILE_MEDIA_QUERY} {
     min-height: unset;
@@ -159,7 +162,7 @@ const Name = styled.h3`
   flex-shrink: 0;
   color: ${colors.gray30};
 
-  ${textStyles.SUIT_18_B}
+  ${textStyles.SUIT_18_SB}
 `;
 
 const Belongs = styled.span`
@@ -170,7 +173,7 @@ const Belongs = styled.span`
   white-space: nowrap;
   color: ${colors.gray300};
 
-  ${textStyles.SUIT_12_M}
+  ${textStyles.SUIT_12_SB}
 `;
 
 const BadgesBox = styled.div`
@@ -230,6 +233,7 @@ const Intro = styled.p`
   display: ${'-webkit-box'};
   margin-top: 16px;
   width: 100%;
+  min-height: 32px;
   overflow: hidden;
   color: ${colors.gray300};
   -webkit-line-clamp: 2;

--- a/src/components/members/main/MemberCard/index.tsx
+++ b/src/components/members/main/MemberCard/index.tsx
@@ -6,6 +6,7 @@ import { FC, SyntheticEvent } from 'react';
 
 import ResizedImage from '@/components/common/ResizedImage';
 import Text from '@/components/common/Text';
+import CoffeeChatButton from '@/components/members/main/MemberCard/CoffeeChatButton';
 import MessageButton from '@/components/members/main/MemberCard/MessageButton';
 import { MOBILE_MEDIA_QUERY } from '@/styles/mediaQuery';
 
@@ -72,11 +73,11 @@ const MemberCard: FC<MemberCardProps> = ({
         </BadgesBox>
         <Intro typography='SUIT_12_M'>{intro}</Intro>
       </ContentArea>
-      {email && email.length > 0 ? (
-        <StyledTooltip name={name} isCoffeeChatActivate={isCoffeeChatActivate} onClick={onMessage} />
-      ) : (
-        <></>
-      )}
+      <SideButtons>
+        {/* TODO: CoffeeChatButton에 커피챗 상세로 이동하는 onClick 넘겨주기 */}
+        {isCoffeeChatActivate && <CoffeeChatButton />}
+        {email && email.length > 0 && <MessageButton name={name} onClick={onMessage} />}
+      </SideButtons>
     </MotionMemberCard>
   );
 };
@@ -223,7 +224,7 @@ const BadgeActiveDot = styled.span`
 
 const Intro = styled(Text)`
   display: ${'-webkit-box'};
-  margin-top: 16px;
+  margin-top: 17px;
   width: 100%;
   min-height: 32px;
   overflow: hidden;
@@ -238,10 +239,13 @@ const Intro = styled(Text)`
   }
 `;
 
-const StyledTooltip = styled(MessageButton)`
+const SideButtons = styled.aside`
+  display: flex;
   position: absolute;
   top: 17px;
   right: 19px;
+  flex-direction: column;
+  gap: 10px;
 
   @media ${MOBILE_MEDIA_QUERY} {
     display: none;

--- a/src/components/members/main/MemberCard/index.tsx
+++ b/src/components/members/main/MemberCard/index.tsx
@@ -2,7 +2,7 @@ import styled from '@emotion/styled';
 import * as AspectRatio from '@radix-ui/react-aspect-ratio';
 import { colors } from '@sopt-makers/colors';
 import { m } from 'framer-motion';
-import { FC, SyntheticEvent, useLayoutEffect, useRef, useState } from 'react';
+import { FC, SyntheticEvent } from 'react';
 
 import ResizedImage from '@/components/common/ResizedImage';
 import Text from '@/components/common/Text';
@@ -78,9 +78,7 @@ const MemberCard: FC<MemberCardProps> = ({
             ))}
             {isBadgeOverflow && (
               <Badge isActive={false}>
-                <Text typography='SUIT_12_SB' color={colors.gray100}>
-                  ...
-                </Text>
+                <Text typography='SUIT_12_SB'>...</Text>
               </Badge>
             )}
           </Badges>
@@ -171,6 +169,7 @@ const DefaultImage = styled.img`
 const TitleBox = styled(m.div)`
   display: flex;
   align-items: center;
+  height: 24px;
 `;
 
 const Name = styled(Text)`

--- a/src/components/members/main/MemberCard/index.tsx
+++ b/src/components/members/main/MemberCard/index.tsx
@@ -49,22 +49,24 @@ const MemberCard: FC<MemberCardProps> = ({
 
   return (
     <MotionMemberCard whileHover='hover'>
-      <StyledImageArea>
-        <StyledAspectRatio ratio={1 / 1}>
-          <ImageHolder variants={imageVariants}>
-            {imageUrl ? (
-              <Image className='image' src={imageUrl} width={235} alt='member_image' />
-            ) : (
-              <DefaultImage className='image' src='/icons/icon-member-default.svg' alt='default_member_image' />
-            )}
-          </ImageHolder>
-        </StyledAspectRatio>
-      </StyledImageArea>
+      <ProfileImage>
+        <StyledImageArea>
+          <StyledAspectRatio ratio={1 / 1}>
+            <ImageHolder variants={imageVariants}>
+              {imageUrl ? (
+                <Image className='image' src={imageUrl} width={235} alt='member_image' />
+              ) : (
+                <DefaultImage className='image' src='/icons/icon-member-default.svg' alt='default_member_image' />
+              )}
+            </ImageHolder>
+          </StyledAspectRatio>
+        </StyledImageArea>
+      </ProfileImage>
 
       <ContentArea>
         <TitleBox>
           <Name typography='SUIT_18_SB'>{name}</Name>
-          <Belongs typography='SUIT_11_M'>{belongs}</Belongs>
+          <Belongs typography='SUIT_12_SB'>{belongs}</Belongs>
         </TitleBox>
         <BadgesBox>
           <Badges>
@@ -83,7 +85,9 @@ const MemberCard: FC<MemberCardProps> = ({
             )}
           </Badges>
         </BadgesBox>
-        <Intro typography='SUIT_12_M'>{intro}</Intro>
+        <Intro typography='SUIT_14_SB' color={colors.gray200}>
+          {intro}
+        </Intro>
       </ContentArea>
       <SideButtons>
         {/* TODO: CoffeeChatButton에 커피챗 상세로 이동하는 onClick 넘겨주기 */}
@@ -98,7 +102,6 @@ export default MemberCard;
 
 const MotionMemberCard = styled(m.div)`
   display: grid;
-  display: flex;
   position: relative;
   flex-direction: column;
   grid:
@@ -128,14 +131,22 @@ const MotionMemberCard = styled(m.div)`
 `;
 
 const StyledAspectRatio = styled(AspectRatio.Root)`
-  grid-area: image;
+  width: 100%;
+`;
+
+const ProfileImage = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
 `;
 
 const StyledImageArea = styled.div`
   transform: translateZ(0);
   border-radius: 50%;
   background-color: ${colors.gray700};
-  width: 180px;
+  width: 100%;
+  max-width: 180px;
   overflow: hidden;
 `;
 
@@ -144,6 +155,7 @@ const ImageHolder = styled(m.div)`
   align-items: center;
   justify-content: center;
   margin: 0 auto;
+  width: 100%;
   height: 100%;
 `;
 
@@ -157,9 +169,9 @@ const ContentArea = styled.div`
 `;
 
 const Image = styled(ResizedImage)`
-  object-fit: cover;
   width: 100%;
   height: 100%;
+  object-fit: cover;
 `;
 
 const DefaultImage = styled.img`
@@ -170,6 +182,10 @@ const TitleBox = styled(m.div)`
   display: flex;
   align-items: center;
   height: 24px;
+
+  @media ${MOBILE_MEDIA_QUERY} {
+    height: 28px;
+  }
 `;
 
 const Name = styled(Text)`
@@ -188,7 +204,7 @@ const Belongs = styled(Text)`
 
 const BadgesBox = styled.div`
   position: relative;
-  margin-top: 10px;
+  margin-top: 8px;
   overflow-x: hidden;
 `;
 
@@ -212,7 +228,6 @@ const Badge = styled.div<{ isActive: boolean }>`
   line-height: 0;
 
   @media ${MOBILE_MEDIA_QUERY} {
-    background-color: ${colors.gray800};
     padding: 4px 6px;
     color: ${colors.gray100};
   }
@@ -231,13 +246,14 @@ const Intro = styled(Text)`
   width: 100%;
   min-height: 32px;
   overflow: hidden;
-  color: ${colors.gray300};
   -webkit-line-clamp: 2;
   -webkit-box-orient: vertical;
 
   @media ${MOBILE_MEDIA_QUERY} {
     margin-top: 8px;
-    color: ${colors.gray600};
+    min-height: 20px;
+    font-size: 13px;
+    font-weight: 600;
     -webkit-line-clamp: 1;
   }
 `;

--- a/src/components/members/main/MemberCard/index.tsx
+++ b/src/components/members/main/MemberCard/index.tsx
@@ -162,6 +162,7 @@ const ImageHolder = styled(m.div)`
 const ContentArea = styled.div`
   grid-area: content;
   width: 100%;
+  overflow: hidden;
 
   @media ${MOBILE_MEDIA_QUERY} {
     min-height: unset;

--- a/src/components/members/main/MemberCard/index.tsx
+++ b/src/components/members/main/MemberCard/index.tsx
@@ -6,6 +6,7 @@ import { FC, SyntheticEvent, useLayoutEffect, useRef, useState } from 'react';
 
 import ResizedImage from '@/components/common/ResizedImage';
 import Text from '@/components/common/Text';
+import { useVisibleBadges } from '@/components/members/main/hooks/useVisibleBadges';
 import CoffeeChatButton from '@/components/members/main/MemberCard/CoffeeChatButton';
 import MessageButton from '@/components/members/main/MemberCard/MessageButton';
 import { MOBILE_MEDIA_QUERY } from '@/styles/mediaQuery';
@@ -44,33 +45,7 @@ const MemberCard: FC<MemberCardProps> = ({
   isCoffeeChatActivate,
   onMessage,
 }) => {
-  const badgesRef = useRef<(HTMLDivElement | null)[]>([]);
-  badgesRef.current = badges.map(() => null);
-  const [visibleBadges, setAvailableBadges] = useState<typeof badges>(badges);
-  const [isBadgeOverflow, setIsBadgeOverflow] = useState<boolean>(false);
-
-  useLayoutEffect(() => {
-    const calculateVisibleBadges = () => {
-      let totalWidth = 0;
-      const visible = [];
-      let overflow = false;
-
-      for (let i = 0; i < badges.length; i++) {
-        const badgeWidth = badgesRef.current[i]?.offsetWidth || 0;
-        if (totalWidth + badgeWidth > MAX_BADGE_WIDTH) {
-          overflow = true;
-          break;
-        }
-        visible.push(badges[i]);
-        totalWidth += badgeWidth + BADGE_GAP;
-      }
-
-      setAvailableBadges(visible);
-      setIsBadgeOverflow(overflow);
-    };
-
-    calculateVisibleBadges();
-  }, [badges]);
+  const { visibleBadges, isBadgeOverflow, badgeRefs } = useVisibleBadges(badges, MAX_BADGE_WIDTH, BADGE_GAP);
 
   return (
     <MotionMemberCard whileHover='hover'>
@@ -94,7 +69,7 @@ const MemberCard: FC<MemberCardProps> = ({
         <BadgesBox>
           <Badges>
             {visibleBadges.map((badge, idx) => (
-              <Badge ref={(el: HTMLDivElement) => (badgesRef.current[idx] = el)} isActive={badge.isActive} key={idx}>
+              <Badge ref={(el: HTMLDivElement) => (badgeRefs.current[idx] = el)} isActive={badge.isActive} key={idx}>
                 {badge.isActive && <BadgeActiveDot />}
                 <Text typography='SUIT_12_SB' color={badge.isActive ? colors.secondary : colors.gray200}>
                   {badge.content}

--- a/src/components/members/main/MemberList/filters/MemberListFilter.tsx
+++ b/src/components/members/main/MemberList/filters/MemberListFilter.tsx
@@ -11,6 +11,7 @@ interface MemberListFilterProps<T> {
   placeholder?: string;
   options: Option<T>[];
   onChange?: (value: string | number | boolean) => void;
+  onDefaultClick?: () => void;
 }
 export function MemberListFilter<T extends string>({
   className,
@@ -20,28 +21,25 @@ export function MemberListFilter<T extends string>({
   value,
   onChange,
   children,
+  onDefaultClick,
 }: PropsWithChildren<MemberListFilterProps<T>>) {
   return (
-    <StyledSelectRoot key={value?.value} className={className} type='text' onChange={onChange} defaultValue={value}>
+    <SelectV2.Root key={value?.value} className={className} type='text' onChange={onChange} defaultValue={value}>
       <SelectV2.Trigger>
         <StyledSelectTrigger placeholder={placeholder} />
       </SelectV2.Trigger>
       <SelectV2.Menu>
-        {defaultOption && <SelectV2.MenuItem option={defaultOption} />}
+        {defaultOption && <SelectV2.MenuItem onClick={onDefaultClick} option={defaultOption} />}
         {options.map((option) => (
           <SelectV2.MenuItem key={option.value} option={option} />
         ))}
         {children}
       </SelectV2.Menu>
-    </StyledSelectRoot>
+    </SelectV2.Root>
   );
 }
 
 export default MemberListFilter;
-
-const StyledSelectRoot = styled(SelectV2.Root)`
-  position: unset;
-`;
 
 const StyledSelectTrigger = styled(SelectV2.TriggerContent)`
   width: max-content;

--- a/src/components/members/main/MemberList/filters/MemberListFilter.tsx
+++ b/src/components/members/main/MemberList/filters/MemberListFilter.tsx
@@ -1,16 +1,8 @@
-import { css } from '@emotion/react';
 import styled from '@emotion/styled';
-import { colors } from '@sopt-makers/colors';
-import { PropsWithChildren, ReactNode } from 'react';
+import { SelectV2 } from '@sopt-makers/ui';
+import { PropsWithChildren } from 'react';
 
-import Select from '@/components/members/common/select/Select';
-import { MOBILE_MEDIA_QUERY } from '@/styles/mediaQuery';
-import { textStyles } from '@/styles/typography';
-
-interface Option<T> {
-  value: T;
-  label: ReactNode;
-}
+import { Option } from '@/components/members/main/MemberList/filters/constants';
 
 interface MemberListFilterProps<T> {
   className?: string;
@@ -22,7 +14,6 @@ interface MemberListFilterProps<T> {
 }
 export function MemberListFilter<T extends string>({
   className,
-  value,
   defaultOption,
   placeholder,
   options,
@@ -30,45 +21,23 @@ export function MemberListFilter<T extends string>({
   children,
 }: PropsWithChildren<MemberListFilterProps<T>>) {
   return (
-    <StyledSelect className={className} placeholder={placeholder} value={value} onChange={onChange} selected={!!value}>
-      {defaultOption && <StyledSelectItem value={defaultOption?.value}>{defaultOption?.label}</StyledSelectItem>}
-      {options.map((option) => (
-        <StyledSelectItem key={option.value} value={option.value}>
-          {option.label}
-        </StyledSelectItem>
-      ))}
-      {children}
-    </StyledSelect>
+    <SelectV2.Root className={className} type='text' onChange={onChange}>
+      <SelectV2.Trigger>
+        <StyledSelectTrigger placeholder={placeholder} />
+      </SelectV2.Trigger>
+      <SelectV2.Menu>
+        {defaultOption && <SelectV2.MenuItem option={defaultOption} />}
+        {options.map((option) => (
+          <SelectV2.MenuItem key={option.value} option={option} />
+        ))}
+        {children}
+      </SelectV2.Menu>
+    </SelectV2.Root>
   );
 }
 
 export default MemberListFilter;
 
-const StyledSelect = styled(Select)<{ selected: boolean }>`
-  ${({ selected }) =>
-    selected &&
-    css`
-      gap: 12px;
-      border-color: ${colors.gray400};
-      background-color: ${colors.gray800};
-      color: ${colors.white};
-    `};
-
-  transition: background-color 0.2s;
-  border-radius: 20px;
-  padding: 9px 26px 9px 22px;
-  min-width: 110px;
-
-  @media ${MOBILE_MEDIA_QUERY} {
-    border-radius: 14px;
-    padding: 18px;
-
-    &[data-placeholder] {
-      ${textStyles.SUIT_16_B};
-    }
-  }
-`;
-
-const StyledSelectItem = styled(Select.Item)`
-  color: ${colors.gray200};
+const StyledSelectTrigger = styled(SelectV2.TriggerContent)`
+  width: fit-content;
 `;

--- a/src/components/members/main/MemberList/filters/MemberListFilter.tsx
+++ b/src/components/members/main/MemberList/filters/MemberListFilter.tsx
@@ -6,22 +6,23 @@ import { Option } from '@/components/members/main/MemberList/filters/constants';
 
 interface MemberListFilterProps<T> {
   className?: string;
-  value?: string;
+  value?: Option<T>;
   defaultOption?: Option<T>;
   placeholder?: string;
   options: Option<T>[];
-  onChange?: (value: string) => void;
+  onChange?: (value: string | number | boolean) => void;
 }
 export function MemberListFilter<T extends string>({
   className,
   defaultOption,
   placeholder,
   options,
+  value,
   onChange,
   children,
 }: PropsWithChildren<MemberListFilterProps<T>>) {
   return (
-    <StyledSelectRoot className={className} type='text' onChange={onChange}>
+    <StyledSelectRoot key={value?.value} className={className} type='text' onChange={onChange} defaultValue={value}>
       <SelectV2.Trigger>
         <StyledSelectTrigger placeholder={placeholder} />
       </SelectV2.Trigger>

--- a/src/components/members/main/MemberList/filters/MemberListFilter.tsx
+++ b/src/components/members/main/MemberList/filters/MemberListFilter.tsx
@@ -21,7 +21,7 @@ export function MemberListFilter<T extends string>({
   children,
 }: PropsWithChildren<MemberListFilterProps<T>>) {
   return (
-    <SelectV2.Root className={className} type='text' onChange={onChange}>
+    <StyledSelectRoot className={className} type='text' onChange={onChange}>
       <SelectV2.Trigger>
         <StyledSelectTrigger placeholder={placeholder} />
       </SelectV2.Trigger>
@@ -32,12 +32,17 @@ export function MemberListFilter<T extends string>({
         ))}
         {children}
       </SelectV2.Menu>
-    </SelectV2.Root>
+    </StyledSelectRoot>
   );
 }
 
 export default MemberListFilter;
 
+const StyledSelectRoot = styled(SelectV2.Root)`
+  position: unset;
+`;
+
 const StyledSelectTrigger = styled(SelectV2.TriggerContent)`
-  width: fit-content;
+  width: max-content;
+  min-width: fit-content;
 `;

--- a/src/components/members/main/MemberList/filters/MemberListFilterSheet.tsx
+++ b/src/components/members/main/MemberList/filters/MemberListFilterSheet.tsx
@@ -4,6 +4,7 @@ import { colors } from '@sopt-makers/colors';
 import { FC, PropsWithChildren, ReactNode, useMemo, useState } from 'react';
 import ReactModalSheet from 'react-modal-sheet';
 
+import Text from '@/components/common/Text';
 import IconCheck from '@/public/icons/icon-filter-check.svg';
 import { textStyles } from '@/styles/typography';
 

--- a/src/components/members/main/MemberList/filters/constants.ts
+++ b/src/components/members/main/MemberList/filters/constants.ts
@@ -1,6 +1,6 @@
 import { GENERATIONS } from '@/constants/generation';
 
-type Option<T = string> = {
+export type Option<T = string> = {
   value: T;
   label: string;
 };

--- a/src/components/members/main/MemberList/filters/constants.ts
+++ b/src/components/members/main/MemberList/filters/constants.ts
@@ -18,11 +18,13 @@ const PART_VALUE = {
   ANDROID: '5',
   iOS: '6',
 } as const;
+
+export const PART_DEFAULT_OPTION: Option = {
+  label: '전체',
+  value: '',
+};
+
 export const PART_OPTIONS: Option[] = [
-  {
-    label: '전체',
-    value: '',
-  },
   {
     label: '기획',
     value: PART_VALUE.PM,
@@ -60,7 +62,7 @@ export const GENERATION_OPTIONS = (() =>
     label: `${generation}기`,
   })))();
 
-export const TEAM_OPTIONS = [
+export const TEAM_OPTIONS: Option[] = [
   { value: '임원진', label: '임원진' },
   { value: '운영팀', label: '운영팀' },
   { value: '미디어팀', label: '미디어팀' },

--- a/src/components/members/main/MemberList/index.tsx
+++ b/src/components/members/main/MemberList/index.tsx
@@ -3,10 +3,9 @@ import styled from '@emotion/styled';
 import { colors } from '@sopt-makers/colors';
 import { IconChevronDown, IconSwitchVertical } from '@sopt-makers/icons';
 import { uniq } from 'lodash-es';
-import dynamic from 'next/dynamic';
 import Link from 'next/link';
 import { useRouter } from 'next/router';
-import React, { FC, ReactNode, useEffect, useMemo, useState } from 'react';
+import React, { ChangeEvent, FC, ReactNode, useEffect, useMemo, useState } from 'react';
 
 import { Profile } from '@/api/endpoint_LEGACY/members/type';
 import Responsive from '@/components/common/Responsive';
@@ -31,7 +30,6 @@ import {
 } from '@/components/members/main/MemberList/filters/constants';
 import MemberListFilter from '@/components/members/main/MemberList/filters/MemberListFilter';
 import MemberListFilterSheet from '@/components/members/main/MemberList/filters/MemberListFilterSheet';
-import MemberSearch from '@/components/members/main/MemberList/MemberSearch';
 import { LATEST_GENERATION } from '@/constants/generation';
 import { playgroundLink } from '@/constants/links';
 import useIntersectionObserver from '@/hooks/useIntersectionObserver';
@@ -40,6 +38,7 @@ import { useRunOnce } from '@/hooks/useRunOnce';
 import IconDiagonalArrow from '@/public/icons/icon-diagonal-arrow.svg';
 import { MOBILE_MEDIA_QUERY } from '@/styles/mediaQuery';
 import { textStyles } from '@/styles/typography';
+import { SearchField } from '@sopt-makers/ui';
 
 const PAGE_LIMIT = 30;
 
@@ -136,6 +135,11 @@ const MemberList: FC<MemberListProps> = ({ banner }) => {
     }
   }, [router.isReady, router.query, router]);
 
+  const handleSearchChange = (e: ChangeEvent<HTMLInputElement>) => setSearch(e.target.value);
+  const handleSearchReset = () => {
+    setSearch('');
+  };
+
   const createTypeSafeHandler =
     <T extends string>(handler: (value: T) => void) =>
     (value: string | number | boolean) => {
@@ -174,7 +178,7 @@ const MemberList: FC<MemberListProps> = ({ banner }) => {
     logClickEvent('filterOrderBy', { orderBy });
   });
 
-  const handleSearch = (searchQuery: string) => {
+  const handleSearchSubmit = (searchQuery: string) => {
     addQueryParamsToUrl({ search: searchQuery });
     logSubmitEvent('searchMember', { content: 'searchQuery' });
   };
@@ -196,8 +200,9 @@ const MemberList: FC<MemberListProps> = ({ banner }) => {
           <StyledMemberSearch
             placeholder='이름, 학교, 회사를 검색해보세요!'
             value={search || ''}
-            onChange={setSearch}
-            onSearch={handleSearch}
+            onChange={handleSearchChange}
+            onSubmit={() => handleSearchSubmit(search as string)}
+            onReset={handleSearchReset}
           />
           <StyledMobileFilterWrapper>
             <StyledMobileFilter
@@ -429,9 +434,10 @@ const MemberList: FC<MemberListProps> = ({ banner }) => {
                 </StyledFilterWrapper>
                 <StyledMemberSearch
                   placeholder='이름, 학교, 회사를 검색해보세요!'
-                  value={search ?? ''}
-                  onChange={setSearch}
-                  onSearch={handleSearch}
+                  value={search || ''}
+                  onChange={handleSearchChange}
+                  onSubmit={() => handleSearchSubmit(search as string)}
+                  onReset={handleSearchReset}
                 />
               </div>
               {memberProfileData && (
@@ -553,7 +559,7 @@ const StyledMakersLink = styled(Text)`
   }
 `;
 
-const StyledMemberSearch = styled(MemberSearch)`
+const StyledMemberSearch = styled(SearchField)`
   min-width: 335px;
   @media ${DESKTOP_TWO_MEDIA_QUERY} {
     grid-area: 'search';

--- a/src/components/members/main/MemberList/index.tsx
+++ b/src/components/members/main/MemberList/index.tsx
@@ -164,6 +164,45 @@ const MemberList: FC<MemberListProps> = ({ banner }) => {
   const handleClickCard = (profile: Profile) => {
     logClickEvent('memberCard', { id: profile.id, name: profile.name });
   };
+
+  const MemberCardWrapper = ({ profile }: { profile: Profile }) => {
+    const sorted = profile.activities.sort((a, b) => b.generation - a.generation);
+    const badges = sorted.map((activity) => ({
+      content: `${activity.generation}기 ${activity.part}`,
+      isActive: activity.generation === LATEST_GENERATION,
+    }));
+
+    const belongs = profile.careers.find((career) => career.isCurrent)?.companyName ?? profile.university;
+
+    return (
+      <Link key={profile.id} href={playgroundLink.memberDetail(profile.id)} onClick={() => handleClickCard(profile)}>
+        <MemberCard
+          name={profile.name}
+          belongs={belongs}
+          badges={badges}
+          intro={profile.introduction}
+          imageUrl={profile.profileImage}
+          isCoffeeChatActivate={profile.isCoffeeChatActivate}
+          email={profile.email}
+          onMessage={(e) => {
+            e.preventDefault();
+            setMessageModalState({
+              show: true,
+              data: {
+                targetId: `${profile.id}`,
+                name: profile.name,
+                profileUrl: profile.profileImage,
+              },
+            });
+          }}
+        />
+        <Responsive only='mobile'>
+          <HLine />
+        </Responsive>
+      </Link>
+    );
+  };
+
   return (
     <StyledContainer>
       <div
@@ -376,47 +415,9 @@ const MemberList: FC<MemberListProps> = ({ banner }) => {
           <StyledCardWrapper>
             {profiles?.map((profiles, index) => (
               <React.Fragment key={index}>
-                {profiles.map((profile) => {
-                  const sorted = [...profile.activities].sort((a, b) => b.generation - a.generation);
-                  const badges = sorted.map((activity) => ({
-                    content: `${activity.generation}기 ${activity.part}`,
-                    isActive: activity.generation === LATEST_GENERATION,
-                  }));
-
-                  const belongs = profile.careers.find((career) => career.isCurrent)?.companyName ?? profile.university;
-
-                  return (
-                    <Link
-                      key={profile.id}
-                      href={playgroundLink.memberDetail(profile.id)}
-                      onClick={() => handleClickCard(profile)}
-                    >
-                      <MemberCard
-                        name={profile.name}
-                        belongs={belongs}
-                        badges={badges}
-                        intro={profile.introduction}
-                        imageUrl={profile.profileImage}
-                        isCoffeeChatActivate={profile.isCoffeeChatActivate}
-                        email={profile.email}
-                        onMessage={(e) => {
-                          e.preventDefault();
-                          setMessageModalState({
-                            show: true,
-                            data: {
-                              targetId: `${profile.id}`,
-                              name: profile.name,
-                              profileUrl: profile.profileImage,
-                            },
-                          });
-                        }}
-                      />
-                      <Responsive only='mobile'>
-                        <HLine />
-                      </Responsive>
-                    </Link>
-                  );
-                })}
+                {profiles.map((profile) => (
+                  <MemberCardWrapper key={profile.id} profile={profile} />
+                ))}
               </React.Fragment>
             ))}
           </StyledCardWrapper>

--- a/src/components/members/main/MemberList/index.tsx
+++ b/src/components/members/main/MemberList/index.tsx
@@ -138,6 +138,7 @@ const MemberList: FC<MemberListProps> = ({ banner }) => {
   const handleSearchChange = (e: ChangeEvent<HTMLInputElement>) => setSearch(e.target.value);
   const handleSearchReset = () => {
     setSearch('');
+    addQueryParamsToUrl({ search: '' });
   };
 
   const createTypeSafeHandler =

--- a/src/components/members/main/MemberList/index.tsx
+++ b/src/components/members/main/MemberList/index.tsx
@@ -701,17 +701,18 @@ const MobileFilterTrigger = styled.button<{ selected?: boolean }>`
   background: ${colors.gray800};
   padding: 11px 16px;
   height: 48px;
-  color: ${colors.white};
+  color: ${colors.gray300};
   ${({ selected }) =>
     selected &&
     css`
-      border-color: ${colors.white};
+      color: ${colors.white};
     `}
 `;
 
 const StyledChevronDown = styled(IconChevronDown)`
   width: 20px;
   height: 20px;
+  color: ${colors.white};
 `;
 
 const StyledSwitchVertical = styled(IconSwitchVertical)`

--- a/src/components/members/main/MemberList/index.tsx
+++ b/src/components/members/main/MemberList/index.tsx
@@ -1,7 +1,7 @@
 import { css } from '@emotion/react';
 import styled from '@emotion/styled';
 import { colors } from '@sopt-makers/colors';
-import { IconChevronDown } from '@sopt-makers/icons';
+import { IconChevronDown, IconSwitchVertical } from '@sopt-makers/icons';
 import { uniq } from 'lodash-es';
 import dynamic from 'next/dynamic';
 import Link from 'next/link';
@@ -192,7 +192,7 @@ const MemberList: FC<MemberListProps> = ({ banner }) => {
         `}
       >
         <Responsive only='mobile'>{banner}</Responsive>
-        <Responsive only='mobile' css={{ marginTop: '40px' }}>
+        <Responsive only='mobile' css={{ marginTop: '20px' }}>
           <StyledMemberSearch
             placeholder='이름, 학교, 회사를 검색해보세요!'
             value={search || ''}
@@ -270,29 +270,25 @@ const MemberList: FC<MemberListProps> = ({ banner }) => {
             <div
               css={css`
                 display: flex;
+                align-items: center;
                 justify-content: space-between;
-                margin-top: 30px;
+                margin-top: 20px;
+                height: 48px;
               `}
             >
-              <Text>{`전체 ${memberProfileData.pages[0].totalMembersCount}명`}</Text>
+              <Text typography='SUIT_14_M'>{`전체 ${memberProfileData.pages[0].totalMembersCount}명`}</Text>
               <StyledMobileFilter
                 placeholder=''
                 options={ORDER_OPTIONS}
                 value={orderBy}
                 onChange={handleSelectOrderBy}
                 trigger={(placeholder) => (
-                  <div
-                    css={css`
-                      display: flex;
-                      align-items: center;
-                      cursor: pointer;
-                    `}
-                  >
-                    {/* <IconArrowUpDown /> */}
-                    <Text typography='SUIT_12_M' color={colors.gray400}>
+                  <OrderFilter>
+                    <Text typography='SUIT_16_M' color={colors.gray300}>
                       {placeholder}
                     </Text>
-                  </div>
+                    <StyledSwitchVertical />
+                  </OrderFilter>
                 )}
               />
             </div>
@@ -449,7 +445,19 @@ const MemberList: FC<MemberListProps> = ({ banner }) => {
                   `}
                 >
                   <Text typography='SUIT_18_M'>{`전체 ${memberProfileData.pages[0].totalMembersCount}명`}</Text>
-                  <OrderBySelect value={orderBy} onChange={handleSelectOrderBy} options={ORDER_OPTIONS} />
+                  <OrderBySelect
+                    value={orderBy}
+                    onChange={handleSelectOrderBy}
+                    options={ORDER_OPTIONS}
+                    trigger={
+                      <OrderFilter>
+                        <Text typography='SUIT_16_M' color={colors.gray300}>
+                          {ORDER_OPTIONS.find((option: Option) => option.value === orderBy)?.label}
+                        </Text>
+                        <StyledSwitchVertical />
+                      </OrderFilter>
+                    }
+                  />
                 </div>
               )}
             </StyledTopWrapper>
@@ -590,6 +598,7 @@ const StyledCardWrapper = styled.div`
     grid-template-columns: repeat(1, 1fr);
     gap: 0 8px;
     justify-items: stretch;
+    margin-top: 0;
 
     & > div {
       width: 100%;
@@ -659,6 +668,7 @@ const StyledMobileFilterWrapper = styled.div`
   gap: 10px;
   align-items: center;
   margin-top: 17px;
+  margin-right: -20px;
   overflow-x: auto;
 
   /* to disable scroll bar */
@@ -695,4 +705,16 @@ const MobileFilterTrigger = styled.button<{ selected?: boolean }>`
 const StyledChevronDown = styled(IconChevronDown)`
   width: 20px;
   height: 20px;
+`;
+
+const StyledSwitchVertical = styled(IconSwitchVertical)`
+  width: 20px;
+  height: 20px;
+  color: ${colors.gray300};
+`;
+
+const OrderFilter = styled.div`
+  display: flex;
+  gap: 12px;
+  align-items: center;
 `;

--- a/src/components/members/main/MemberList/index.tsx
+++ b/src/components/members/main/MemberList/index.tsx
@@ -691,15 +691,15 @@ const StyledMobileFilter = styled(MemberListFilterSheet)`
 
 const MobileFilterTrigger = styled.button<{ selected?: boolean }>`
   display: flex;
-  justify-content: center;
-  align-items: center;
   gap: 12px;
-  min-width: fit-content;
-  width: max-content;
+  align-items: center;
+  justify-content: center;
   border: 1px solid transparent;
   border-radius: 10px;
   background: ${colors.gray800};
   padding: 11px 16px;
+  width: max-content;
+  min-width: fit-content;
   height: 48px;
   color: ${colors.gray300};
   ${({ selected }) =>

--- a/src/components/members/main/MemberList/index.tsx
+++ b/src/components/members/main/MemberList/index.tsx
@@ -175,7 +175,11 @@ const MemberList: FC<MemberListProps> = ({ banner }) => {
     const belongs = profile.careers.find((career) => career.isCurrent)?.companyName ?? profile.university;
 
     return (
-      <Link key={profile.id} href={playgroundLink.memberDetail(profile.id)} onClick={() => handleClickCard(profile)}>
+      <StyledLink
+        key={profile.id}
+        href={playgroundLink.memberDetail(profile.id)}
+        onClick={() => handleClickCard(profile)}
+      >
         <MemberCard
           name={profile.name}
           belongs={belongs}
@@ -199,7 +203,7 @@ const MemberList: FC<MemberListProps> = ({ banner }) => {
         <Responsive only='mobile'>
           <HLine />
         </Responsive>
-      </Link>
+      </StyledLink>
     );
   };
 
@@ -624,10 +628,14 @@ const EmptyDescription = styled.span`
 `;
 
 const HLine = styled.hr`
+  position: absolute;
+  bottom: 0;
+  left: -20px;
   margin: 0;
   border: 0;
   border-bottom: 1px solid ${colors.gray800};
   padding: 0;
+  width: 100dvw;
 `;
 
 const Target = styled.div`
@@ -659,4 +667,8 @@ const MobileFilterTrigger = styled.button<{ selected?: boolean }>`
     `}
 
   ${textStyles.SUIT_13_M};
+`;
+
+const StyledLink = styled(Link)`
+  position: relative;
 `;

--- a/src/components/members/main/MemberList/index.tsx
+++ b/src/components/members/main/MemberList/index.tsx
@@ -216,111 +216,6 @@ const MemberList: FC<MemberListProps> = ({ banner }) => {
         `}
       >
         <Responsive only='mobile'>{banner}</Responsive>
-        <Responsive only='mobile' css={{ marginTop: '40px' }}>
-          <StyledMemberSearch
-            placeholder='이름, 학교, 회사를 검색해보세요!'
-            value={search}
-            onChange={setSearch}
-            onSearch={handleSearch}
-          />
-          <StyledMobileFilterWrapper>
-            <StyledMobileFilter
-              value={generation}
-              onChange={handleSelectGeneration}
-              options={GENERATION_OPTIONS}
-              defaultOption={GENERATION_DEFAULT_OPTION}
-              placeholder='기수'
-              trigger={(placeholder) => (
-                <MobileFilterTrigger selected={Boolean(generation)}>
-                  {placeholder}
-                  <IconExpand />
-                </MobileFilterTrigger>
-              )}
-            />
-            <StyledMobileFilter
-              placeholder='파트'
-              value={part}
-              onChange={handleSelectPart}
-              options={PART_OPTIONS}
-              trigger={(placeholder) => (
-                <MobileFilterTrigger selected={Boolean(part)}>
-                  {placeholder}
-                  <IconExpand />
-                </MobileFilterTrigger>
-              )}
-            />
-            <StyledMobileFilter
-              options={TEAM_OPTIONS}
-              value={team}
-              onChange={handleSelectTeam}
-              defaultOption={FILTER_DEFAULT_OPTION}
-              placeholder='활동'
-              trigger={(placeholder) => (
-                <MobileFilterTrigger selected={Boolean(team)}>
-                  {placeholder}
-                  <IconExpand />
-                </MobileFilterTrigger>
-              )}
-            />
-            <StyledMobileFilter
-              placeholder='MBTI'
-              defaultOption={FILTER_DEFAULT_OPTION}
-              options={MBTI_OPTIONS}
-              value={mbti}
-              onChange={handleSelectMbti}
-              trigger={(placeholder) => (
-                <MobileFilterTrigger selected={Boolean(mbti)}>
-                  {placeholder}
-                  <IconExpand />
-                </MobileFilterTrigger>
-              )}
-            />
-            <StyledMobileFilter
-              placeholder='재직 상태'
-              defaultOption={FILTER_DEFAULT_OPTION}
-              options={EMPLOYED_OPTIONS}
-              value={employed}
-              onChange={handleSelectEmployed}
-              trigger={(placeholder) => (
-                <MobileFilterTrigger selected={Boolean(employed)}>
-                  {placeholder}
-                  <IconExpand />
-                </MobileFilterTrigger>
-              )}
-            />
-          </StyledMobileFilterWrapper>
-          {memberProfileData && (
-            <div
-              css={css`
-                display: flex;
-                justify-content: space-between;
-                margin-top: 30px;
-              `}
-            >
-              <Text>{`전체 ${memberProfileData.pages[0].totalMembersCount}명`}</Text>
-              <StyledMobileFilter
-                placeholder=''
-                options={ORDER_OPTIONS}
-                value={orderBy}
-                onChange={handleSelectOrderBy}
-                trigger={(placeholder) => (
-                  <div
-                    css={css`
-                      display: flex;
-                      align-items: center;
-                      cursor: pointer;
-                    `}
-                  >
-                    <IconArrowUpDown />
-                    <Text typography='SUIT_12_M' color={colors.gray400}>
-                      {placeholder}
-                    </Text>
-                  </div>
-                )}
-              />
-            </div>
-          )}
-        </Responsive>
       </div>
       <StyledMain>
         <Responsive
@@ -348,22 +243,22 @@ const MemberList: FC<MemberListProps> = ({ banner }) => {
               <EmptyDescription>검색어를 바르게 입력했는지 확인하거나, 필터를 변경해보세요.</EmptyDescription>
             </StyledEmpty>
           )}
-          <Responsive only='desktop'>
-            <StyledTopWrapper>
-              <div
-                css={css`
-                  display: flex;
-                  justify-content: space-between;
-                  @media ${DESKTOP_TWO_MEDIA_QUERY} {
-                    display: grid;
-                    grid:
-                      [row1-start] 'search' [row1-end]
-                      [row2-start] 'filter' [row2-end]
-                      [row3-start] 'orderBy' [row3-end]
-                      / 1fr;
-                  }
-                `}
-              >
+          <StyledTopWrapper>
+            <div
+              css={css`
+                display: flex;
+                justify-content: space-between;
+                @media ${DESKTOP_TWO_MEDIA_QUERY} {
+                  display: grid;
+                  grid:
+                    [row1-start] 'search' [row1-end]
+                    [row2-start] 'filter' [row2-end]
+                    [row3-start] 'orderBy' [row3-end]
+                    / 1fr;
+                }
+              `}
+            >
+              <FilterScrollWrapper>
                 <StyledFilterWrapper>
                   <MemberListFilter
                     placeholder='기수'
@@ -400,29 +295,29 @@ const MemberList: FC<MemberListProps> = ({ banner }) => {
                     onChange={handleSelectEmployed}
                   />
                 </StyledFilterWrapper>
-                <StyledMemberSearch
-                  placeholder='이름, 학교, 회사를 검색해보세요!'
-                  value={search}
-                  onChange={setSearch}
-                  onSearch={handleSearch}
-                />
+              </FilterScrollWrapper>
+              <StyledMemberSearch
+                placeholder='이름, 학교, 회사를 검색해보세요!'
+                value={search}
+                onChange={setSearch}
+                onSearch={handleSearch}
+              />
+            </div>
+            {memberProfileData && (
+              <div
+                css={css`
+                  display: flex;
+                  grid-area: 'orderBy';
+                  justify-content: space-between;
+                  order: 3;
+                  margin-top: 30px;
+                `}
+              >
+                <Text typography='SUIT_18_M'>{`전체 ${memberProfileData.pages[0].totalMembersCount}명`}</Text>
+                <OrderBySelect value={orderBy} onChange={handleSelectOrderBy} options={ORDER_OPTIONS} />
               </div>
-              {memberProfileData && (
-                <div
-                  css={css`
-                    display: flex;
-                    grid-area: 'orderBy';
-                    justify-content: space-between;
-                    order: 3;
-                    margin-top: 30px;
-                  `}
-                >
-                  <Text typography='SUIT_18_M'>{`전체 ${memberProfileData.pages[0].totalMembersCount}명`}</Text>
-                  <OrderBySelect value={orderBy} onChange={handleSelectOrderBy} options={ORDER_OPTIONS} />
-                </div>
-              )}
-            </StyledTopWrapper>
-          </Responsive>
+            )}
+          </StyledTopWrapper>
         </StyledRightWrapper>
       </StyledMain>
       <Target ref={ref} />
@@ -454,7 +349,6 @@ const StyledContainer = styled.div`
   flex-direction: column;
   align-items: center;
   padding-bottom: 100px;
-  min-height: 101vh;
 
   @media ${MOBILE_MEDIA_QUERY} {
     margin-top: 0;
@@ -482,35 +376,26 @@ const StyledRightWrapper = styled.div`
   width: 100%;
 `;
 
-const StyledMobileFilterWrapper = styled.div`
-  display: flex;
-  gap: 10px;
-  align-items: center;
-  margin-top: 17px;
-  overflow-x: auto;
-
-  /* to disable scroll bar */
-  -ms-overflow-style: none; /* IE and Edge */
-  scrollbar-width: none; /* Firefox */
-  ::-webkit-scrollbar {
-    display: none; /* Chrome, Safari, Opera */
-  }
-`;
-
 const StyledTopWrapper = styled.div`
   display: flex;
   flex-direction: column;
 `;
 
+const FilterScrollWrapper = styled.div`
+  @media ${DESKTOP_TWO_MEDIA_QUERY} {
+    display: flex;
+    grid-area: 'filter';
+    gap: 10px;
+    align-items: center;
+    order: 2;
+    margin-top: 17px;
+    overflow-x: auto;
+  }
+`;
+
 const StyledFilterWrapper = styled.div`
   display: flex;
   column-gap: 10px;
-
-  @media ${DESKTOP_TWO_MEDIA_QUERY} {
-    grid-area: 'filter';
-    order: 2;
-    margin-top: 35px;
-  }
 `;
 
 const StyledMakersLink = styled(Text)`

--- a/src/components/members/main/MemberList/index.tsx
+++ b/src/components/members/main/MemberList/index.tsx
@@ -40,9 +40,6 @@ import { textStyles } from '@/styles/typography';
 
 const PAGE_LIMIT = 30;
 
-const MemberListFilterSheet = dynamic(() => import('./filters/MemberListFilterSheet').then((comp) => comp.default), {
-  ssr: false,
-});
 interface MemberListProps {
   banner: ReactNode;
 }
@@ -253,9 +250,47 @@ const MemberList: FC<MemberListProps> = ({ banner }) => {
           <StyledCardWrapper>
             {profiles?.map((profiles, index) => (
               <React.Fragment key={index}>
-                {profiles.map((profile) => (
-                  <MemberCardWrapper key={profile.id} profile={profile} />
-                ))}
+                {profiles.map((profile) => {
+                  const sorted = profile.activities.sort((a, b) => b.generation - a.generation);
+                  const badges = sorted.map((activity) => ({
+                    content: `${activity.generation}기 ${activity.part}`,
+                    isActive: activity.generation === LATEST_GENERATION,
+                  }));
+
+                  const belongs = profile.careers.find((career) => career.isCurrent)?.companyName ?? profile.university;
+
+                  return (
+                    <StyledLink
+                      key={profile.id}
+                      href={playgroundLink.memberDetail(profile.id)}
+                      onClick={() => handleClickCard(profile)}
+                    >
+                      <MemberCard
+                        name={profile.name}
+                        belongs={belongs}
+                        badges={badges}
+                        intro={profile.introduction}
+                        imageUrl={profile.profileImage}
+                        isCoffeeChatActivate={profile.isCoffeeChatActivate}
+                        email={profile.email}
+                        onMessage={(e) => {
+                          e.preventDefault();
+                          setMessageModalState({
+                            show: true,
+                            data: {
+                              targetId: `${profile.id}`,
+                              name: profile.name,
+                              profileUrl: profile.profileImage,
+                            },
+                          });
+                        }}
+                      />
+                      <Responsive only='mobile'>
+                        <HLine />
+                      </Responsive>
+                    </StyledLink>
+                  );
+                })}
               </React.Fragment>
             ))}
           </StyledCardWrapper>

--- a/src/components/members/main/MemberList/index.tsx
+++ b/src/components/members/main/MemberList/index.tsx
@@ -333,6 +333,21 @@ const MemberList: FC<MemberListProps> = ({ banner }) => {
           {banner}
         </Responsive>
         <StyledRightWrapper>
+          <StyledCardWrapper>
+            {profiles?.map((profiles, index) => (
+              <React.Fragment key={index}>
+                {profiles.map((profile) => (
+                  <MemberCardWrapper key={profile.id} profile={profile} />
+                ))}
+              </React.Fragment>
+            ))}
+          </StyledCardWrapper>
+          {isEmpty && (
+            <StyledEmpty>
+              <EmptyTitle>OMG... 검색 결과가 없어요.</EmptyTitle>
+              <EmptyDescription>검색어를 바르게 입력했는지 확인하거나, 필터를 변경해보세요.</EmptyDescription>
+            </StyledEmpty>
+          )}
           <Responsive only='desktop'>
             <StyledTopWrapper>
               <div
@@ -354,41 +369,34 @@ const MemberList: FC<MemberListProps> = ({ banner }) => {
                     placeholder='기수'
                     defaultOption={GENERATION_DEFAULT_OPTION}
                     options={GENERATION_OPTIONS}
-                    value={generation ?? ''}
                     onChange={handleSelectGeneration}
                   />
-                  <MemberListFilter
-                    placeholder='파트'
-                    value={part ?? ''}
-                    onChange={handleSelectPart}
-                    options={PART_OPTIONS}
-                  />
+                  <MemberListFilter placeholder='파트' onChange={handleSelectPart} options={PART_OPTIONS} />
                   <MemberListFilter
                     placeholder='활동'
                     options={TEAM_OPTIONS}
-                    value={team ?? ''}
                     onChange={handleSelectTeam}
                     defaultOption={FILTER_DEFAULT_OPTION}
                   >
                     <Link href={playgroundLink.makers()}>
-                      <StyledMakersLink>
-                        메이커스
-                        <IconDiagonalArrow />
-                      </StyledMakersLink>
+                      <div>
+                        <StyledMakersLink typography='SUIT_16_M'>
+                          메이커스
+                          <IconDiagonalArrow />
+                        </StyledMakersLink>
+                      </div>
                     </Link>
                   </MemberListFilter>
                   <MemberListFilter
                     placeholder='MBTI'
                     defaultOption={FILTER_DEFAULT_OPTION}
                     options={MBTI_OPTIONS}
-                    value={mbti ?? ''}
                     onChange={handleSelectMbti}
                   />
                   <MemberListFilter
                     placeholder='재직 상태'
                     defaultOption={FILTER_DEFAULT_OPTION}
                     options={EMPLOYED_OPTIONS}
-                    value={employed ?? ''}
                     onChange={handleSelectEmployed}
                   />
                 </StyledFilterWrapper>
@@ -415,22 +423,6 @@ const MemberList: FC<MemberListProps> = ({ banner }) => {
               )}
             </StyledTopWrapper>
           </Responsive>
-
-          <StyledCardWrapper>
-            {profiles?.map((profiles, index) => (
-              <React.Fragment key={index}>
-                {profiles.map((profile) => (
-                  <MemberCardWrapper key={profile.id} profile={profile} />
-                ))}
-              </React.Fragment>
-            ))}
-          </StyledCardWrapper>
-          {isEmpty && (
-            <StyledEmpty>
-              <EmptyTitle>OMG... 검색 결과가 없어요.</EmptyTitle>
-              <EmptyDescription>검색어를 바르게 입력했는지 확인하거나, 필터를 변경해보세요.</EmptyDescription>
-            </StyledEmpty>
-          )}
         </StyledRightWrapper>
       </StyledMain>
       <Target ref={ref} />
@@ -486,7 +478,7 @@ const StyledMain = styled.main`
 const StyledRightWrapper = styled.div`
   display: flex;
   flex: 1;
-  flex-direction: column;
+  flex-direction: column-reverse;
   width: 100%;
 `;
 
@@ -521,21 +513,17 @@ const StyledFilterWrapper = styled.div`
   }
 `;
 
-const StyledMakersLink = styled.div`
+const StyledMakersLink = styled(Text)`
   display: flex;
   align-items: center;
   justify-content: space-between;
   transition: color 0.2s background-color 0.2s;
   outline: none;
   border-radius: 6px;
-  cursor: pointer;
-  padding: 5px 10px;
-  color: ${colors.gray200};
+  padding: 8px 12px;
 
   &:hover {
-    outline: none;
-    background-color: ${colors.gray600};
-    color: ${colors.white};
+    background-color: ${colors.gray700};
   }
 `;
 

--- a/src/components/members/main/MemberList/index.tsx
+++ b/src/components/members/main/MemberList/index.tsx
@@ -572,18 +572,18 @@ const StyledMemberSearch = styled(MemberSearch)`
 
 const StyledCardWrapper = styled.div`
   display: grid;
-  grid-template-columns: repeat(4, minmax(10px, 303px));
-  gap: 30px;
+  grid-template-columns: repeat(4, minmax(10px, 310px));
+  gap: 24px;
   align-items: center;
   justify-items: stretch;
   margin-top: 28px;
 
   @media ${DESKTOP_ONE_MEDIA_QUERY} {
-    grid-template-columns: repeat(3, minmax(10px, 303px));
+    grid-template-columns: repeat(3, minmax(10px, 310px));
   }
 
   @media ${DESKTOP_TWO_MEDIA_QUERY} {
-    grid-template-columns: repeat(2, minmax(10px, 303px));
+    grid-template-columns: repeat(2, minmax(10px, 310px));
   }
 
   @media ${MOBILE_MEDIA_QUERY} {

--- a/src/components/members/main/MemberList/index.tsx
+++ b/src/components/members/main/MemberList/index.tsx
@@ -676,6 +676,7 @@ const StyledMobileFilterWrapper = styled.div`
   align-items: center;
   margin-top: 17px;
   margin-right: -20px;
+  padding-right: 20px;
   overflow-x: auto;
 
   /* to disable scroll bar */

--- a/src/components/members/main/hooks/useVisibleBadges.ts
+++ b/src/components/members/main/hooks/useVisibleBadges.ts
@@ -10,10 +10,15 @@ export const useVisibleBadges = (badges: Badge[], ellipsisWidth: number, badgeGa
   const badgeRefs = useRef<(HTMLDivElement | null)[]>([]);
   badgeRefs.current = badges.map(() => null);
   const badgeWrapperRef = useRef<HTMLDivElement>(null);
-  const [visibleBadges, setAvailableBadges] = useState<typeof badges>(badges);
+  const [visibleBadges, setVisibleBadges] = useState<typeof badges>(badges);
   const [isBadgeOverflow, setIsBadgeOverflow] = useState<boolean>(false);
 
   useLayoutEffect(() => {
+    // 뱃지 개수가 2이하면 계산 로직 스킵
+    if (badges.length <= 1) {
+      isCalculated.current = true;
+      return;
+    }
     if (isCalculated.current) return;
 
     const calculateVisibleBadges = () => {
@@ -33,7 +38,7 @@ export const useVisibleBadges = (badges: Badge[], ellipsisWidth: number, badgeGa
         totalWidth += badgeWidth + badgeGap;
       }
       isCalculated.current = true;
-      setAvailableBadges(visible);
+      setVisibleBadges(visible);
       setIsBadgeOverflow(overflow);
     };
 

--- a/src/components/members/main/hooks/useVisibleBadges.ts
+++ b/src/components/members/main/hooks/useVisibleBadges.ts
@@ -29,7 +29,7 @@ export const useVisibleBadges = (badges: Badge[], ellipsisWidth: number, badgeGa
 
       for (let i = 0; i < badges.length; i++) {
         const badgeWidth = badgeRefs.current[i]?.offsetWidth || 0;
-        console.log('here', badgeWrapperWidth);
+        
         if (totalWidth + badgeWidth > badgeWrapperWidth - ellipsisWidth) {
           overflow = true;
           break;

--- a/src/components/members/main/hooks/useVisibleBadges.ts
+++ b/src/components/members/main/hooks/useVisibleBadges.ts
@@ -1,0 +1,38 @@
+import { useLayoutEffect, useRef, useState } from 'react';
+
+interface Badge {
+  content: string;
+  isActive: boolean;
+}
+
+export const useVisibleBadges = (badges: Badge[], maxBadgeWidth: number, badgeGap: number) => {
+  const badgeRefs = useRef<(HTMLDivElement | null)[]>([]);
+  badgeRefs.current = badges.map(() => null);
+  const [visibleBadges, setAvailableBadges] = useState<typeof badges>(badges);
+  const [isBadgeOverflow, setIsBadgeOverflow] = useState<boolean>(false);
+
+  useLayoutEffect(() => {
+    const calculateVisibleBadges = () => {
+      let totalWidth = 0;
+      const visible = [];
+      let overflow = false;
+
+      for (let i = 0; i < badges.length; i++) {
+        const badgeWidth = badgeRefs.current[i]?.offsetWidth || 0;
+        if (totalWidth + badgeWidth > maxBadgeWidth) {
+          overflow = true;
+          break;
+        }
+        visible.push(badges[i]);
+        totalWidth += badgeWidth + badgeGap;
+      }
+
+      setAvailableBadges(visible);
+      setIsBadgeOverflow(overflow);
+    };
+
+    calculateVisibleBadges();
+  }, [badges, maxBadgeWidth, badgeGap]);
+
+  return { visibleBadges, isBadgeOverflow, badgeRefs };
+};

--- a/src/components/members/main/hooks/useVisibleBadges.ts
+++ b/src/components/members/main/hooks/useVisibleBadges.ts
@@ -5,34 +5,40 @@ interface Badge {
   isActive: boolean;
 }
 
-export const useVisibleBadges = (badges: Badge[], maxBadgeWidth: number, badgeGap: number) => {
+export const useVisibleBadges = (badges: Badge[], ellipsisWidth: number, badgeGap: number) => {
+  const isCalculated = useRef<boolean>(false);
   const badgeRefs = useRef<(HTMLDivElement | null)[]>([]);
   badgeRefs.current = badges.map(() => null);
+  const badgeWrapperRef = useRef<HTMLDivElement>(null);
   const [visibleBadges, setAvailableBadges] = useState<typeof badges>(badges);
   const [isBadgeOverflow, setIsBadgeOverflow] = useState<boolean>(false);
 
   useLayoutEffect(() => {
+    if (isCalculated.current) return;
+
     const calculateVisibleBadges = () => {
       let totalWidth = 0;
       const visible = [];
       let overflow = false;
+      const badgeWrapperWidth = badgeWrapperRef.current?.offsetWidth || 0;
 
       for (let i = 0; i < badges.length; i++) {
         const badgeWidth = badgeRefs.current[i]?.offsetWidth || 0;
-        if (totalWidth + badgeWidth > maxBadgeWidth) {
+        console.log('here', badgeWrapperWidth);
+        if (totalWidth + badgeWidth > badgeWrapperWidth - ellipsisWidth) {
           overflow = true;
           break;
         }
         visible.push(badges[i]);
         totalWidth += badgeWidth + badgeGap;
       }
-
+      isCalculated.current = true;
       setAvailableBadges(visible);
       setIsBadgeOverflow(overflow);
     };
 
     calculateVisibleBadges();
-  }, [badges, maxBadgeWidth, badgeGap]);
+  }, [badges, ellipsisWidth, badgeGap]);
 
-  return { visibleBadges, isBadgeOverflow, badgeRefs };
+  return { visibleBadges, isBadgeOverflow, badgeRefs, badgeWrapperRef };
 };

--- a/src/pages/members/index.tsx
+++ b/src/pages/members/index.tsx
@@ -7,7 +7,6 @@ import MemberList from '@/components/members/main/MemberList';
 import OnBoardingBanner from '@/components/members/main/MemberList/OnBoardingBanner';
 import { MOBILE_MEDIA_QUERY } from '@/styles/mediaQuery';
 import { setLayout } from '@/utils/layout';
-import CoffeeChatList from '@/components/coffeechat/CoffeeChatList';
 
 const MemberPage: FC = () => {
   const { data: memberOfMeData } = useGetMemberOfMe();
@@ -17,7 +16,6 @@ const MemberPage: FC = () => {
 
   return (
     <AuthRequired>
-      <CoffeeChatList />
       <MemberList banner={onboardingBanner} />
     </AuthRequired>
   );

--- a/yarn.lock
+++ b/yarn.lock
@@ -6217,10 +6217,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@sopt-makers/colors@npm:^3.0.1":
-  version: 3.0.1
-  resolution: "@sopt-makers/colors@npm:3.0.1"
-  checksum: 370bc284525f7b80eeb036b51f4c5c3a8e652a7015d4c77decd5dfabb27681074039cceb683519e98687d7abdbdca33a432e46e756d27d99d77b90c4686c2941
+"@sopt-makers/colors@npm:^3.0.2":
+  version: 3.0.2
+  resolution: "@sopt-makers/colors@npm:3.0.2"
+  checksum: 938f02c3301edbc5bd3806b6206f341273bc93bb513b11457367b5c6a80e42625c9bf7f5f627a27d42b8e19a3effd8921ce2bf0d0b50a086fb1e918e76e5208e
   languageName: node
   linkType: hard
 
@@ -6235,15 +6235,6 @@ __metadata:
   version: 2.0.1
   resolution: "@sopt-makers/fonts@npm:2.0.1"
   checksum: eb734be0cef629e408bb5e34aba88921be2b2a7df73fe8e3d24b96846a0486e41b8962c0657fe5649f76ea11b5a1872337aa83462f8bb49daa796ccd693b0d14
-  languageName: node
-  linkType: hard
-
-"@sopt-makers/icons@npm:^1.0.3":
-  version: 1.0.4
-  resolution: "@sopt-makers/icons@npm:1.0.4"
-  peerDependencies:
-    react: ^18.2.0
-  checksum: cc3cd1201bd2c798b6a6b35ffad4cd9450dd6c3443be9c553957c929a8cba758b488e782537a8f4da6481c1f0c7c9b58f971edba3522fcab0aba6c4d4a31cf37
   languageName: node
   linkType: hard
 
@@ -6272,21 +6263,22 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@sopt-makers/ui@npm:^2.0.5":
-  version: 2.0.5
-  resolution: "@sopt-makers/ui@npm:2.0.5"
+"@sopt-makers/ui@npm:2.4.4":
+  version: 2.4.4
+  resolution: "@sopt-makers/ui@npm:2.4.4"
   dependencies:
     "@radix-ui/react-dialog": ^1.0.5
     "@radix-ui/react-switch": ^1.0.3
-    "@sopt-makers/colors": ^3.0.1
+    "@sopt-makers/colors": ^3.0.2
     "@sopt-makers/fonts": ^2.0.1
-    "@sopt-makers/icons": ^1.0.3
+    "@sopt-makers/icons": ^1.0.5
     "@vanilla-extract/css": ^1.14.0
     "@vanilla-extract/sprinkles": 1.6.1
     tsup: ^8.0.2
   peerDependencies:
     react: ^18.2.0
-  checksum: 39f8afc40d8a58bad72d3068f53e51f03ca3c9a03a65d4857506861f3acc74af2339eced38d33e6255990646a847573e94bcd646f85608bb7ac24f0af04a6eac
+    react-dom: ^18.2.0
+  checksum: cddae8b5328294c56a4a2997160e1cb879afeef14d16fbabd1ee73cddea842bc206dc6014b96c48765cd226e09e1e8f580d1bff0f27613ac972b908bfb005ee6
   languageName: node
   linkType: hard
 
@@ -19747,7 +19739,7 @@ __metadata:
     "@sopt-makers/colors": ^3.0.0
     "@sopt-makers/fonts": ^1.0.0
     "@sopt-makers/icons": ^1.0.5
-    "@sopt-makers/ui": ^2.0.5
+    "@sopt-makers/ui": 2.4.4
     "@storybook/addon-actions": ^7.0.23
     "@storybook/addon-docs": ^7.0.23
     "@storybook/addon-essentials": ^7.0.23


### PR DESCRIPTION
### 🤫 쉿, 나한테만 말해줘요. 이슈넘버
- close #1597

### 🧐 어떤 것을 변경했어요~?
<!-- 실제로 변경한 사항을 설명해주세요.-->
- [x] [PC] 멤버 카드 mds 디자인 반영
- [x] [PC] 멤버 카드 내 쪽지 버튼과 커피챗 버튼 분리
- [x] [MO] 멤버 프로필 왼쪽 상단에 커피챗 아이콘 표시
- [x] 활동 뱃지가 카드 너비를 넘어갈 경우 ellipsis 처리
- [x] [PC] 필터링 Select mds로 변경
- [x] [MO] 바텀시트와 연결되는 필터링 Select를 mds 디자인으로 변경 (mds Select 사용 불가)
- [x] SearchField mds로 변경
- [x] 순서 정렬 영역 mds 디자인으로 일부 변경 

### 🤔 그렇다면, 어떻게 구현했어요~?
<!-- 실제로 구현한 로직에 대해 설명해주세요.-->
생각했던 것보다 고난이 많은 작업이었습니다...
특히 mds에서 요구하는 데이터 구조와 type을 일치시키기 위해 기존 코드를 바꾸는 과정이 쉽지 않더라구요!
그리고 기존에 Member 탭 관련 코드 (특히 `<MemberList/>`)가 컴포넌트 분리가 안되어있고 많은 로직이 통합되어있었어요.
갈아엎기에는 시간이 부족해서, 이 부분은 **추후 다시 리팩토링**을 해야할 것 같습니다. (반드시..!)
그래서 코드가 지저분한데 이 부분은 양해 부탁드립니다 ㅠㅠ

그리고 프로필 카드에서 뱃지가 넘치면 생략처리 하는 부분이 있는데,
추가되어야하는 뱃지 크기를 동적으로 계산해주어야해서 상당히 복잡한 과정이었습니다.
![image](https://github.com/user-attachments/assets/38ef3d90-0dca-4911-8284-4554ab3fd912)

ref로 width를 동적으로 계산하여 최대 들어갈 수 있는 뱃지를 확인하는 방식으로 구현을 했구요.
이 [트러블 슈팅 과정](https://simeunseo.notion.site/SP1-125599a6f0d280d78b3ede8e98ccac48?pvs=4)을 기록해놨는데 혹시 궁금하시면 읽어보셔요! (진짜 그냥 기록용으로 일단 적어놓은거라서 글이 엉망이긴합니다)
실제 구현 내용은 [useVisibleBadges.ts](https://github.com/sopt-makers/sopt-playground-frontend/pull/1600/files#diff-d5a14176fe3d710d4bb53b19bdae14f295335c4e975b946b58a851b3f6fb5f1c)확인 부탁드립니다

flag을 두어서 이 계산은 첫 마운트시에만 실행되도록 했고,
뱃지가 2개 이하인 경우는 ellipsis처리될 필요가 없기 때문에 스킵하고 3개 이상일 경우만 계산을 하도록 했습니다.

### ❤️‍🔥 당신이 생각하는 PR포인트, 내겐 매력포인트.
<!-- 해당 PR에서 논의가 필요한 사항을 적어주세요. -->
- 커피챗 쪽 작업 끝나고나면 멤버 카드 커피챗 버튼에 링크 연결하는거 필요합니다!
- 커피챗과 함께 처음에 전달 받은 멤버탭은 mds가 완전히 적용되지 않은 상태여서, 태희언니가 mds 작업을 추가적으로 해서 오늘 공유해줬어요. 그런데 이거까지 전부 적용하려면 PR이 너무 늦어질 것 같아서, 우선 처음 전달받은 내용까지만 적용을 해두었습니다. 그래도 대부분은 적용된 상태이며 아마 모바일 바텀시트 디자인이랑 순서 정렬 mds로 바꾸기 정도만 처리하면 될 것 같아요!
- 전체적으로 멤버탭에서 모든 기능이 잘 동작하는지, 오류가 없는지 확인해주시면 감사하겠습니다.

### 📸 스크린샷, 없으면 이것 참,, 섭섭한데요?
#### 뱃지 ellipsis
https://github.com/user-attachments/assets/52284a1a-130b-4185-a044-7e729c0e68a5

#### select mds
https://github.com/user-attachments/assets/9a0919a4-ff5c-4aa4-9ab5-fef748ede7dc

#### mobile
https://github.com/user-attachments/assets/b4589f30-c98a-4045-8a6d-8634440810a3

