### PR TITLE
feat: 멤버 프로필, 상세 정보, 프로젝트, 모임 정보 컴포넌트 분리

### DIFF
--- a/src/api/endpoint/members/getMemberCrew.ts
+++ b/src/api/endpoint/members/getMemberCrew.ts
@@ -9,24 +9,28 @@ interface Params {
   take?: number;
 }
 
+const meetingsResponseScheme = z.array(
+  z.object({
+    id: z.number(),
+    isMeetingLeader: z.boolean(),
+    title: z.string(),
+    imageUrl: z.string(),
+    category: z.string().nullable(),
+    isActiveMeeting: z.boolean(),
+    mstartDate: z.string(),
+    mendDate: z.string(),
+  }),
+);
+
+export type MeetingsResponse = z.infer<typeof meetingsResponseScheme>;
+
 export const getMemberCrew = createEndpoint({
   request: ({ params, id }: { params: Params; id: number }) => ({
     method: 'GET',
     url: `api/v1/members/crew/${id}/${QS.create(params)}`,
   }),
   serverResponseScheme: z.object({
-    meetings: z.array(
-      z.object({
-        id: z.number(),
-        isMeetingLeader: z.boolean(),
-        title: z.string(),
-        imageUrl: z.string(),
-        category: z.string().nullable(),
-        isActiveMeeting: z.boolean(),
-        mstartDate: z.string(),
-        mendDate: z.string(),
-      }),
-    ),
+    meetings: meetingsResponseScheme,
     meta: z.object({
       page: z.number().nullable(),
       take: z.number().nullable(),

--- a/src/components/members/detail/ActivitySection/MemberDetail.tsx
+++ b/src/components/members/detail/ActivitySection/MemberDetail.tsx
@@ -4,7 +4,6 @@ import { fonts } from '@sopt-makers/fonts';
 import { IconAlertTriangle, IconUserX } from '@sopt-makers/icons';
 import { Flex } from '@toss/emotion-utils';
 import axios from 'axios';
-import dayjs from 'dayjs';
 import { uniq } from 'lodash-es';
 import Link from 'next/link';
 import { useRouter } from 'next/router';
@@ -12,49 +11,35 @@ import CallIcon from 'public/icons/icon-call.svg';
 import EditIcon from 'public/icons/icon-edit.svg';
 import MailIcon from 'public/icons/icon-mail.svg';
 import ProfileIcon from 'public/icons/icon-profile.svg';
-import { CSSProperties, FC, useEffect, useMemo, useState } from 'react';
+import { FC, useMemo } from 'react';
 
 import { useGetMemberCrewInfiniteQuery } from '@/api/endpoint/members/getMemberCrew';
 import { useGetMemberOfMe } from '@/api/endpoint/members/getMemberOfMe';
 import { useGetMemberProfileById } from '@/api/endpoint_LEGACY/hooks';
 import Loading from '@/components/common/Loading';
 import ResizedImage from '@/components/common/ResizedImage';
-import Text from '@/components/common/Text';
 import useEventLogger from '@/components/eventLogger/hooks/useEventLogger';
 import FeedDropdown from '@/components/feed/common/FeedDropdown';
-import MemberDetailSection from '@/components/members/detail/ActivitySection/MemberDetailSection';
-import MemberMeetingCard from '@/components/members/detail/ActivitySection/MemberMeetingCard';
-import MemberProjectCard from '@/components/members/detail/ActivitySection/MemberProjectCard';
 import CareerSection from '@/components/members/detail/CareerSection';
+import DetailInfoSection from '@/components/members/detail/DetailinfoSection';
 import EmptyProfile from '@/components/members/detail/EmptyProfile';
-import InfoItem from '@/components/members/detail/InfoItem';
+import GroupSection from '@/components/members/detail/GroupSection';
 import InterestSection from '@/components/members/detail/InterestSection';
+import ProjectSection from '@/components/members/detail/ProjectSection';
 import SoptActivitySection from '@/components/members/detail/SoptActivitySection';
 import { useBlockMember } from '@/components/members/hooks/useBlockMember';
 import { useReportMember } from '@/components/members/hooks/useReportMember';
-import { DEFAULT_DATE } from '@/components/members/upload/constants';
 import { playgroundLink } from '@/constants/links';
 import useEnterScreen from '@/hooks/useEnterScreen';
 import { useRunOnce } from '@/hooks/useRunOnce';
 import IconCoffee from '@/public/icons/icon-coffee.svg';
 import IconMore from '@/public/icons/icon-dots-vertical.svg';
 import { MOBILE_MEDIA_QUERY } from '@/styles/mediaQuery';
-import { textStyles } from '@/styles/typography';
 import { safeParseInt } from '@/utils';
 
 interface MemberDetailProps {
   memberId: string;
 }
-
-const convertBirthdayFormat = (birthday?: string) => {
-  // FIXME: 서버쪽에 YYYY-MM-DD 형태로 무조건 업로드시 전송해줘야 하는 이슈가 있어서,
-  // 생년월일을 보내지 않았을 경우에 DEFAULT_DATE를 전송하도록 임시처리 해 두었습니다. 이를 클라에서 보여주기 위해 대응합니다.
-  if (birthday) {
-    const isDefaultDay = dayjs(birthday).isSame(dayjs(DEFAULT_DATE));
-    return isDefaultDay ? '' : dayjs(birthday).format('YYYY-MM-DD');
-  }
-  return '';
-};
 
 const MemberDetail: FC<MemberDetailProps> = ({ memberId }) => {
   const { logClickEvent, logPageViewEvent } = useEventLogger();
@@ -192,22 +177,7 @@ const MemberDetail: FC<MemberDetailProps> = ({ memberId }) => {
           )}
         </ProfileContainer>
 
-        {(profile.birthday || profile.address || profile.university || profile.address) && (
-          <MemberDetailSection style={{ gap: '30px' }}>
-            {profile.birthday && <InfoItem label='생년월일' content={convertBirthdayFormat(profile.birthday)} />}
-            {profile.university && <InfoItem label='학교'>{profile.university}</InfoItem>}
-            {profile.major && <InfoItem label='전공'>{profile.major}</InfoItem>}
-            {profile.address && (
-              <InfoItem label='활동 지역'>
-                <StyledAddressBadgeWrapper>
-                  {profile.address.split(',').map((address) => (
-                    <AddressBadge key={address}>{address}</AddressBadge>
-                  ))}
-                </StyledAddressBadgeWrapper>
-              </InfoItem>
-            )}
-          </MemberDetailSection>
-        )}
+        <DetailInfoSection profile={profile} />
 
         <SoptActivitySection soptActivities={sortedSoptActivities} />
 
@@ -257,80 +227,15 @@ const MemberDetail: FC<MemberDetailProps> = ({ memberId }) => {
           />
         )}
 
-        <ActivityContainer>
-          <ActivityTitle>{profile.name}님이 참여한 프로젝트</ActivityTitle>
-          {profile.projects.length > 0 && (
-            <>
-              <ActivitySub>{profile.projects.length}개의 프로젝트에 참여</ActivitySub>
-              <ActivityDisplay>
-                {profile.projects.map((project) => (
-                  <MemberProjectCard key={project.id} {...project} />
-                ))}
-              </ActivityDisplay>
-            </>
-          )}
-          {profile.projects.length === 0 && (
-            <>
-              <ActivitySub>아직 참여한 프로젝트가 없어요</ActivitySub>
-              {String(me?.id) === memberId && (
-                <ActivityUploadNudge>
-                  <Text typography='SUIT_14_M' style={{ textAlign: 'center', lineHeight: '24px' }}>
-                    참여한 프로젝트를 등록하면 <br />
-                    공식 홈페이지에도 프로젝트가 업로드 돼요!
-                  </Text>
-                  <ActivityUploadButton
-                    onClick={() =>
-                      logClickEvent('projectUpload', {
-                        referral: 'myPage',
-                      })
-                    }
-                    href={playgroundLink.projectUpload()}
-                  >
-                    + 내 프로젝트 올리기
-                  </ActivityUploadButton>
-                  <ActivityUploadMaskImg src='/icons/img/project-mask.png' alt='project-mask-image' height={317} />
-                </ActivityUploadNudge>
-              )}
-            </>
-          )}
-        </ActivityContainer>
-        <ActivityContainer>
-          <ActivityTitle>{profile.name}님이 참여한 모임</ActivityTitle>
-          {meetingList.length > 0 && (
-            <>
-              <ActivitySub>{meetingList.length}개의 모임에 참여</ActivitySub>
-              <ActivityDisplay>
-                {meetingList.map((meeting) => (
-                  <MemberMeetingCard
-                    key={meeting.id}
-                    {...meeting}
-                    {...(meeting.isMeetingLeader && { userName: profile.name })}
-                  />
-                ))}
-              </ActivityDisplay>
-              <Target ref={ref} />
-            </>
-          )}
-          {meetingList.length === 0 && (
-            <>
-              <ActivitySub>아직 참여한 모임이 없어요</ActivitySub>
-              {String(me?.id) === memberId && (
-                <ActivityUploadNudge>
-                  <Text typography='SUIT_14_M' style={{ textAlign: 'center', lineHeight: '24px' }}>
-                    모임을 참여하여 <br />
-                    SOPT 구성원들과의 추억을 쌓아보세요!
-                  </Text>
-                  <ActivityUploadButton href={playgroundLink.groupList()}>모임 둘러보러 가기</ActivityUploadButton>
-                  <ActivityUploadMaskImg src='/icons/img/meeting-mask.png' alt='meeting-mask-image' height={134} />
-                </ActivityUploadNudge>
-              )}
-            </>
-          )}
-        </ActivityContainer>
+        <ProjectSection profile={profile} memberId={memberId} meId={me?.id} />
+
+        <GroupSection profile={profile} meetingList={meetingList} ref={ref} meId={me?.id} memberId={memberId} />
       </Wrapper>
     </Container>
   );
 };
+
+export default MemberDetail;
 
 const Container = styled.div`
   display: flex;
@@ -528,120 +433,6 @@ const ContactWrapper = styled.div<{ shouldDivide: boolean }>`
     margin-top: 16px;
   }
 `;
-
-const StyledAddressBadgeWrapper = styled.div`
-  display: flex;
-  flex-wrap: wrap;
-  gap: 8px;
-  align-items: center;
-
-  @media ${MOBILE_MEDIA_QUERY} {
-    gap: 10px;
-  }
-`;
-
-const AddressBadge = styled.div`
-  border-radius: 13px;
-  background-color: ${colors.gray700};
-  padding: 6px 14px;
-  line-height: 16px;
-  color: ${colors.gray10};
-
-  ${textStyles.SUIT_14_M};
-`;
-
-const ActivityContainer = styled.div`
-  margin-top: 80px;
-`;
-
-const ActivityTitle = styled.div`
-  line-height: 100%;
-  font-size: 32px;
-  font-weight: 700;
-  @media ${MOBILE_MEDIA_QUERY} {
-    font-size: 22px;
-  }
-`;
-
-const ActivitySub = styled.div`
-  margin-top: 18px;
-  line-height: 100%;
-  color: #989ba0;
-  font-size: 22px;
-  font-weight: 500;
-  @media ${MOBILE_MEDIA_QUERY} {
-    margin-top: 10px;
-    font-size: 14px;
-  }
-`;
-
-const ActivityDisplay = styled.div`
-  display: grid;
-  grid-template-columns: repeat(2, minmax(10px, 1fr));
-  row-gap: 20px;
-  column-gap: 29px;
-  margin-top: 32px;
-
-  @media ${MOBILE_MEDIA_QUERY} {
-    display: flex;
-    flex-direction: column;
-    gap: 24px;
-    margin-top: 24px;
-  }
-`;
-
-const ActivityUploadNudge = styled.div`
-  display: flex;
-  position: relative;
-  flex-direction: column;
-  align-items: center;
-  justify-content: center;
-  margin-top: 60px;
-  border-radius: 30px;
-  background-color: ${colors.gray800};
-  height: 317px;
-
-  @media ${MOBILE_MEDIA_QUERY} {
-    padding: 20px;
-    height: 212px;
-  }
-`;
-
-const ActivityUploadMaskImg = styled(ResizedImage)`
-  position: absolute;
-  max-height: 317px;
-  object-fit: cover;
-
-  @media ${MOBILE_MEDIA_QUERY} {
-    top: 0;
-    max-height: 134px;
-  }
-`;
-
-const ActivityUploadButton = styled(Link)`
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  z-index: 1;
-  margin-top: 24px;
-  border-radius: 14px;
-  background-color: ${colors.gray10};
-  padding: 14px 48px;
-  color: ${colors.gray800};
-
-  ${textStyles.SUIT_15_SB};
-
-  @media ${MOBILE_MEDIA_QUERY} {
-    margin-top: 50px;
-    width: 100%;
-  }
-`;
-
-const Target = styled.div`
-  width: 100%;
-`;
-
-export default MemberDetail;
 
 const ImageSection = styled.div`
   position: relative;

--- a/src/components/members/detail/ActivitySection/MemberDetail.tsx
+++ b/src/components/members/detail/ActivitySection/MemberDetail.tsx
@@ -65,18 +65,16 @@ const MemberDetail: FC<MemberDetailProps> = ({ memberId }) => {
 
         <SoptActivitySection soptActivities={sortedSoptActivities} />
 
-        {(profile.careers?.length > 0 || profile.skill || profile.links?.length > 0) && (
-          <CareerSection
-            careers={profile.careers}
-            links={profile.links}
-            skill={profile.skill}
-            name={profile.name}
-            email={profile.email}
-            profileImage={profile.profileImage}
-            memberId={memberId}
-            isMine={profile.isMine}
-          />
-        )}
+        <CareerSection
+          careers={profile.careers}
+          links={profile.links}
+          skill={profile.skill}
+          name={profile.name}
+          email={profile.email}
+          profileImage={profile.profileImage}
+          memberId={memberId}
+          isMine={profile.isMine}
+        />
 
         {(profile.sojuCapacity ||
           profile.mbti ||

--- a/src/components/members/detail/ActivitySection/MemberDetail.tsx
+++ b/src/components/members/detail/ActivitySection/MemberDetail.tsx
@@ -1,39 +1,18 @@
 import styled from '@emotion/styled';
-import { colors } from '@sopt-makers/colors';
-import { fonts } from '@sopt-makers/fonts';
-import { IconAlertTriangle, IconUserX } from '@sopt-makers/icons';
-import { Flex } from '@toss/emotion-utils';
-import axios from 'axios';
-import { uniq } from 'lodash-es';
-import Link from 'next/link';
-import { useRouter } from 'next/router';
-import CallIcon from 'public/icons/icon-call.svg';
-import EditIcon from 'public/icons/icon-edit.svg';
-import MailIcon from 'public/icons/icon-mail.svg';
-import ProfileIcon from 'public/icons/icon-profile.svg';
 import { FC, useMemo } from 'react';
 
-import { useGetMemberCrewInfiniteQuery } from '@/api/endpoint/members/getMemberCrew';
 import { useGetMemberOfMe } from '@/api/endpoint/members/getMemberOfMe';
 import { useGetMemberProfileById } from '@/api/endpoint_LEGACY/hooks';
 import Loading from '@/components/common/Loading';
-import ResizedImage from '@/components/common/ResizedImage';
 import useEventLogger from '@/components/eventLogger/hooks/useEventLogger';
-import FeedDropdown from '@/components/feed/common/FeedDropdown';
 import CareerSection from '@/components/members/detail/CareerSection';
 import DetailInfoSection from '@/components/members/detail/DetailinfoSection';
-import EmptyProfile from '@/components/members/detail/EmptyProfile';
 import GroupSection from '@/components/members/detail/GroupSection';
 import InterestSection from '@/components/members/detail/InterestSection';
+import ProfileSection from '@/components/members/detail/ProfileSection';
 import ProjectSection from '@/components/members/detail/ProjectSection';
 import SoptActivitySection from '@/components/members/detail/SoptActivitySection';
-import { useBlockMember } from '@/components/members/hooks/useBlockMember';
-import { useReportMember } from '@/components/members/hooks/useReportMember';
-import { playgroundLink } from '@/constants/links';
-import useEnterScreen from '@/hooks/useEnterScreen';
 import { useRunOnce } from '@/hooks/useRunOnce';
-import IconCoffee from '@/public/icons/icon-coffee.svg';
-import IconMore from '@/public/icons/icon-dots-vertical.svg';
 import { MOBILE_MEDIA_QUERY } from '@/styles/mediaQuery';
 import { safeParseInt } from '@/utils';
 
@@ -42,27 +21,15 @@ interface MemberDetailProps {
 }
 
 const MemberDetail: FC<MemberDetailProps> = ({ memberId }) => {
-  const { logClickEvent, logPageViewEvent } = useEventLogger();
-  const router = useRouter();
-
-  const { ref } = useEnterScreen({
-    onEnter: () => {
-      fetchNextPage();
-    },
-  });
+  const { logPageViewEvent } = useEventLogger();
 
   const {
     data: profile,
     isLoading,
     error: profileError,
   } = useGetMemberProfileById(safeParseInt(memberId) ?? undefined);
-  const {
-    data: memberCrewData,
-    fetchNextPage,
-    error: crewError,
-  } = useGetMemberCrewInfiniteQuery(20, safeParseInt(memberId) ?? undefined);
+
   const { data: me } = useGetMemberOfMe();
-  const meetingList = memberCrewData?.pages.map((page) => page.meetings).flat() ?? [];
 
   const sortedSoptActivities = useMemo(() => {
     if (!profile?.soptActivities) {
@@ -82,13 +49,6 @@ const MemberDetail: FC<MemberDetailProps> = ({ memberId }) => {
     }
   }, [profile, memberId]);
 
-  const { handleReportMember } = useReportMember();
-  const { handleBlockMember } = useBlockMember();
-
-  if (profileError?.response?.status === 400 || (axios.isAxiosError(crewError) && crewError.response?.status === 400)) {
-    return <EmptyProfile />;
-  }
-
   if (isLoading || !profile)
     return (
       <Container>
@@ -99,83 +59,7 @@ const MemberDetail: FC<MemberDetailProps> = ({ memberId }) => {
   return (
     <Container>
       <Wrapper>
-        <ProfileContainer>
-          <ImageSection>
-            {profile.profileImage ? (
-              <ProfileImage src={profile.profileImage} height={171} />
-            ) : (
-              <EmptyProfileImage>
-                <ProfileIcon />
-              </EmptyProfileImage>
-            )}
-            {profile.isCoffeeChatActivate && (
-              <IconContainer>
-                <IconCoffee />
-              </IconContainer>
-            )}
-          </ImageSection>
-          <ProfileContents>
-            <NameWrapper>
-              <div className='name'>{profile.name}</div>
-              <div className='part'>{uniq(profile.soptActivities.map(({ part }) => part)).join('/')}</div>
-            </NameWrapper>
-            <div className='intro'>{profile.introduction}</div>
-            <ContactWrapper shouldDivide={!!profile.phone && !!profile.email}>
-              {profile.phone && (
-                <Link passHref href={`tel:${profile.phone}`} legacyBehavior>
-                  <div style={{ cursor: 'pointer' }}>
-                    <CallIcon />
-                    <div className='phone'>{profile.phone}</div>
-                  </div>
-                </Link>
-              )}
-              {profile.email && (
-                <Link passHref href={`mailto:${profile.email}`} legacyBehavior>
-                  <div style={{ cursor: 'pointer' }}>
-                    <MailIcon />
-                    <div className='email'>{profile.email}</div>
-                  </div>
-                </Link>
-              )}
-            </ContactWrapper>
-          </ProfileContents>
-
-          {profile.isMine ? (
-            <EditButton
-              onClick={() => {
-                router.push(playgroundLink.memberEdit());
-                logClickEvent('editProfile');
-              }}
-            >
-              <EditIcon />
-            </EditButton>
-          ) : (
-            <MoreIconContainer>
-              <FeedDropdown trigger={<StyledIconMore />}>
-                <FeedDropdown.Item
-                  onClick={() => {
-                    handleReportMember(safeParseInt(memberId) ?? undefined);
-                  }}
-                >
-                  <Flex align='center' css={{ gap: '10px', color: `${colors.gray10}` }}>
-                    <IconAlertTriangle css={{ width: '16px', height: '16px' }} />
-                    신고
-                  </Flex>
-                </FeedDropdown.Item>
-                <FeedDropdown.Item
-                  type='danger'
-                  onClick={() => {
-                    handleBlockMember(safeParseInt(memberId) ?? undefined);
-                  }}
-                >
-                  <Flex align='center' css={{ gap: '10px' }}>
-                    <IconUserX css={{ width: '16px', height: '16px' }} /> 차단
-                  </Flex>
-                </FeedDropdown.Item>
-              </FeedDropdown>
-            </MoreIconContainer>
-          )}
-        </ProfileContainer>
+        <ProfileSection profile={profile} memberId={memberId} />
 
         <DetailInfoSection profile={profile} />
 
@@ -229,7 +113,7 @@ const MemberDetail: FC<MemberDetailProps> = ({ memberId }) => {
 
         <ProjectSection profile={profile} memberId={memberId} meId={me?.id} />
 
-        <GroupSection profile={profile} meetingList={meetingList} ref={ref} meId={me?.id} memberId={memberId} />
+        <GroupSection profile={profile} meId={me?.id} memberId={memberId} />
       </Wrapper>
     </Container>
   );
@@ -256,232 +140,5 @@ const Wrapper = styled.div`
   @media ${MOBILE_MEDIA_QUERY} {
     gap: 24px;
     width: 100%;
-  }
-`;
-
-const ProfileContainer = styled.div`
-  display: flex;
-  position: relative;
-  gap: 33px;
-  align-items: center;
-  width: 100%;
-  letter-spacing: -0.01em;
-  font-weight: 500;
-  @media ${MOBILE_MEDIA_QUERY} {
-    gap: 20px;
-    align-items: flex-start;
-  }
-`;
-
-const EmptyProfileImage = styled.div`
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  border-radius: 36px;
-  background: ${colors.gray700};
-  width: 171px;
-  height: 171px;
-  @media ${MOBILE_MEDIA_QUERY} {
-    border-radius: 20px;
-    width: 78px;
-    min-width: 78px;
-    height: 78px;
-
-    & > svg {
-      width: 40px;
-      height: 40px;
-    }
-  }
-`;
-
-const ProfileImage = styled(ResizedImage)`
-  border-radius: 36px;
-  width: 171px;
-  height: 171px;
-  object-fit: cover;
-  @media ${MOBILE_MEDIA_QUERY} {
-    border-radius: 20px;
-    width: 100px;
-    height: 100px;
-  }
-`;
-
-const ProfileContents = styled.div`
-  display: flex;
-  flex-direction: column;
-  justify-content: space-between;
-  width: 100%;
-  height: 128px;
-
-  .intro {
-    margin-top: 16px;
-    color: #c0c5c9;
-    ${fonts.BODY_16_M}
-
-    @media ${MOBILE_MEDIA_QUERY} {
-      margin-top: 8px;
-
-      ${fonts.BODY_14_M}
-    }
-  }
-
-  @media ${MOBILE_MEDIA_QUERY} {
-    width: 171px;
-    height: auto;
-  }
-`;
-
-const EditButton = styled.div`
-  display: flex;
-  position: absolute;
-  top: 22px;
-  right: 0;
-  align-items: center;
-  justify-content: center;
-  border-radius: 50%;
-  background: #2c2d2e;
-  cursor: pointer;
-  width: 40px;
-  height: 40px;
-
-  svg {
-    width: 26.05px;
-    height: auto;
-  }
-
-  @media ${MOBILE_MEDIA_QUERY} {
-    top: 5px;
-    width: 32px;
-    height: 32px;
-
-    svg {
-      width: 19.26px;
-    }
-  }
-`;
-
-const NameWrapper = styled.div`
-  display: flex;
-  gap: 12px;
-  align-items: center;
-
-  .name {
-    ${fonts.HEADING_32_B}
-    @media ${MOBILE_MEDIA_QUERY} {
-      ${fonts.HEADING_24_B}
-    }
-  }
-
-  .part {
-    color: #808388;
-    ${fonts.BODY_16_M}
-
-    @media ${MOBILE_MEDIA_QUERY} {
-      ${fonts.BODY_14_M}
-    }
-  }
-
-  @media ${MOBILE_MEDIA_QUERY} {
-    display: flex;
-    flex-direction: column;
-    gap: 0;
-    align-items: flex-start;
-  }
-`;
-
-const ContactWrapper = styled.div<{ shouldDivide: boolean }>`
-  display: flex;
-  line-height: 100%;
-  color: #808388;
-  font-size: 14px;
-
-  & > div {
-    display: flex;
-    gap: 4px;
-    align-items: center;
-
-    @media ${MOBILE_MEDIA_QUERY} {
-      gap: 7px;
-    }
-  }
-
-  .phone {
-    box-sizing: border-box;
-    margin-right: 13px;
-    border-right: ${({ shouldDivide }) => (shouldDivide ? '1.5px solid #3c3d40' : 'none')};
-    padding-right: 17px;
-    @media ${MOBILE_MEDIA_QUERY} {
-      margin: 0;
-      border: 0;
-      padding: 0;
-    }
-  }
-
-  .email {
-    max-width: 140px;
-    overflow: visible;
-  }
-
-  svg {
-    width: 20px;
-    height: auto;
-  }
-
-  @media ${MOBILE_MEDIA_QUERY} {
-    flex-direction: column;
-    gap: 4px;
-    margin-top: 16px;
-  }
-`;
-
-const ImageSection = styled.div`
-  position: relative;
-`;
-
-const IconContainer = styled.div`
-  display: flex;
-  position: absolute;
-  top: -8px;
-  right: -8px;
-  align-items: center;
-  justify-content: center;
-  border-radius: 50%;
-  background: ${colors.blue400};
-  padding: 5px;
-  width: 32px;
-  height: 32px;
-
-  @media ${MOBILE_MEDIA_QUERY} {
-    padding: 3px;
-    width: 26px;
-    height: 26px;
-
-    & > svg {
-      width: 19px;
-      height: 19px;
-    }
-  }
-`;
-
-const MoreIconContainer = styled.div`
-  position: relative;
-  width: auto;
-  height: 171px;
-  text-align: right;
-
-  @media ${MOBILE_MEDIA_QUERY} {
-    width: 100%;
-    height: auto;
-  }
-`;
-
-const StyledIconMore = styled(IconMore)`
-  cursor: pointer;
-  padding-top: 12px;
-  width: 24px;
-  height: 24px;
-
-  @media ${MOBILE_MEDIA_QUERY} {
-    padding-top: 4px;
   }
 `;

--- a/src/components/members/detail/CareerSection/index.tsx
+++ b/src/components/members/detail/CareerSection/index.tsx
@@ -1,19 +1,19 @@
 import styled from '@emotion/styled';
 import { Slot } from '@radix-ui/react-slot';
 import { colors } from '@sopt-makers/colors';
+import { fonts } from '@sopt-makers/fonts';
 import Link from 'next/link';
+import { useRouter } from 'next/router';
+import { playgroundLink } from 'playground-common/export';
 
 import { MemberLink } from '@/api/endpoint_LEGACY/members/type';
 import MemberDetailSection from '@/components/members/detail/ActivitySection/MemberDetailSection';
 import CareerItem from '@/components/members/detail/CareerSection/CareerItem';
 import InfoItem from '@/components/members/detail/InfoItem';
+import MessageSection from '@/components/members/detail/MessageSection';
 import { Career } from '@/components/members/detail/types';
 import { MOBILE_MEDIA_QUERY } from '@/styles/mediaQuery';
-import MessageSection from '@/components/members/detail/MessageSection';
 import { textStyles } from '@/styles/typography';
-import { playgroundLink } from 'playground-common/export';
-import { useRouter } from 'next/router';
-import { fonts } from '@sopt-makers/fonts';
 
 interface CareerSectionProps {
   careers: Career[];
@@ -41,7 +41,9 @@ export default function CareerSection({
   const router = useRouter();
   const Container = shouldNeedOnlyItems ? Slot : StyledMemberDetailSection;
 
-  return (
+  const hasCareerOrSkillOrLinks = careers?.length > 0 || skill?.length > 0 || links?.length > 0;
+
+  return hasCareerOrSkillOrLinks ? (
     <Container>
       <>
         {careers?.length > 0 && (
@@ -85,7 +87,7 @@ export default function CareerSection({
         <MessageSection name={name} email={email} profileImage={profileImage} memberId={memberId} />
       )}
     </Container>
-  );
+  ) : null;
 }
 
 const StyledLink = styled(Link)`

--- a/src/components/members/detail/DetailinfoSection/index.stories.tsx
+++ b/src/components/members/detail/DetailinfoSection/index.stories.tsx
@@ -1,0 +1,18 @@
+import { Meta } from '@storybook/react';
+
+import DetailInfoSection from './index';
+
+export default {
+  component: DetailInfoSection,
+} as Meta<typeof DetailInfoSection>;
+
+export const Default = {
+  args: {
+    profile: {
+      birthday: '2000-09-09',
+      university: '서울대학교',
+      major: '컴퓨터공학',
+      address: '어린이대공원역',
+    },
+  },
+};

--- a/src/components/members/detail/DetailinfoSection/index.tsx
+++ b/src/components/members/detail/DetailinfoSection/index.tsx
@@ -1,0 +1,68 @@
+import styled from '@emotion/styled';
+import { colors } from '@sopt-makers/colors';
+import dayjs from 'dayjs';
+
+import { ProfileDetail } from '@/api/endpoint_LEGACY/members/type';
+import Text from '@/components/common/Text';
+import MemberDetailSection from '@/components/members/detail/ActivitySection/MemberDetailSection';
+import InfoItem from '@/components/members/detail/InfoItem';
+import { DEFAULT_DATE } from '@/components/members/upload/constants';
+import { MOBILE_MEDIA_QUERY } from '@/styles/mediaQuery';
+
+interface DetailInfoSectionProps {
+  profile: ProfileDetail;
+}
+
+const convertBirthdayFormat = (birthday?: string) => {
+  // FIXME: 서버쪽에 YYYY-MM-DD 형태로 무조건 업로드시 전송해줘야 하는 이슈가 있어서,
+  // 생년월일을 보내지 않았을 경우에 DEFAULT_DATE를 전송하도록 임시처리 해 두었습니다. 이를 클라에서 보여주기 위해 대응합니다.
+  if (birthday) {
+    const isDefaultDay = dayjs(birthday).isSame(dayjs(DEFAULT_DATE));
+    return isDefaultDay ? '' : dayjs(birthday).format('YYYY-MM-DD');
+  }
+  return '';
+};
+
+const DetailInfoSection = ({ profile }: DetailInfoSectionProps) => {
+  const hasProfileInfo = profile.birthday || profile.university || profile.major || profile.address;
+
+  return hasProfileInfo ? (
+    <MemberDetailSection style={{ gap: '30px' }}>
+      {profile.birthday && <InfoItem label='생년월일' content={convertBirthdayFormat(profile.birthday)} />}
+      {profile.university && <InfoItem label='학교'>{profile.university}</InfoItem>}
+      {profile.major && <InfoItem label='전공'>{profile.major}</InfoItem>}
+      {profile.address && (
+        <InfoItem label='활동 지역'>
+          <StyledAddressBadgeWrapper>
+            {profile.address.split(',').map((address) => (
+              <AddressBadge key={address}>
+                <Text typography='SUIT_14_M'>{address}</Text>
+              </AddressBadge>
+            ))}
+          </StyledAddressBadgeWrapper>
+        </InfoItem>
+      )}
+    </MemberDetailSection>
+  ) : null;
+};
+
+export default DetailInfoSection;
+
+const StyledAddressBadgeWrapper = styled.div`
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  align-items: center;
+
+  @media ${MOBILE_MEDIA_QUERY} {
+    gap: 10px;
+  }
+`;
+
+const AddressBadge = styled.div`
+  border-radius: 13px;
+  background-color: ${colors.gray700};
+  padding: 6px 14px;
+  line-height: 16px;
+  color: ${colors.gray10};
+`;

--- a/src/components/members/detail/GroupSection/index.stories.tsx
+++ b/src/components/members/detail/GroupSection/index.stories.tsx
@@ -1,0 +1,29 @@
+import { Meta } from '@storybook/react';
+
+import GroupSection from './index';
+
+export default {
+  component: GroupSection,
+} as Meta<typeof GroupSection>;
+
+export const Default = {
+  args: {
+    profile: {
+      name: '홍길동',
+    },
+    meetingList: [
+      {
+        id: 1,
+        category: '스터디',
+        imageUrl:
+          'https://wsrv.nl/?url=https%3A%2F%2Fs3.ap-northeast-2.amazonaws.com%2Fsopt-makers-internal%2F%2Fdev%2Fimage%2Fproject%2F08e783ca-e3bd-4144-9b29-fcf543ab3b27-tossfeed-thumbnail.png&h=168&output=webp',
+        isActiveMeeting: true,
+        isMeetingLeader: false,
+        mendDate: '2025-12-25T00:00:00',
+        mstartDate: '2024-12-25T00:00:00',
+        title: '스터디 테스트 ~',
+      },
+    ],
+  },
+  name: 'Default',
+};

--- a/src/components/members/detail/GroupSection/index.tsx
+++ b/src/components/members/detail/GroupSection/index.tsx
@@ -1,0 +1,150 @@
+import styled from '@emotion/styled';
+import { colors } from '@sopt-makers/colors';
+import Link from 'next/link';
+
+import { MeetingsResponse } from '@/api/endpoint/members/getMemberCrew';
+import { ProfileDetail } from '@/api/endpoint_LEGACY/members/type';
+import ResizedImage from '@/components/common/ResizedImage';
+import Text from '@/components/common/Text';
+import MemberMeetingCard from '@/components/members/detail/ActivitySection/MemberMeetingCard';
+import { playgroundLink } from '@/constants/links';
+import { MOBILE_MEDIA_QUERY } from '@/styles/mediaQuery';
+
+interface GroupSectionProps {
+  profile: ProfileDetail;
+  meetingList: MeetingsResponse;
+  ref: React.RefObject<HTMLDivElement>;
+  meId?: number | undefined;
+  memberId: string;
+}
+
+const GroupSection = ({ profile, meetingList, ref, meId, memberId }: GroupSectionProps) => {
+  return (
+    <Container>
+      <ActivityTitle>{profile.name}님이 참여한 모임</ActivityTitle>
+      {meetingList.length > 0 && (
+        <>
+          <ActivitySub>{meetingList.length}개의 모임에 참여</ActivitySub>
+          <ActivityDisplay>
+            {meetingList.map((meeting) => (
+              <MemberMeetingCard
+                key={meeting.id}
+                {...meeting}
+                {...(meeting.isMeetingLeader && { userName: profile.name })}
+              />
+            ))}
+          </ActivityDisplay>
+          <Target ref={ref} />
+        </>
+      )}
+      {meetingList.length === 0 && (
+        <>
+          <ActivitySub>아직 참여한 모임이 없어요</ActivitySub>
+          {String(meId) === memberId && (
+            <ActivityUploadNudge>
+              <Text typography='SUIT_14_M' style={{ textAlign: 'center', lineHeight: '24px' }}>
+                모임을 참여하여 <br />
+                SOPT 구성원들과의 추억을 쌓아보세요!
+              </Text>
+              <ActivityUploadButton href={playgroundLink.groupList()}>
+                <Text typography='SUIT_15_SB'>모임 둘러보러 가기</Text>
+              </ActivityUploadButton>
+              <ActivityUploadMaskImg src='/icons/img/meeting-mask.png' alt='meeting-mask-image' height={134} />
+            </ActivityUploadNudge>
+          )}
+        </>
+      )}
+    </Container>
+  );
+};
+
+export default GroupSection;
+
+const Container = styled.section`
+  margin-top: 80px;
+`;
+
+const ActivityTitle = styled.div`
+  line-height: 100%;
+  font-size: 32px;
+  font-weight: 700;
+  @media ${MOBILE_MEDIA_QUERY} {
+    font-size: 22px;
+  }
+`;
+
+const ActivitySub = styled.div`
+  margin-top: 18px;
+  line-height: 100%;
+  color: #989ba0;
+  font-size: 22px;
+  font-weight: 500;
+  @media ${MOBILE_MEDIA_QUERY} {
+    margin-top: 10px;
+    font-size: 14px;
+  }
+`;
+
+const ActivityDisplay = styled.div`
+  display: grid;
+  grid-template-columns: repeat(2, minmax(10px, 1fr));
+  row-gap: 20px;
+  column-gap: 29px;
+  margin-top: 32px;
+
+  @media ${MOBILE_MEDIA_QUERY} {
+    display: flex;
+    flex-direction: column;
+    gap: 24px;
+    margin-top: 24px;
+  }
+`;
+
+const ActivityUploadNudge = styled.div`
+  display: flex;
+  position: relative;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  margin-top: 60px;
+  border-radius: 30px;
+  background-color: ${colors.gray800};
+  height: 317px;
+
+  @media ${MOBILE_MEDIA_QUERY} {
+    padding: 20px;
+    height: 212px;
+  }
+`;
+
+const ActivityUploadMaskImg = styled(ResizedImage)`
+  position: absolute;
+  max-height: 317px;
+  object-fit: cover;
+
+  @media ${MOBILE_MEDIA_QUERY} {
+    top: 0;
+    max-height: 134px;
+  }
+`;
+
+const ActivityUploadButton = styled(Link)`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1;
+  margin-top: 24px;
+  border-radius: 14px;
+  background-color: ${colors.gray10};
+  padding: 14px 48px;
+  color: ${colors.gray800};
+
+  @media ${MOBILE_MEDIA_QUERY} {
+    margin-top: 50px;
+    width: 100%;
+  }
+`;
+
+const Target = styled.div`
+  width: 100%;
+`;

--- a/src/components/members/detail/MessageSection/index.tsx
+++ b/src/components/members/detail/MessageSection/index.tsx
@@ -1,13 +1,13 @@
-import MessageModal, { MessageCategory } from '@/components/members/detail/MessageSection/MessageModal';
-
-import { MOBILE_MEDIA_QUERY } from '@/styles/mediaQuery';
-import { colors } from '@sopt-makers/colors';
+import { css } from '@emotion/react';
 import styled from '@emotion/styled';
-import { textStyles } from '@/styles/typography';
-import useEventLogger from '@/components/eventLogger/hooks/useEventLogger';
+import { colors } from '@sopt-makers/colors';
+
 import useModalState from '@/components/common/Modal/useModalState';
 import useToast from '@/components/common/Toast/useToast';
-import { css } from '@emotion/react';
+import useEventLogger from '@/components/eventLogger/hooks/useEventLogger';
+import MessageModal, { MessageCategory } from '@/components/members/detail/MessageSection/MessageModal';
+import { MOBILE_MEDIA_QUERY } from '@/styles/mediaQuery';
+import { textStyles } from '@/styles/typography';
 
 interface MessageSectionProps {
   name: string;
@@ -21,7 +21,7 @@ export default function MessageSection({ name, email, profileImage, memberId }: 
   const toast = useToast();
   const { logSubmitEvent } = useEventLogger();
 
-  const isEmptyEmail = email === null || email.length < 1;
+  const isEmptyEmail = !email || email.length < 1;
 
   const handleClickMessageButton = () => {
     if (isEmptyEmail) {

--- a/src/components/members/detail/ProfileSection/index.stories.tsx
+++ b/src/components/members/detail/ProfileSection/index.stories.tsx
@@ -1,0 +1,36 @@
+import { Meta } from '@storybook/react';
+
+import ProfileSection from '@/components/members/detail/ProfileSection';
+
+export default {
+  component: ProfileSection,
+} as Meta<typeof ProfileSection>;
+
+export const Default = {
+  args: {
+    profile: {
+      name: '정도영',
+      introduction: '안녕하시오와',
+      profileImage:
+        'https://s3.ap-northeast-2.amazonaws.com/sopt-makers-internal//dev/image/project/dded5fe2-1264-4449-bbff-65b21a6de01f-77208067.jpeg',
+      birthday: '1998-02-14',
+      isPhonelind: true,
+      phone: '010-1234-5678',
+      email: 'byebye@naver.com',
+      soptActivities: [
+        {
+          generation: 30,
+          part: 'iOS',
+          team: null,
+          projects: [],
+        },
+      ],
+
+      allowOfficial: false,
+      isCoffeeChatActivate: false,
+      coffeeChatBio: null,
+      isMine: false,
+    },
+  },
+  name: 'Default',
+};

--- a/src/components/members/detail/ProfileSection/index.tsx
+++ b/src/components/members/detail/ProfileSection/index.tsx
@@ -1,0 +1,346 @@
+import styled from '@emotion/styled';
+import { colors } from '@sopt-makers/colors';
+import { fonts } from '@sopt-makers/fonts';
+import { IconAlertTriangle, IconUserX } from '@sopt-makers/icons';
+import { Flex } from '@toss/emotion-utils';
+import { uniq } from 'lodash-es';
+import Link from 'next/link';
+import { useRouter } from 'next/router';
+import { playgroundLink } from 'playground-common/export';
+import CallIcon from 'public/icons/icon-call.svg';
+import EditIcon from 'public/icons/icon-edit.svg';
+import MailIcon from 'public/icons/icon-mail.svg';
+import ProfileIcon from 'public/icons/icon-profile.svg';
+
+import { ProfileDetail } from '@/api/endpoint_LEGACY/members/type';
+import ResizedImage from '@/components/common/ResizedImage';
+import useEventLogger from '@/components/eventLogger/hooks/useEventLogger';
+import FeedDropdown from '@/components/feed/common/FeedDropdown';
+import { useBlockMember } from '@/components/members/hooks/useBlockMember';
+import { useReportMember } from '@/components/members/hooks/useReportMember';
+import IconCoffee from '@/public/icons/icon-coffee.svg';
+import IconMore from '@/public/icons/icon-dots-vertical.svg';
+import { MOBILE_MEDIA_QUERY } from '@/styles/mediaQuery';
+import { safeParseInt } from '@/utils';
+
+interface ProfileSectionProps {
+  profile: ProfileDetail;
+  memberId: string;
+}
+
+const ProfileSection = ({ profile, memberId }: ProfileSectionProps) => {
+  const router = useRouter();
+  const { logClickEvent } = useEventLogger();
+
+  const { handleReportMember } = useReportMember();
+  const { handleBlockMember } = useBlockMember();
+
+  return (
+    <ProfileContainer>
+      <ImageSection>
+        {profile.profileImage ? (
+          <ProfileImage src={profile.profileImage} height={171} />
+        ) : (
+          <EmptyProfileImage>
+            <ProfileIcon />
+          </EmptyProfileImage>
+        )}
+        {profile.isCoffeeChatActivate && (
+          <IconContainer>
+            <IconCoffee />
+          </IconContainer>
+        )}
+      </ImageSection>
+      <ProfileContents>
+        <NameWrapper>
+          <div className='name'>{profile.name}</div>
+          <div className='part'>{uniq(profile.soptActivities.map(({ part }) => part)).join('/')}</div>
+        </NameWrapper>
+        <div className='intro'>{profile.introduction}</div>
+        <ContactWrapper shouldDivide={!!profile.phone && !!profile.email}>
+          {profile.phone && (
+            <Link passHref href={`tel:${profile.phone}`} legacyBehavior>
+              <div style={{ cursor: 'pointer' }}>
+                <CallIcon />
+                <div className='phone'>{profile.phone}</div>
+              </div>
+            </Link>
+          )}
+          {profile.email && (
+            <Link passHref href={`mailto:${profile.email}`} legacyBehavior>
+              <div style={{ cursor: 'pointer' }}>
+                <MailIcon />
+                <div className='email'>{profile.email}</div>
+              </div>
+            </Link>
+          )}
+        </ContactWrapper>
+      </ProfileContents>
+
+      {profile.isMine ? (
+        <EditButton
+          onClick={() => {
+            router.push(playgroundLink.memberEdit());
+            logClickEvent('editProfile');
+          }}
+        >
+          <EditIcon />
+        </EditButton>
+      ) : (
+        <MoreIconContainer>
+          <FeedDropdown trigger={<StyledIconMore />}>
+            <FeedDropdown.Item
+              onClick={() => {
+                handleReportMember(safeParseInt(memberId) ?? undefined);
+              }}
+            >
+              <Flex align='center' css={{ gap: '10px', color: `${colors.gray10}` }}>
+                <IconAlertTriangle css={{ width: '16px', height: '16px' }} />
+                신고
+              </Flex>
+            </FeedDropdown.Item>
+            <FeedDropdown.Item
+              type='danger'
+              onClick={() => {
+                handleBlockMember(safeParseInt(memberId) ?? undefined);
+              }}
+            >
+              <Flex align='center' css={{ gap: '10px' }}>
+                <IconUserX css={{ width: '16px', height: '16px' }} /> 차단
+              </Flex>
+            </FeedDropdown.Item>
+          </FeedDropdown>
+        </MoreIconContainer>
+      )}
+    </ProfileContainer>
+  );
+};
+
+export default ProfileSection;
+
+const ProfileContainer = styled.div`
+  display: flex;
+  position: relative;
+  gap: 33px;
+  align-items: center;
+  width: 100%;
+  letter-spacing: -0.01em;
+  font-weight: 500;
+  @media ${MOBILE_MEDIA_QUERY} {
+    gap: 20px;
+    align-items: flex-start;
+  }
+`;
+
+const EmptyProfileImage = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 36px;
+  background: ${colors.gray700};
+  width: 171px;
+  height: 171px;
+  @media ${MOBILE_MEDIA_QUERY} {
+    border-radius: 20px;
+    width: 78px;
+    min-width: 78px;
+    height: 78px;
+
+    & > svg {
+      width: 40px;
+      height: 40px;
+    }
+  }
+`;
+
+const ProfileImage = styled(ResizedImage)`
+  border-radius: 36px;
+  width: 171px;
+  height: 171px;
+  object-fit: cover;
+  @media ${MOBILE_MEDIA_QUERY} {
+    border-radius: 20px;
+    width: 100px;
+    height: 100px;
+  }
+`;
+
+const ProfileContents = styled.div`
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  width: 100%;
+  height: 128px;
+
+  .intro {
+    margin-top: 16px;
+    color: #c0c5c9;
+    ${fonts.BODY_16_M}
+
+    @media ${MOBILE_MEDIA_QUERY} {
+      margin-top: 8px;
+
+      ${fonts.BODY_14_M}
+    }
+  }
+
+  @media ${MOBILE_MEDIA_QUERY} {
+    width: 171px;
+    height: auto;
+  }
+`;
+
+const EditButton = styled.div`
+  display: flex;
+  position: absolute;
+  top: 22px;
+  right: 0;
+  align-items: center;
+  justify-content: center;
+  border-radius: 50%;
+  background: #2c2d2e;
+  cursor: pointer;
+  width: 40px;
+  height: 40px;
+
+  svg {
+    width: 26.05px;
+    height: auto;
+  }
+
+  @media ${MOBILE_MEDIA_QUERY} {
+    top: 5px;
+    width: 32px;
+    height: 32px;
+
+    svg {
+      width: 19.26px;
+    }
+  }
+`;
+
+const NameWrapper = styled.div`
+  display: flex;
+  gap: 12px;
+  align-items: center;
+
+  .name {
+    ${fonts.HEADING_32_B}
+    @media ${MOBILE_MEDIA_QUERY} {
+      ${fonts.HEADING_24_B}
+    }
+  }
+
+  .part {
+    color: #808388;
+    ${fonts.BODY_16_M}
+
+    @media ${MOBILE_MEDIA_QUERY} {
+      ${fonts.BODY_14_M}
+    }
+  }
+
+  @media ${MOBILE_MEDIA_QUERY} {
+    display: flex;
+    flex-direction: column;
+    gap: 0;
+    align-items: flex-start;
+  }
+`;
+
+const ContactWrapper = styled.div<{ shouldDivide: boolean }>`
+  display: flex;
+  line-height: 100%;
+  color: #808388;
+  font-size: 14px;
+
+  & > div {
+    display: flex;
+    gap: 4px;
+    align-items: center;
+
+    @media ${MOBILE_MEDIA_QUERY} {
+      gap: 7px;
+    }
+  }
+
+  .phone {
+    box-sizing: border-box;
+    margin-right: 13px;
+    border-right: ${({ shouldDivide }) => (shouldDivide ? '1.5px solid #3c3d40' : 'none')};
+    padding-right: 17px;
+    @media ${MOBILE_MEDIA_QUERY} {
+      margin: 0;
+      border: 0;
+      padding: 0;
+    }
+  }
+
+  .email {
+    max-width: 140px;
+    overflow: visible;
+  }
+
+  svg {
+    width: 20px;
+    height: auto;
+  }
+
+  @media ${MOBILE_MEDIA_QUERY} {
+    flex-direction: column;
+    gap: 4px;
+    margin-top: 16px;
+  }
+`;
+
+const ImageSection = styled.div`
+  position: relative;
+`;
+
+const IconContainer = styled.div`
+  display: flex;
+  position: absolute;
+  top: -8px;
+  right: -8px;
+  align-items: center;
+  justify-content: center;
+  border-radius: 50%;
+  background: ${colors.blue400};
+  padding: 5px;
+  width: 32px;
+  height: 32px;
+
+  @media ${MOBILE_MEDIA_QUERY} {
+    padding: 3px;
+    width: 26px;
+    height: 26px;
+
+    & > svg {
+      width: 19px;
+      height: 19px;
+    }
+  }
+`;
+
+const MoreIconContainer = styled.div`
+  position: relative;
+  width: auto;
+  height: 171px;
+  text-align: right;
+
+  @media ${MOBILE_MEDIA_QUERY} {
+    width: 100%;
+    height: auto;
+  }
+`;
+
+const StyledIconMore = styled(IconMore)`
+  cursor: pointer;
+  padding-top: 12px;
+  width: 24px;
+  height: 24px;
+
+  @media ${MOBILE_MEDIA_QUERY} {
+    padding-top: 4px;
+  }
+`;

--- a/src/components/members/detail/ProjectSection/index.stories.tsx
+++ b/src/components/members/detail/ProjectSection/index.stories.tsx
@@ -1,0 +1,38 @@
+import { Meta } from '@storybook/react';
+
+import ProjectSection from '@/components/members/detail/ProjectSection';
+
+export default {
+  component: ProjectSection,
+} as Meta<typeof ProjectSection>;
+
+export const Default = {
+  args: {
+    profile: {
+      name: '홍길동',
+      projects: [
+        {
+          id: 1,
+          category: 'APPJAM',
+          generation: 35,
+          serviceType: ['WEB'],
+          name: '프로젝트 이름1',
+          summary: '프로젝트 요약1',
+          thumbnailImage:
+            'https://wsrv.nl/?url=https%3A%2F%2Fs3.ap-northeast-2.amazonaws.com%2Fsopt-makers-internal%2F%2Fdev%2Fimage%2Fproject%2F297aefa4-f06f-4aff-b017-3308c26cf534-3d_chunsik.png&h=168&output=webp',
+        },
+        {
+          id: 2,
+          category: 'SOPKATHON',
+          generation: 34,
+          serviceType: ['APP'],
+          name: '프로젝트 이름2',
+          summary: '프로젝트 요약2',
+          thumbnailImage:
+            'https://wsrv.nl/?url=https%3A%2F%2Fs3.ap-northeast-2.amazonaws.com%2Fsopt-makers-internal%2F%2Fdev%2Fimage%2Fproject%2F08e783ca-e3bd-4144-9b29-fcf543ab3b27-tossfeed-thumbnail.png&h=168&output=webp',
+        },
+      ],
+    },
+  },
+  name: 'Default',
+};

--- a/src/components/members/detail/ProjectSection/index.tsx
+++ b/src/components/members/detail/ProjectSection/index.tsx
@@ -1,0 +1,148 @@
+import styled from '@emotion/styled';
+import { colors } from '@sopt-makers/colors';
+import Link from 'next/link';
+import { playgroundLink } from 'playground-common/export';
+
+import { ProfileDetail } from '@/api/endpoint_LEGACY/members/type';
+import ResizedImage from '@/components/common/ResizedImage';
+import Text from '@/components/common/Text';
+import useEventLogger from '@/components/eventLogger/hooks/useEventLogger';
+import MemberProjectCard from '@/components/members/detail/ActivitySection/MemberProjectCard';
+import { MOBILE_MEDIA_QUERY } from '@/styles/mediaQuery';
+
+interface ProjectActivitySectionProps {
+  profile: ProfileDetail;
+  memberId: string;
+  meId?: number | undefined;
+}
+
+const ProjectSection = ({ profile, memberId, meId }: ProjectActivitySectionProps) => {
+  const { logClickEvent } = useEventLogger();
+
+  return (
+    <Container>
+      <ActivityTitle>{profile.name}님이 참여한 프로젝트</ActivityTitle>
+      {profile.projects.length > 0 && (
+        <>
+          <ActivitySub>{profile.projects.length}개의 프로젝트에 참여</ActivitySub>
+          <ActivityDisplay>
+            {profile.projects.map((project) => (
+              <MemberProjectCard key={project.id} {...project} />
+            ))}
+          </ActivityDisplay>
+        </>
+      )}
+      {profile.projects.length === 0 && (
+        <>
+          <ActivitySub>아직 참여한 프로젝트가 없어요</ActivitySub>
+          {String(meId) === memberId && (
+            <ActivityUploadNudge>
+              <Text typography='SUIT_14_M' style={{ textAlign: 'center', lineHeight: '24px' }}>
+                참여한 프로젝트를 등록하면 <br />
+                공식 홈페이지에도 프로젝트가 업로드 돼요!
+              </Text>
+              <ActivityUploadButton
+                onClick={() =>
+                  logClickEvent('projectUpload', {
+                    referral: 'myPage',
+                  })
+                }
+                href={playgroundLink.projectUpload()}
+              >
+                <Text typography='SUIT_15_SB'>+ 내 프로젝트 올리기</Text>
+              </ActivityUploadButton>
+              <ActivityUploadMaskImg src='/icons/img/project-mask.png' alt='project-mask-image' height={317} />
+            </ActivityUploadNudge>
+          )}
+        </>
+      )}
+    </Container>
+  );
+};
+
+const Container = styled.section`
+  margin-top: 80px;
+`;
+
+const ActivityTitle = styled.div`
+  line-height: 100%;
+  font-size: 32px;
+  font-weight: 700;
+  @media ${MOBILE_MEDIA_QUERY} {
+    font-size: 22px;
+  }
+`;
+
+const ActivitySub = styled.div`
+  margin-top: 18px;
+  line-height: 100%;
+  color: #989ba0;
+  font-size: 22px;
+  font-weight: 500;
+  @media ${MOBILE_MEDIA_QUERY} {
+    margin-top: 10px;
+    font-size: 14px;
+  }
+`;
+
+const ActivityDisplay = styled.div`
+  display: grid;
+  grid-template-columns: repeat(2, minmax(10px, 1fr));
+  row-gap: 20px;
+  column-gap: 29px;
+  margin-top: 32px;
+
+  @media ${MOBILE_MEDIA_QUERY} {
+    display: flex;
+    flex-direction: column;
+    gap: 24px;
+    margin-top: 24px;
+  }
+`;
+
+const ActivityUploadNudge = styled.div`
+  display: flex;
+  position: relative;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  margin-top: 60px;
+  border-radius: 30px;
+  background-color: ${colors.gray800};
+  height: 317px;
+
+  @media ${MOBILE_MEDIA_QUERY} {
+    padding: 20px;
+    height: 212px;
+  }
+`;
+
+const ActivityUploadMaskImg = styled(ResizedImage)`
+  position: absolute;
+  max-height: 317px;
+  object-fit: cover;
+
+  @media ${MOBILE_MEDIA_QUERY} {
+    top: 0;
+    max-height: 134px;
+  }
+`;
+
+const ActivityUploadButton = styled(Link)`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1;
+  margin-top: 24px;
+  border-radius: 14px;
+  background-color: ${colors.gray10};
+  padding: 14px 48px;
+  color: ${colors.gray800};
+
+  @media ${MOBILE_MEDIA_QUERY} {
+    margin-top: 50px;
+    width: 100%;
+  }
+`;
+
+export default ProjectSection;


### PR DESCRIPTION
### 🤫 쉿, 나한테만 말해줘요. 이슈넘버
- close #1596 

### 🧐 어떤 것을 변경했어요~?
<!-- 실제로 변경한 사항을 설명해주세요.-->
멤버 프로필, 상세 정보, 프로젝트, 모임 정보를 컴포넌트로 분리했습니다!

CareerSection은 이미 컴포넌트로 분리되어 있어서, 스토리북에서 발생하는 오류만 수정했어요!

### 🤔 그렇다면, 어떻게 구현했어요~?
<!-- 실제로 구현한 로직에 대해 설명해주세요.-->
기존의 하나의 컴포넌트에 있던 뷰 로직을 분리했습니다.
상위에서 profile을 인자를 통해서 주면 각 Section에 해당하는 뷰에서 데이터를 보여줄 수 있도록 수정했습니다.

### ❤️‍🔥 당신이 생각하는 PR포인트, 내겐 매력포인트.
<!-- 해당 PR에서 논의가 필요한 사항을 적어주세요. -->
커피챗 페이지 상세조회 API 명세서에서 profile과 관련된 부분이 없어서, `useGetMemberProfileById`을 추가로 작성해서 프로필 정보를 가져와야할 것 같아요!

커피챗 상세 뷰에서 사용되는 부분은 아래 순서로 사용하시면 됩니다.

```typescript
<CareerSection
          careers={profile.careers}
          links={profile.links}
          skill={profile.skill}
          name={profile.name}
          email={profile.email}
          profileImage={profile.profileImage}
          memberId={memberId}
          isMine={profile.isMine}
        />

<DetailInfoSection profile={profile} />

<SoptActivitySection soptActivities={sortedSoptActivities} />

<ProjectSection profile={profile} memberId={memberId} meId={me?.id} />
```

MemberDetail.tsx에서 뷰들을 다 분리했어요! 
코드가 삭제된 부분이 많아서 보기 힘들 수도 있는데, 각 Section별 뷰들을 모두 컴포넌트로 분리했습니다!

### 📸 스크린샷, 없으면 이것 참,, 섭섭한데요?
스토리북에서 확인할 수 있습니다!
<img width="719" alt="image" src="https://github.com/user-attachments/assets/dae54590-c85b-4def-80e3-0a5b2bc9d6d0">