### PR TITLE
feat: 커피챗 오픈/수정 로직 구현

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "@sopt-makers/colors": "^3.0.0",
     "@sopt-makers/fonts": "^1.0.0",
     "@sopt-makers/icons": "^1.0.5",
-    "@sopt-makers/ui": "^2.4.4",
+    "@sopt-makers/ui": "^2.5.0",
     "@tanstack/react-query": "^5.4.3",
     "@toss/emotion-utils": "^1.1.10",
     "@toss/error-boundary": "^1.4.6",

--- a/src/api/endpoint/coffeechat/editCoffeechat.ts
+++ b/src/api/endpoint/coffeechat/editCoffeechat.ts
@@ -1,0 +1,13 @@
+import { z } from 'zod';
+
+import { createEndpoint } from '@/api/typedAxios';
+import { CoffeechatFormContent } from '@/components/coffeechat/upload/CoffeechatForm/types';
+
+export const editCoffeechat = createEndpoint({
+  request: (requestBody: CoffeechatFormContent) => ({
+    method: 'PUT',
+    url: 'api/v1/members/coffeechat/details',
+    data: requestBody,
+  }),
+  serverResponseScheme: z.unknown(),
+});

--- a/src/api/endpoint/coffeechat/uploadCoffeechat.ts
+++ b/src/api/endpoint/coffeechat/uploadCoffeechat.ts
@@ -1,0 +1,13 @@
+import { z } from 'zod';
+
+import { createEndpoint } from '@/api/typedAxios';
+import { CoffeechatFormContent } from '@/components/coffeechat/upload/CoffeechatForm/types';
+
+export const uploadCoffeechat = createEndpoint({
+  request: (reqeustBody: CoffeechatFormContent) => ({
+    method: 'POST',
+    url: 'api/v1/members/coffeechat/details',
+    data: reqeustBody,
+  }),
+  serverResponseScheme: z.unknown(),
+});

--- a/src/components/coffeechat/page/CoffeechatUploadPage.tsx
+++ b/src/components/coffeechat/page/CoffeechatUploadPage.tsx
@@ -2,11 +2,13 @@ import { yupResolver } from '@hookform/resolvers/yup';
 import { FormProvider, useForm } from 'react-hook-form';
 
 import DesktopCoffeechatUploadLayout from '@/components/coffeechat/page/layout/DesktopCoffeechatUploadLayout';
+import MobileCoffeechatUploadLayout from '@/components/coffeechat/page/layout/MobileCoffeechatUploadLayout';
 import CoffeechatForm from '@/components/coffeechat/upload/CoffeechatForm';
 import { coffeChatchema } from '@/components/coffeechat/upload/CoffeechatForm/schema';
 import { CoffeechatFormContent } from '@/components/coffeechat/upload/CoffeechatForm/types';
 import UploadButton from '@/components/coffeechat/upload/CoffeechatForm/UploadButton';
 import ProgressBox from '@/components/coffeechat/upload/ProgressBox';
+import Responsive from '@/components/common/Responsive';
 
 interface CoffeechatUploadPageProps {
   uploadType: '오픈' | '수정';
@@ -21,13 +23,16 @@ export default function CoffeechatUploadPage({ uploadType, form, onSubmit }: Cof
   return (
     <FormProvider {...methods}>
       <form onSubmit={handleSubmit(onSubmit)}>
-        {/* <Responsive only='desktop'> */}
-        <DesktopCoffeechatUploadLayout
-          main={<CoffeechatForm />}
-          aside={<ProgressBox uploadType={uploadType} myInfoInprogress={false} coffeechatInfoInprogress={false} />}
-          submitButton={<UploadButton />}
-        />
-        {/* </Responsive> */}
+        <Responsive only='desktop'>
+          <DesktopCoffeechatUploadLayout
+            main={<CoffeechatForm />}
+            aside={<ProgressBox uploadType={uploadType} myInfoInprogress={false} coffeechatInfoInprogress={false} />}
+            submitButton={<UploadButton />}
+          />
+        </Responsive>
+        <Responsive only='mobile'>
+          <MobileCoffeechatUploadLayout main={<CoffeechatForm />} submitButton={<UploadButton />} />
+        </Responsive>
       </form>
     </FormProvider>
   );

--- a/src/components/coffeechat/page/CoffeechatUploadPage.tsx
+++ b/src/components/coffeechat/page/CoffeechatUploadPage.tsx
@@ -1,23 +1,26 @@
 import { yupResolver } from '@hookform/resolvers/yup';
-import { FieldValues, FormProvider, SubmitHandler, useForm } from 'react-hook-form';
+import { FieldValues, FormProvider, useForm } from 'react-hook-form';
 
 import DesktopCoffeechatUploadLayout from '@/components/coffeechat/page/layout/DesktopCoffeechatUploadLayout';
 import MobileCoffeechatUploadLayout from '@/components/coffeechat/page/layout/MobileCoffeechatUploadLayout';
 import CoffeechatForm from '@/components/coffeechat/upload/CoffeechatForm';
 import { coffeeChatchema } from '@/components/coffeechat/upload/CoffeechatForm/schema';
+import SubmitDialog from '@/components/coffeechat/upload/CoffeechatForm/SubmitDialog';
 import { CoffeechatFormContent } from '@/components/coffeechat/upload/CoffeechatForm/types';
 import UploadButton from '@/components/coffeechat/upload/CoffeechatForm/UploadButton';
 import ProgressBox from '@/components/coffeechat/upload/ProgressBox';
+import useModalState from '@/components/common/Modal/useModalState';
 import Responsive from '@/components/common/Responsive';
 interface CoffeechatUploadPageProps {
   uploadType: '오픈' | '수정';
   form: CoffeechatFormContent;
-  onSubmit: SubmitHandler<CoffeechatFormContent>;
+  onSubmit: <T extends FieldValues>(values: T) => void;
 }
 
 export default function CoffeechatUploadPage({ uploadType, form, onSubmit }: CoffeechatUploadPageProps) {
   const methods = useForm<CoffeechatFormContent>({ resolver: yupResolver(coffeeChatchema), defaultValues: form });
   const { handleSubmit, setFocus, watch } = methods;
+  const { isOpen, onClose, onOpen } = useModalState();
 
   const findFirstErrorFieldInOrder = (errors: FieldValues): string | null => {
     const fieldOrder = [
@@ -63,30 +66,33 @@ export default function CoffeechatUploadPage({ uploadType, form, onSubmit }: Cof
 
   return (
     <FormProvider {...methods}>
-      <form id='coffeechatForm' onSubmit={handleSubmit(onSubmit, onError)}>
-        <Responsive only='desktop'>
-          <DesktopCoffeechatUploadLayout
-            main={<CoffeechatForm />}
-            aside={
-              <ProgressBox
-                uploadType={uploadType}
-                myInfoInprogress={!!(watch('memberInfo.career') && watch('memberInfo.introduction'))}
-                coffeechatInfoInprogress={
-                  !!(
-                    watch('coffeeChatInfo.sections') &&
-                    watch('coffeeChatInfo.bio') &&
-                    watch('coffeeChatInfo.topicTypes') &&
-                    watch('coffeeChatInfo.topic')
-                  )
-                }
-              />
-            }
-            submitButton={<UploadButton />}
-          />
-        </Responsive>
-        <Responsive only='mobile'>
-          <MobileCoffeechatUploadLayout main={<CoffeechatForm />} submitButton={<UploadButton />} />
-        </Responsive>
+      <form onSubmit={handleSubmit(onOpen, onError)}>
+        <SubmitDialog isOpen={isOpen} onClose={onClose} onSubmit={onSubmit} />
+        <>
+          <Responsive only='desktop'>
+            <DesktopCoffeechatUploadLayout
+              main={<CoffeechatForm />}
+              aside={
+                <ProgressBox
+                  uploadType={uploadType}
+                  myInfoInprogress={!!(watch('memberInfo.career') && watch('memberInfo.introduction'))}
+                  coffeechatInfoInprogress={
+                    !!(
+                      watch('coffeeChatInfo.sections') &&
+                      watch('coffeeChatInfo.bio') &&
+                      watch('coffeeChatInfo.topicTypes') &&
+                      watch('coffeeChatInfo.topic')
+                    )
+                  }
+                />
+              }
+              submitButton={<UploadButton />}
+            />
+          </Responsive>
+          <Responsive only='mobile'>
+            <MobileCoffeechatUploadLayout main={<CoffeechatForm />} submitButton={<UploadButton />} />
+          </Responsive>
+        </>
       </form>
     </FormProvider>
   );

--- a/src/components/coffeechat/page/CoffeechatUploadPage.tsx
+++ b/src/components/coffeechat/page/CoffeechatUploadPage.tsx
@@ -17,7 +17,7 @@ interface CoffeechatUploadPageProps {
 
 export default function CoffeechatUploadPage({ uploadType, form, onSubmit }: CoffeechatUploadPageProps) {
   const methods = useForm<CoffeechatFormContent>({ resolver: yupResolver(coffeeChatchema), defaultValues: form });
-  const { handleSubmit, setFocus } = methods;
+  const { handleSubmit, setFocus, watch } = methods;
 
   const findFirstErrorFieldInOrder = (errors: FieldValues): string | null => {
     const fieldOrder = [
@@ -67,7 +67,20 @@ export default function CoffeechatUploadPage({ uploadType, form, onSubmit }: Cof
         <Responsive only='desktop'>
           <DesktopCoffeechatUploadLayout
             main={<CoffeechatForm />}
-            aside={<ProgressBox uploadType={uploadType} myInfoInprogress={false} coffeechatInfoInprogress={false} />}
+            aside={
+              <ProgressBox
+                uploadType={uploadType}
+                myInfoInprogress={!!(watch('memberInfo.career') && watch('memberInfo.introduction'))}
+                coffeechatInfoInprogress={
+                  !!(
+                    watch('coffeeChatInfo.sections') &&
+                    watch('coffeeChatInfo.bio') &&
+                    watch('coffeeChatInfo.topicTypes') &&
+                    watch('coffeeChatInfo.topic')
+                  )
+                }
+              />
+            }
             submitButton={<UploadButton />}
           />
         </Responsive>

--- a/src/components/coffeechat/page/CoffeechatUploadPage.tsx
+++ b/src/components/coffeechat/page/CoffeechatUploadPage.tsx
@@ -9,6 +9,7 @@ import SubmitDialog from '@/components/coffeechat/upload/CoffeechatForm/SubmitDi
 import { CoffeechatFormContent } from '@/components/coffeechat/upload/CoffeechatForm/types';
 import UploadButton from '@/components/coffeechat/upload/CoffeechatForm/UploadButton';
 import ProgressBox from '@/components/coffeechat/upload/ProgressBox';
+import UploadHeader from '@/components/coffeechat/upload/UploadHeader';
 import useModalState from '@/components/common/Modal/useModalState';
 import Responsive from '@/components/common/Responsive';
 interface CoffeechatUploadPageProps {
@@ -71,7 +72,12 @@ export default function CoffeechatUploadPage({ uploadType, form, onSubmit }: Cof
         <>
           <Responsive only='desktop'>
             <DesktopCoffeechatUploadLayout
-              main={<CoffeechatForm />}
+              main={
+                <>
+                  <UploadHeader uploadType={uploadType} />
+                  <CoffeechatForm />
+                </>
+              }
               aside={
                 <ProgressBox
                   uploadType={uploadType}
@@ -90,7 +96,15 @@ export default function CoffeechatUploadPage({ uploadType, form, onSubmit }: Cof
             />
           </Responsive>
           <Responsive only='mobile'>
-            <MobileCoffeechatUploadLayout main={<CoffeechatForm />} submitButton={<UploadButton />} />
+            <MobileCoffeechatUploadLayout
+              main={
+                <>
+                  <UploadHeader uploadType={uploadType} />
+                  <CoffeechatForm />
+                </>
+              }
+              submitButton={<UploadButton />}
+            />
           </Responsive>
         </>
       </form>

--- a/src/components/coffeechat/page/CoffeechatUploadPage.tsx
+++ b/src/components/coffeechat/page/CoffeechatUploadPage.tsx
@@ -1,15 +1,14 @@
 import { yupResolver } from '@hookform/resolvers/yup';
-import { FormProvider, SubmitHandler, useForm } from 'react-hook-form';
+import { FieldValues, FormProvider, SubmitHandler, useForm } from 'react-hook-form';
 
 import DesktopCoffeechatUploadLayout from '@/components/coffeechat/page/layout/DesktopCoffeechatUploadLayout';
 import MobileCoffeechatUploadLayout from '@/components/coffeechat/page/layout/MobileCoffeechatUploadLayout';
 import CoffeechatForm from '@/components/coffeechat/upload/CoffeechatForm';
-import { coffeChatchema } from '@/components/coffeechat/upload/CoffeechatForm/schema';
+import { coffeeChatchema } from '@/components/coffeechat/upload/CoffeechatForm/schema';
 import { CoffeechatFormContent } from '@/components/coffeechat/upload/CoffeechatForm/types';
 import UploadButton from '@/components/coffeechat/upload/CoffeechatForm/UploadButton';
 import ProgressBox from '@/components/coffeechat/upload/ProgressBox';
 import Responsive from '@/components/common/Responsive';
-
 interface CoffeechatUploadPageProps {
   uploadType: '오픈' | '수정';
   form: CoffeechatFormContent;
@@ -17,11 +16,54 @@ interface CoffeechatUploadPageProps {
 }
 
 export default function CoffeechatUploadPage({ uploadType, form, onSubmit }: CoffeechatUploadPageProps) {
-  const methods = useForm<CoffeechatFormContent>({ resolver: yupResolver(coffeChatchema), defaultValues: form });
+  const methods = useForm<CoffeechatFormContent>({ resolver: yupResolver(coffeeChatchema), defaultValues: form });
+  const { handleSubmit, setFocus } = methods;
+
+  const findFirstErrorFieldInOrder = (errors: FieldValues): string | null => {
+    const fieldOrder = [
+      'memberInfo.career',
+      'memberInfo.introduction',
+      'coffeeChatInfo.sections',
+      'coffeeChatInfo.bio',
+      'coffeeChatInfo.topicTypes',
+      'coffeeChatInfo.topic',
+      'coffeeChatInfo.meetingType',
+      'coffeeChatInfo.guideline',
+    ];
+
+    for (const fieldPath of fieldOrder) {
+      const keys = fieldPath.split('.');
+      let currentError = errors;
+
+      for (const key of keys) {
+        currentError = currentError[key];
+        if (!currentError) break;
+      }
+
+      if (currentError?.message) {
+        return fieldPath;
+      }
+    }
+
+    return null;
+  };
+
+  const onError = (errors: FieldValues) => {
+    const firstErrorField = findFirstErrorFieldInOrder(errors);
+
+    if (firstErrorField) {
+      setFocus(firstErrorField as keyof CoffeechatFormContent);
+      const errorElement = document.querySelector(`[name="${firstErrorField}"]`);
+      console.log(errorElement);
+      if (errorElement) {
+        errorElement.scrollIntoView({ behavior: 'smooth', block: 'center' });
+      }
+    }
+  };
 
   return (
     <FormProvider {...methods}>
-      <form id='coffeechatForm' onSubmit={methods.handleSubmit(onSubmit)}>
+      <form id='coffeechatForm' onSubmit={handleSubmit(onSubmit, onError)}>
         <Responsive only='desktop'>
           <DesktopCoffeechatUploadLayout
             main={<CoffeechatForm />}

--- a/src/components/coffeechat/page/CoffeechatUploadPage.tsx
+++ b/src/components/coffeechat/page/CoffeechatUploadPage.tsx
@@ -54,7 +54,7 @@ export default function CoffeechatUploadPage({ uploadType, form, onSubmit }: Cof
     if (firstErrorField) {
       setFocus(firstErrorField as keyof CoffeechatFormContent);
       const errorElement = document.querySelector(`[name="${firstErrorField}"]`);
-      console.log(errorElement);
+
       if (errorElement) {
         errorElement.scrollIntoView({ behavior: 'smooth', block: 'center' });
       }

--- a/src/components/coffeechat/page/CoffeechatUploadPage.tsx
+++ b/src/components/coffeechat/page/CoffeechatUploadPage.tsx
@@ -1,22 +1,33 @@
-import CoffeechatForm from '@/components/coffeechat/upload/CoffeechatForm';
-import { coffeChatchema } from '@/components/coffeechat/upload/CoffeechatForm/schema';
-import { CoffeechatFormContent } from '@/components/coffeechat/upload/CoffeechatForm/types';
 import { yupResolver } from '@hookform/resolvers/yup';
 import { FormProvider, useForm } from 'react-hook-form';
 
+import DesktopCoffeechatUploadLayout from '@/components/coffeechat/page/layout/DesktopCoffeechatUploadLayout';
+import CoffeechatForm from '@/components/coffeechat/upload/CoffeechatForm';
+import { coffeChatchema } from '@/components/coffeechat/upload/CoffeechatForm/schema';
+import { CoffeechatFormContent } from '@/components/coffeechat/upload/CoffeechatForm/types';
+import UploadButton from '@/components/coffeechat/upload/CoffeechatForm/UploadButton';
+import ProgressBox from '@/components/coffeechat/upload/ProgressBox';
+
 interface CoffeechatUploadPageProps {
+  uploadType: '오픈' | '수정';
   form: CoffeechatFormContent;
   onSubmit: () => void;
 }
 
-export default function CoffeechatUploadPage({ form, onSubmit }: CoffeechatUploadPageProps) {
+export default function CoffeechatUploadPage({ uploadType, form, onSubmit }: CoffeechatUploadPageProps) {
   const methods = useForm<CoffeechatFormContent>({ resolver: yupResolver(coffeChatchema), defaultValues: form });
   const { handleSubmit } = methods;
 
   return (
     <FormProvider {...methods}>
       <form onSubmit={handleSubmit(onSubmit)}>
-        <CoffeechatForm />
+        {/* <Responsive only='desktop'> */}
+        <DesktopCoffeechatUploadLayout
+          main={<CoffeechatForm />}
+          aside={<ProgressBox uploadType={uploadType} myInfoInprogress={false} coffeechatInfoInprogress={false} />}
+          submitButton={<UploadButton />}
+        />
+        {/* </Responsive> */}
       </form>
     </FormProvider>
   );

--- a/src/components/coffeechat/page/CoffeechatUploadPage.tsx
+++ b/src/components/coffeechat/page/CoffeechatUploadPage.tsx
@@ -92,7 +92,7 @@ export default function CoffeechatUploadPage({ uploadType, form, onSubmit }: Cof
                   }
                 />
               }
-              submitButton={<UploadButton />}
+              submitButton={<UploadButton uploadType={uploadType} />}
             />
           </Responsive>
           <Responsive only='mobile'>
@@ -103,7 +103,7 @@ export default function CoffeechatUploadPage({ uploadType, form, onSubmit }: Cof
                   <CoffeechatForm />
                 </>
               }
-              submitButton={<UploadButton />}
+              submitButton={<UploadButton uploadType={uploadType} />}
             />
           </Responsive>
         </>

--- a/src/components/coffeechat/page/CoffeechatUploadPage.tsx
+++ b/src/components/coffeechat/page/CoffeechatUploadPage.tsx
@@ -1,5 +1,5 @@
 import { yupResolver } from '@hookform/resolvers/yup';
-import { FormProvider, useForm } from 'react-hook-form';
+import { FormProvider, SubmitHandler, useForm } from 'react-hook-form';
 
 import DesktopCoffeechatUploadLayout from '@/components/coffeechat/page/layout/DesktopCoffeechatUploadLayout';
 import MobileCoffeechatUploadLayout from '@/components/coffeechat/page/layout/MobileCoffeechatUploadLayout';
@@ -13,16 +13,15 @@ import Responsive from '@/components/common/Responsive';
 interface CoffeechatUploadPageProps {
   uploadType: '오픈' | '수정';
   form: CoffeechatFormContent;
-  onSubmit: () => void;
+  onSubmit: SubmitHandler<CoffeechatFormContent>;
 }
 
 export default function CoffeechatUploadPage({ uploadType, form, onSubmit }: CoffeechatUploadPageProps) {
   const methods = useForm<CoffeechatFormContent>({ resolver: yupResolver(coffeChatchema), defaultValues: form });
-  const { handleSubmit } = methods;
 
   return (
     <FormProvider {...methods}>
-      <form onSubmit={handleSubmit(onSubmit)}>
+      <form id='coffeechatForm' onSubmit={methods.handleSubmit(onSubmit)}>
         <Responsive only='desktop'>
           <DesktopCoffeechatUploadLayout
             main={<CoffeechatForm />}

--- a/src/components/coffeechat/page/layout/DesktopCoffeechatUploadLayout.tsx
+++ b/src/components/coffeechat/page/layout/DesktopCoffeechatUploadLayout.tsx
@@ -1,3 +1,4 @@
+import { COFFEECHAT_TABLET_MEDIA_QUERY } from '@/components/coffeechat/mediaQuery';
 import styled from '@emotion/styled';
 import { ReactNode } from 'react';
 
@@ -32,6 +33,12 @@ const Layout = styled.div`
   gap: 30px;
   justify-content: center;
   margin: 0 30px;
+  margin-top: 48px;
+  margin-bottom: 180px;
+
+  @media ${COFFEECHAT_TABLET_MEDIA_QUERY} {
+    margin-top: 0;
+  }
 `;
 
 const Body = styled.section`

--- a/src/components/coffeechat/page/layout/DesktopCoffeechatUploadLayout.tsx
+++ b/src/components/coffeechat/page/layout/DesktopCoffeechatUploadLayout.tsx
@@ -1,0 +1,49 @@
+import styled from '@emotion/styled';
+import { ReactNode } from 'react';
+
+interface DesktopCoffeechatUploadLayoutProps {
+  main: ReactNode;
+  aside: ReactNode;
+  submitButton: ReactNode;
+}
+
+export default function DesktopCoffeechatUploadLayout({
+  main,
+  aside,
+  submitButton,
+}: DesktopCoffeechatUploadLayoutProps) {
+  return (
+    <Layout>
+      <Main>
+        <Body>{main}</Body>
+        <Footer>{submitButton}</Footer>
+      </Main>
+      <Aside>{aside}</Aside>
+    </Layout>
+  );
+}
+
+const Footer = styled.footer`
+  margin: 62px 0 50px;
+`;
+
+const Layout = styled.div`
+  display: flex;
+  gap: 30px;
+  justify-content: center;
+  margin: 0 30px;
+`;
+
+const Body = styled.section`
+  display: flex;
+  flex-direction: column;
+`;
+
+const Main = styled.main`
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  margin: 0 40px;
+`;
+
+const Aside = styled.aside``;

--- a/src/components/coffeechat/page/layout/MobileCoffeechatUploadLayout.tsx
+++ b/src/components/coffeechat/page/layout/MobileCoffeechatUploadLayout.tsx
@@ -1,0 +1,27 @@
+import styled from '@emotion/styled';
+import { ReactNode } from 'react';
+
+interface MobileCoffeechatUploadLayoutProps {
+  main: ReactNode;
+  submitButton: ReactNode;
+}
+
+export default function MobileCoffeechatUploadLayout({ main, submitButton }: MobileCoffeechatUploadLayoutProps) {
+  return (
+    <Layout>
+      <>{main}</>
+      <Footer>{submitButton}</Footer>
+    </Layout>
+  );
+}
+
+const Layout = styled.div`
+  display: flex;
+  flex-direction: column;
+  margin: 0 20px;
+`;
+
+const Footer = styled.footer`
+  margin: 40px 0 56px;
+  width: 100%;
+`;

--- a/src/components/coffeechat/page/layout/MobileCoffeechatUploadLayout.tsx
+++ b/src/components/coffeechat/page/layout/MobileCoffeechatUploadLayout.tsx
@@ -1,3 +1,5 @@
+import { COFFEECHAT_MOBILE_MEDIA_QUERY } from '@/components/coffeechat/mediaQuery';
+import { MOBILE_MEDIA_QUERY } from '@/styles/mediaQuery';
 import styled from '@emotion/styled';
 import { ReactNode } from 'react';
 
@@ -19,6 +21,15 @@ const Layout = styled.div`
   display: flex;
   flex-direction: column;
   margin: 0 20px;
+  margin-bottom: 180px;
+
+  @media ${MOBILE_MEDIA_QUERY} {
+    margin-top: 48px;
+  }
+
+  @media ${COFFEECHAT_MOBILE_MEDIA_QUERY} {
+    margin-top: 0;
+  }
 `;
 
 const Footer = styled.footer`

--- a/src/components/coffeechat/upload/CoffeechatForm/ChipField/index.tsx
+++ b/src/components/coffeechat/upload/CoffeechatForm/ChipField/index.tsx
@@ -22,7 +22,7 @@ export default function ChipField({ field, errorMessage, chipList, isSingleSelec
         name={field}
         control={control}
         render={({ field }) => (
-          <ChipsWrapper>
+          <ChipsWrapper {...field}>
             {chipList.map((chip) => (
               <div
                 key={chip}

--- a/src/components/coffeechat/upload/CoffeechatForm/ChipField/index.tsx
+++ b/src/components/coffeechat/upload/CoffeechatForm/ChipField/index.tsx
@@ -32,10 +32,10 @@ export default function ChipField({ field, errorMessage, chipList, isSingleSelec
                   } else {
                     const newValue =
                       Array.isArray(field.value) && field.value.includes(chip)
-                        ? field.value.filter((item) => item !== chip) // 이미 선택된 경우 제거
-                        : [...(Array.isArray(field.value) ? field.value : []), chip]; // 복수 선택 모드일 경우 추가
+                        ? field.value.filter((item) => item !== chip) // MEMO: 이미 선택된 경우 제거
+                        : [...(Array.isArray(field.value) ? field.value : []), chip]; // MEMO: 복수 선택 모드일 경우 추가
 
-                    field.onChange(newValue); // 배열 업데이트
+                    field.onChange(newValue); // MEMO: 배열 업데이트
                   }
                 }}
               >
@@ -54,42 +54,6 @@ export default function ChipField({ field, errorMessage, chipList, isSingleSelec
           </ChipsWrapper>
         )}
       />
-
-      {/* {chipList.map((chip) => {
-          return (
-            <div key={chip}>
-              <Responsive only='desktop'>
-                <Chip size='sm' active={true}>
-                  {chip}
-                </Chip>
-              </Responsive>
-              <Responsive only='mobile'>
-                <Chip size='md' active={true}>
-                  {chip}
-                </Chip>
-              </Responsive>
-            </div>
-          );
-        })} */}
-      {/* <Controller
-          name={key}
-          control={control}
-          render={({ field }) => (
-            <div>
-              {chipList.map((chip) => (
-                <Chip size='sm' active={true} onClick={() => {
-                  const newValue = field.value.includes(chip)
-                    ? field.value.filter((item) => item !== chip) // 이미 선택된 경우 제거
-                    : [...field.value, chip]; // 새로 선택된 경우 추가
-                  field.onChange(newValue); // 배열 업데이트
-                }}>
-                {chip}
-              </Chip>
-             
-              ))}
-            </div>
-          )}
-        /> */}
     </FormItem>
   );
 }

--- a/src/components/coffeechat/upload/CoffeechatForm/ChipField/index.tsx
+++ b/src/components/coffeechat/upload/CoffeechatForm/ChipField/index.tsx
@@ -1,41 +1,100 @@
 import styled from '@emotion/styled';
 import { Chip } from '@sopt-makers/ui';
+import { Controller, useFormContext } from 'react-hook-form';
 
+import { CoffeechatFormContent, CoffeechatFormPaths } from '@/components/coffeechat/upload/CoffeechatForm/types';
 import FormItem from '@/components/common/form/FormItem';
 import Responsive from '@/components/common/Responsive';
 
 interface ChipFieldProps {
+  field: CoffeechatFormPaths;
   errorMessage: string;
   chipList: readonly string[];
-  activeChipList: string[];
+  isSingleSelect?: boolean;
 }
 
-export default function ChipField({ errorMessage, chipList, activeChipList }: ChipFieldProps) {
+export default function ChipField({ field, errorMessage, chipList, isSingleSelect = false }: ChipFieldProps) {
+  const { control } = useFormContext<CoffeechatFormContent>();
+
   return (
     <FormItem errorMessage={errorMessage}>
-      <CareerChips>
-        {chipList.map((chip) => {
+      <Controller
+        name={field}
+        control={control}
+        render={({ field }) => (
+          <ChipsWrapper>
+            {chipList.map((chip) => (
+              <div
+                key={chip}
+                onClick={() => {
+                  if (isSingleSelect) {
+                    field.onChange([chip]);
+                  } else {
+                    const newValue =
+                      Array.isArray(field.value) && field.value.includes(chip)
+                        ? field.value.filter((item) => item !== chip) // 이미 선택된 경우 제거
+                        : [...(Array.isArray(field.value) ? field.value : []), chip]; // 복수 선택 모드일 경우 추가
+
+                    field.onChange(newValue); // 배열 업데이트
+                  }
+                }}
+              >
+                <Responsive only='desktop'>
+                  <Chip size='sm' active={Array.isArray(field.value) && field.value.includes(chip)}>
+                    {chip}
+                  </Chip>
+                </Responsive>
+                <Responsive only='mobile'>
+                  <Chip size='md' active={Array.isArray(field.value) && field.value.includes(chip)}>
+                    {chip}
+                  </Chip>
+                </Responsive>
+              </div>
+            ))}
+          </ChipsWrapper>
+        )}
+      />
+
+      {/* {chipList.map((chip) => {
           return (
             <div key={chip}>
               <Responsive only='desktop'>
-                <Chip size='sm' active={activeChipList.includes(chip)}>
+                <Chip size='sm' active={true}>
                   {chip}
                 </Chip>
               </Responsive>
               <Responsive only='mobile'>
-                <Chip size='md' active={activeChipList.includes(chip)}>
+                <Chip size='md' active={true}>
                   {chip}
                 </Chip>
               </Responsive>
             </div>
           );
-        })}
-      </CareerChips>
+        })} */}
+      {/* <Controller
+          name={key}
+          control={control}
+          render={({ field }) => (
+            <div>
+              {chipList.map((chip) => (
+                <Chip size='sm' active={true} onClick={() => {
+                  const newValue = field.value.includes(chip)
+                    ? field.value.filter((item) => item !== chip) // 이미 선택된 경우 제거
+                    : [...field.value, chip]; // 새로 선택된 경우 추가
+                  field.onChange(newValue); // 배열 업데이트
+                }}>
+                {chip}
+              </Chip>
+             
+              ))}
+            </div>
+          )}
+        /> */}
     </FormItem>
   );
 }
 
-const CareerChips = styled.div`
+const ChipsWrapper = styled.div`
   display: flex;
   flex-wrap: wrap;
   gap: 10px;

--- a/src/components/coffeechat/upload/CoffeechatForm/CoffeechatInfoForm/index.tsx
+++ b/src/components/coffeechat/upload/CoffeechatForm/CoffeechatInfoForm/index.tsx
@@ -1,6 +1,6 @@
 import styled from '@emotion/styled';
 import { SelectV2, TextArea } from '@sopt-makers/ui';
-import { useFormContext } from 'react-hook-form';
+import { Controller, useFormContext } from 'react-hook-form';
 
 import { COFFEECHAT_MOBILE_MEDIA_QUERY } from '@/components/coffeechat/mediaQuery';
 import ChipField from '@/components/coffeechat/upload/CoffeechatForm/ChipField';
@@ -9,25 +9,16 @@ import {
   COFFECHAT_TOPIC,
   MEETING_TYPE_OPTIONS,
 } from '@/components/coffeechat/upload/CoffeechatForm/constants';
-import { CoffeechatFormContent, CoffeechatFormPaths } from '@/components/coffeechat/upload/CoffeechatForm/types';
+import { CoffeechatFormContent } from '@/components/coffeechat/upload/CoffeechatForm/types';
 import FormTitle from '@/components/common/form/FormTitle';
 import TextFieldLineBreak from '@/components/common/form/TextFieldLineBreak';
 import Responsive from '@/components/common/Responsive';
 
 export default function CoffeechatInfoForm() {
   const {
-    setValue,
-    watch,
     control,
     formState: { errors },
   } = useFormContext<CoffeechatFormContent>();
-
-  const handleChange = (key: CoffeechatFormPaths, valueOrEvent: string | React.ChangeEvent<HTMLTextAreaElement>) => {
-    const value = typeof valueOrEvent === 'string' ? valueOrEvent : valueOrEvent.target.value;
-
-    setValue(key, value);
-  };
-
   return (
     <>
       <CoffeechatSectionWrapper>
@@ -48,13 +39,19 @@ export default function CoffeechatInfoForm() {
         <FormTitle essential breakPoint={COFFEECHAT_MOBILE_MEDIA_QUERY}>
           커피챗 제목
         </FormTitle>
-        <TextArea
-          value={watch('coffeeChatInfo.bio') ?? ''}
-          placeholder='ex. 디자인 관련 고민이 있다면, 함께 나눠봐요!'
-          maxLength={40}
-          isError={!!errors.coffeeChatInfo?.bio}
-          errorMessage='커피챗 제목을 입력해주세요'
-          onChange={(e) => handleChange('coffeeChatInfo.bio', e)}
+        <Controller
+          name='coffeeChatInfo.bio'
+          control={control}
+          render={({ field }) => (
+            <TextArea
+              value={field.value ?? ''}
+              placeholder='ex. 디자인 관련 고민이 있다면, 함께 나눠봐요!'
+              maxLength={40}
+              isError={!!errors.coffeeChatInfo?.bio}
+              errorMessage='커피챗 제목을 입력해주세요'
+              onChange={(e) => field.onChange(e.target.value)}
+            />
+          )}
         />
       </article>
       <TopicWrapper>
@@ -67,92 +64,111 @@ export default function CoffeechatInfoForm() {
         </FormTitle>
         <ChipField
           field='coffeeChatInfo.topicTypes'
-          errorMessage={errors.coffeeChatInfo?.topicTypes ? '커피챗 주제 소개를 입력해주세요' : ''}
+          errorMessage={errors.coffeeChatInfo?.topicTypes ? '커피챗 주제 키워드를 선택해주세요' : ''}
           chipList={COFFECHAT_TOPIC}
         />
-        <>
-          <Responsive only='desktop'>
-            <TextFieldLineBreak
-              value={watch('coffeeChatInfo.topic') ?? ''}
-              maxLength={1000}
-              fixedHeight={189}
-              lineBreakPlaceholder={[
-                '• PM과 서비스기획자로 일하는 방법',
-                '• 포트폴리오 준비 및 작성 노하우',
-                '• 직무 전환 시 준비할 것들',
-                '• 당근, 토스, 넥슨, 하나은행, LG전자 면접 후기',
-              ]}
-              isError={!!errors.coffeeChatInfo?.topic}
-              errorMessage='자기소개를 입력해주세요'
-              onChange={(e) => handleChange('coffeeChatInfo.topic', e)}
-            />
-          </Responsive>
-          <Responsive only='mobile'>
-            <TextFieldLineBreak
-              value={watch('coffeeChatInfo.topic') ?? ''}
-              maxLength={1000}
-              fixedHeight={176}
-              lineBreakPlaceholder={[
-                '• PM과 서비스기획자로 일하는 방법',
-                '• 포트폴리오 준비 및 작성 노하우',
-                '• 직무 전환 시 준비할 것들',
-                '• 당근, 토스, 넥슨, 하나은행, LG전자 면접 후기',
-              ]}
-              isError={!!errors.coffeeChatInfo?.topic}
-              errorMessage='자기소개를 입력해주세요'
-              onChange={(e) => handleChange('coffeeChatInfo.topic', e)}
-            />
-          </Responsive>
-        </>
+
+        <Controller
+          name='coffeeChatInfo.topic'
+          control={control}
+          render={({ field }) => (
+            <>
+              <Responsive only='desktop'>
+                <TextFieldLineBreak
+                  value={field.value ?? ''}
+                  maxLength={1000}
+                  fixedHeight={189}
+                  lineBreakPlaceholder={[
+                    '• PM과 서비스기획자로 일하는 방법',
+                    '• 포트폴리오 준비 및 작성 노하우',
+                    '• 직무 전환 시 준비할 것들',
+                    '• 당근, 토스, 넥슨, 하나은행, LG전자 면접 후기',
+                  ]}
+                  isError={!!errors.coffeeChatInfo?.topic}
+                  errorMessage='커피챗 주제 소개를 입력해주세요'
+                  onChange={(e) => field.onChange(e.target.value)}
+                />
+              </Responsive>
+              <Responsive only='mobile'>
+                <TextFieldLineBreak
+                  value={field.value ?? ''}
+                  maxLength={1000}
+                  fixedHeight={176}
+                  lineBreakPlaceholder={[
+                    '• PM과 서비스기획자로 일하는 방법',
+                    '• 포트폴리오 준비 및 작성 노하우',
+                    '• 직무 전환 시 준비할 것들',
+                    '• 당근, 토스, 넥슨, 하나은행, LG전자 면접 후기',
+                  ]}
+                  isError={!!errors.coffeeChatInfo?.topic}
+                  errorMessage='커피챗 주제 소개를 입력해주세요'
+                  onChange={(e) => field.onChange(e.target.value)}
+                />
+              </Responsive>
+            </>
+          )}
+        />
       </TopicWrapper>
       <article>
         <FormTitle breakPoint={COFFEECHAT_MOBILE_MEDIA_QUERY}>커피챗 진행 방식</FormTitle>
-        <SelectV2.Root
-          type='text'
-          visibleOptions={3}
-          defaultValue={MEETING_TYPE_OPTIONS.find((option) => option.value === watch('coffeeChatInfo.meetingType'))}
-          onChange={(value) => handleChange('coffeeChatInfo.meetingType', String(value))}
-        >
-          <SelectV2.Trigger>
-            <SelectV2.TriggerContent placeholder={'진행 방식 선택'} />
-          </SelectV2.Trigger>
-          <SelectV2.Menu>
-            {MEETING_TYPE_OPTIONS.map((option) => (
-              <SelectV2.MenuItem key={option.value} option={option} />
-            ))}
-          </SelectV2.Menu>
-        </SelectV2.Root>
+        <Controller
+          name='coffeeChatInfo.meetingType'
+          control={control}
+          render={({ field }) => (
+            <SelectV2.Root
+              type='text'
+              visibleOptions={3}
+              defaultValue={MEETING_TYPE_OPTIONS.find((option) => option.value === field.value)}
+              onChange={(value) => field.onChange(value)}
+            >
+              <SelectV2.Trigger>
+                <SelectV2.TriggerContent placeholder={'진행 방식 선택'} />
+              </SelectV2.Trigger>
+              <SelectV2.Menu>
+                {MEETING_TYPE_OPTIONS.map((option) => (
+                  <SelectV2.MenuItem key={option.value} option={option} />
+                ))}
+              </SelectV2.Menu>
+            </SelectV2.Root>
+          )}
+        />
       </article>
       <article>
         <FormTitle breakPoint={COFFEECHAT_MOBILE_MEDIA_QUERY}>유의사항</FormTitle>
-        <>
-          <Responsive only='desktop'>
-            <TextFieldLineBreak
-              value={watch('coffeeChatInfo.guideline') ?? ''}
-              maxLength={1000}
-              fixedHeight={159}
-              lineBreakPlaceholder={[
-                '• 신청 전 알아두어야 할 공지 ',
-                '• 이런 분께 추천해요 ',
-                '• 커피챗 가능한 시간대',
-              ]}
-              onChange={(e) => handleChange('coffeeChatInfo.guideline', e)}
-            />
-          </Responsive>
-          <Responsive only='mobile'>
-            <TextFieldLineBreak
-              value={watch('coffeeChatInfo.guideline') ?? ''}
-              maxLength={1000}
-              fixedHeight={150}
-              lineBreakPlaceholder={[
-                '• 신청 전 알아두어야 할 공지 ',
-                '• 이런 분께 추천해요 ',
-                '• 커피챗 가능한 시간대',
-              ]}
-              onChange={(e) => handleChange('coffeeChatInfo.guideline', e)}
-            />
-          </Responsive>
-        </>
+        <Controller
+          name='coffeeChatInfo.guideline'
+          control={control}
+          render={({ field }) => (
+            <>
+              <Responsive only='desktop'>
+                <TextFieldLineBreak
+                  value={field.value ?? ''}
+                  maxLength={1000}
+                  fixedHeight={159}
+                  lineBreakPlaceholder={[
+                    '• 신청 전 알아두어야 할 공지 ',
+                    '• 이런 분께 추천해요 ',
+                    '• 커피챗 가능한 시간대',
+                  ]}
+                  onChange={(e) => field.onChange(e.target.value)}
+                />
+              </Responsive>
+              <Responsive only='mobile'>
+                <TextFieldLineBreak
+                  value={field.value ?? ''}
+                  maxLength={1000}
+                  fixedHeight={150}
+                  lineBreakPlaceholder={[
+                    '• 신청 전 알아두어야 할 공지 ',
+                    '• 이런 분께 추천해요 ',
+                    '• 커피챗 가능한 시간대',
+                  ]}
+                  onChange={(e) => field.onChange(e.target.value)}
+                />
+              </Responsive>
+            </>
+          )}
+        />
       </article>
     </>
   );

--- a/src/components/coffeechat/upload/CoffeechatForm/CoffeechatInfoForm/index.tsx
+++ b/src/components/coffeechat/upload/CoffeechatForm/CoffeechatInfoForm/index.tsx
@@ -44,6 +44,7 @@ export default function CoffeechatInfoForm() {
           control={control}
           render={({ field }) => (
             <TextArea
+              name={field.name}
               value={field.value ?? ''}
               placeholder='ex. 디자인 관련 고민이 있다면, 함께 나눠봐요!'
               maxLength={40}
@@ -75,6 +76,7 @@ export default function CoffeechatInfoForm() {
             <>
               <Responsive only='desktop'>
                 <TextFieldLineBreak
+                  name={field.name}
                   value={field.value ?? ''}
                   maxLength={1000}
                   fixedHeight={189}
@@ -91,6 +93,7 @@ export default function CoffeechatInfoForm() {
               </Responsive>
               <Responsive only='mobile'>
                 <TextFieldLineBreak
+                  name={field.name}
                   value={field.value ?? ''}
                   maxLength={1000}
                   fixedHeight={176}
@@ -115,21 +118,23 @@ export default function CoffeechatInfoForm() {
           name='coffeeChatInfo.meetingType'
           control={control}
           render={({ field }) => (
-            <SelectV2.Root
-              type='text'
-              visibleOptions={3}
-              defaultValue={MEETING_TYPE_OPTIONS.find((option) => option.value === field.value)}
-              onChange={(value) => field.onChange(value)}
-            >
-              <SelectV2.Trigger>
-                <SelectV2.TriggerContent placeholder={'진행 방식 선택'} />
-              </SelectV2.Trigger>
-              <SelectV2.Menu>
-                {MEETING_TYPE_OPTIONS.map((option) => (
-                  <SelectV2.MenuItem key={option.value} option={option} />
-                ))}
-              </SelectV2.Menu>
-            </SelectV2.Root>
+            <div {...field}>
+              <SelectV2.Root
+                type='text'
+                visibleOptions={3}
+                defaultValue={MEETING_TYPE_OPTIONS.find((option) => option.value === field.value)}
+                onChange={(value) => field.onChange(value)}
+              >
+                <SelectV2.Trigger>
+                  <SelectV2.TriggerContent placeholder={'진행 방식 선택'} />
+                </SelectV2.Trigger>
+                <SelectV2.Menu>
+                  {MEETING_TYPE_OPTIONS.map((option) => (
+                    <SelectV2.MenuItem key={option.value} option={option} />
+                  ))}
+                </SelectV2.Menu>
+              </SelectV2.Root>
+            </div>
           )}
         />
       </article>
@@ -142,6 +147,7 @@ export default function CoffeechatInfoForm() {
             <>
               <Responsive only='desktop'>
                 <TextFieldLineBreak
+                  name={field.name}
                   value={field.value ?? ''}
                   maxLength={1000}
                   fixedHeight={159}
@@ -155,6 +161,7 @@ export default function CoffeechatInfoForm() {
               </Responsive>
               <Responsive only='mobile'>
                 <TextFieldLineBreak
+                  name={field.name}
                   value={field.value ?? ''}
                   maxLength={1000}
                   fixedHeight={150}

--- a/src/components/coffeechat/upload/CoffeechatForm/CoffeechatInfoForm/index.tsx
+++ b/src/components/coffeechat/upload/CoffeechatForm/CoffeechatInfoForm/index.tsx
@@ -1,5 +1,6 @@
 import styled from '@emotion/styled';
 import { SelectV2, TextArea } from '@sopt-makers/ui';
+import { useFormContext } from 'react-hook-form';
 
 import { COFFEECHAT_MOBILE_MEDIA_QUERY } from '@/components/coffeechat/mediaQuery';
 import ChipField from '@/components/coffeechat/upload/CoffeechatForm/ChipField';
@@ -8,11 +9,25 @@ import {
   COFFECHAT_TOPIC,
   MEETING_TYPE_OPTIONS,
 } from '@/components/coffeechat/upload/CoffeechatForm/constants';
+import { CoffeechatFormContent, CoffeechatFormPaths } from '@/components/coffeechat/upload/CoffeechatForm/types';
 import FormTitle from '@/components/common/form/FormTitle';
 import TextFieldLineBreak from '@/components/common/form/TextFieldLineBreak';
 import Responsive from '@/components/common/Responsive';
 
 export default function CoffeechatInfoForm() {
+  const {
+    setValue,
+    watch,
+    control,
+    formState: { errors },
+  } = useFormContext<CoffeechatFormContent>();
+
+  const handleChange = (key: CoffeechatFormPaths, valueOrEvent: string | React.ChangeEvent<HTMLTextAreaElement>) => {
+    const value = typeof valueOrEvent === 'string' ? valueOrEvent : valueOrEvent.target.value;
+
+    setValue(key, value);
+  };
+
   return (
     <>
       <CoffeechatSectionWrapper>
@@ -23,18 +38,23 @@ export default function CoffeechatInfoForm() {
         >
           관련 분야
         </FormTitle>
-        <ChipField errorMessage='관련 분야를 선택해주세요' chipList={COFFECHAT_SECTION} activeChipList={[]} />
+        <ChipField
+          field='coffeeChatInfo.sections'
+          errorMessage={errors.coffeeChatInfo?.sections ? '관련 분야를 선택해주세요' : ''}
+          chipList={COFFECHAT_SECTION}
+        />
       </CoffeechatSectionWrapper>
       <article>
         <FormTitle essential breakPoint={COFFEECHAT_MOBILE_MEDIA_QUERY}>
           커피챗 제목
         </FormTitle>
         <TextArea
-          value=''
+          value={watch('coffeeChatInfo.bio') ?? ''}
           placeholder='ex. 디자인 관련 고민이 있다면, 함께 나눠봐요!'
           maxLength={40}
-          isError={true}
+          isError={!!errors.coffeeChatInfo?.bio}
           errorMessage='커피챗 제목을 입력해주세요'
+          onChange={(e) => handleChange('coffeeChatInfo.bio', e)}
         />
       </article>
       <TopicWrapper>
@@ -45,11 +65,15 @@ export default function CoffeechatInfoForm() {
         >
           커피챗 주제 및 소개
         </FormTitle>
-        <ChipField errorMessage='관련 분야를 선택해주세요' chipList={COFFECHAT_TOPIC} activeChipList={[]} />
+        <ChipField
+          field='coffeeChatInfo.topicTypes'
+          errorMessage={errors.coffeeChatInfo?.topicTypes ? '커피챗 주제 소개를 입력해주세요' : ''}
+          chipList={COFFECHAT_TOPIC}
+        />
         <>
           <Responsive only='desktop'>
             <TextFieldLineBreak
-              value=''
+              value={watch('coffeeChatInfo.topic') ?? ''}
               maxLength={1000}
               fixedHeight={189}
               lineBreakPlaceholder={[
@@ -58,13 +82,14 @@ export default function CoffeechatInfoForm() {
                 '• 직무 전환 시 준비할 것들',
                 '• 당근, 토스, 넥슨, 하나은행, LG전자 면접 후기',
               ]}
-              isError
+              isError={!!errors.coffeeChatInfo?.topic}
               errorMessage='자기소개를 입력해주세요'
+              onChange={(e) => handleChange('coffeeChatInfo.topic', e)}
             />
           </Responsive>
           <Responsive only='mobile'>
             <TextFieldLineBreak
-              value=''
+              value={watch('coffeeChatInfo.topic') ?? ''}
               maxLength={1000}
               fixedHeight={176}
               lineBreakPlaceholder={[
@@ -73,17 +98,23 @@ export default function CoffeechatInfoForm() {
                 '• 직무 전환 시 준비할 것들',
                 '• 당근, 토스, 넥슨, 하나은행, LG전자 면접 후기',
               ]}
-              isError
+              isError={!!errors.coffeeChatInfo?.topic}
               errorMessage='자기소개를 입력해주세요'
+              onChange={(e) => handleChange('coffeeChatInfo.topic', e)}
             />
           </Responsive>
         </>
       </TopicWrapper>
       <article>
         <FormTitle breakPoint={COFFEECHAT_MOBILE_MEDIA_QUERY}>커피챗 진행 방식</FormTitle>
-        <SelectV2.Root type='text' visibleOptions={3}>
+        <SelectV2.Root
+          type='text'
+          visibleOptions={3}
+          defaultValue={MEETING_TYPE_OPTIONS.find((option) => option.value === watch('coffeeChatInfo.meetingType'))}
+          onChange={(value) => handleChange('coffeeChatInfo.meetingType', String(value))}
+        >
           <SelectV2.Trigger>
-            <SelectV2.TriggerContent placeholder='진행 방식 선택' />
+            <SelectV2.TriggerContent placeholder={'진행 방식 선택'} />
           </SelectV2.Trigger>
           <SelectV2.Menu>
             {MEETING_TYPE_OPTIONS.map((option) => (
@@ -97,7 +128,7 @@ export default function CoffeechatInfoForm() {
         <>
           <Responsive only='desktop'>
             <TextFieldLineBreak
-              value=''
+              value={watch('coffeeChatInfo.guideline') ?? ''}
               maxLength={1000}
               fixedHeight={159}
               lineBreakPlaceholder={[
@@ -105,11 +136,12 @@ export default function CoffeechatInfoForm() {
                 '• 이런 분께 추천해요 ',
                 '• 커피챗 가능한 시간대',
               ]}
+              onChange={(e) => handleChange('coffeeChatInfo.guideline', e)}
             />
           </Responsive>
           <Responsive only='mobile'>
             <TextFieldLineBreak
-              value=''
+              value={watch('coffeeChatInfo.guideline') ?? ''}
               maxLength={1000}
               fixedHeight={150}
               lineBreakPlaceholder={[
@@ -117,6 +149,7 @@ export default function CoffeechatInfoForm() {
                 '• 이런 분께 추천해요 ',
                 '• 커피챗 가능한 시간대',
               ]}
+              onChange={(e) => handleChange('coffeeChatInfo.guideline', e)}
             />
           </Responsive>
         </>

--- a/src/components/coffeechat/upload/CoffeechatForm/MyInfoForm/index.tsx
+++ b/src/components/coffeechat/upload/CoffeechatForm/MyInfoForm/index.tsx
@@ -1,25 +1,19 @@
 import styled from '@emotion/styled';
-import { useFormContext } from 'react-hook-form';
+import { Controller, useFormContext } from 'react-hook-form';
 
 import { COFFEECHAT_MOBILE_MEDIA_QUERY } from '@/components/coffeechat/mediaQuery';
 import ChipField from '@/components/coffeechat/upload/CoffeechatForm/ChipField';
 import { CAREER_LEVEL } from '@/components/coffeechat/upload/CoffeechatForm/constants';
-import { CoffeechatFormContent, CoffeechatFormPaths } from '@/components/coffeechat/upload/CoffeechatForm/types';
+import { CoffeechatFormContent } from '@/components/coffeechat/upload/CoffeechatForm/types';
 import FormTitle from '@/components/common/form/FormTitle';
 import TextFieldLineBreak from '@/components/common/form/TextFieldLineBreak';
 import Responsive from '@/components/common/Responsive';
 
 export default function MyInfoForm() {
   const {
-    setValue,
-    watch,
     control,
     formState: { errors },
   } = useFormContext<CoffeechatFormContent>();
-
-  const handleChange = (key: CoffeechatFormPaths, e: React.ChangeEvent<HTMLTextAreaElement>) => {
-    setValue(key, e.target.value);
-  };
 
   return (
     <>
@@ -42,28 +36,36 @@ export default function MyInfoForm() {
         <FormTitle essential breakPoint={COFFEECHAT_MOBILE_MEDIA_QUERY}>
           자기소개
         </FormTitle>
-        <Responsive only='desktop'>
-          <TextFieldLineBreak
-            value={watch('memberInfo.introduction') ?? ''}
-            maxLength={200}
-            fixedHeight={126}
-            lineBreakPlaceholder={['• 직무 경험이나 관심 분야를 적어주면 더 좋아요!']}
-            isError={!!errors.memberInfo?.introduction}
-            errorMessage='자기소개를 입력해주세요'
-            onChange={(e) => handleChange('memberInfo.introduction', e)}
-          />
-        </Responsive>
-        <Responsive only='mobile'>
-          <TextFieldLineBreak
-            value={watch('memberInfo.introduction') ?? ''}
-            maxLength={200}
-            fixedHeight={150}
-            lineBreakPlaceholder={['• 직무 경험이나 관심 분야를 적어주면 더 좋아요!']}
-            isError={!!errors.memberInfo?.introduction}
-            errorMessage='자기소개를 입력해주세요'
-            onChange={(e) => handleChange('memberInfo.introduction', e)}
-          />
-        </Responsive>
+        <Controller
+          name='memberInfo.introduction'
+          control={control}
+          render={({ field }) => (
+            <>
+              <Responsive only='desktop'>
+                <TextFieldLineBreak
+                  value={field.value ?? ''}
+                  maxLength={200}
+                  fixedHeight={126}
+                  lineBreakPlaceholder={['• 직무 경험이나 관심 분야를 적어주면 더 좋아요!']}
+                  isError={!!errors.memberInfo?.introduction}
+                  errorMessage='자기소개를 입력해주세요'
+                  onChange={(e) => field.onChange(e.target.value)}
+                />
+              </Responsive>
+              <Responsive only='mobile'>
+                <TextFieldLineBreak
+                  value={field.value ?? ''}
+                  maxLength={200}
+                  fixedHeight={150}
+                  lineBreakPlaceholder={['• 직무 경험이나 관심 분야를 적어주면 더 좋아요!']}
+                  isError={!!errors.memberInfo?.introduction}
+                  errorMessage='자기소개를 입력해주세요'
+                  onChange={(e) => field.onChange(e.target.value)}
+                />
+              </Responsive>
+            </>
+          )}
+        />
       </article>
     </>
   );

--- a/src/components/coffeechat/upload/CoffeechatForm/MyInfoForm/index.tsx
+++ b/src/components/coffeechat/upload/CoffeechatForm/MyInfoForm/index.tsx
@@ -1,13 +1,26 @@
 import styled from '@emotion/styled';
+import { useFormContext } from 'react-hook-form';
 
 import { COFFEECHAT_MOBILE_MEDIA_QUERY } from '@/components/coffeechat/mediaQuery';
 import ChipField from '@/components/coffeechat/upload/CoffeechatForm/ChipField';
 import { CAREER_LEVEL } from '@/components/coffeechat/upload/CoffeechatForm/constants';
+import { CoffeechatFormContent, CoffeechatFormPaths } from '@/components/coffeechat/upload/CoffeechatForm/types';
 import FormTitle from '@/components/common/form/FormTitle';
 import TextFieldLineBreak from '@/components/common/form/TextFieldLineBreak';
 import Responsive from '@/components/common/Responsive';
 
 export default function MyInfoForm() {
+  const {
+    setValue,
+    watch,
+    control,
+    formState: { errors },
+  } = useFormContext<CoffeechatFormContent>();
+
+  const handleChange = (key: CoffeechatFormPaths, e: React.ChangeEvent<HTMLTextAreaElement>) => {
+    setValue(key, e.target.value);
+  };
+
   return (
     <>
       <CareerWrapper>
@@ -18,7 +31,12 @@ export default function MyInfoForm() {
         >
           경력
         </FormTitle>
-        <ChipField errorMessage='경력을 선택해주세요' chipList={CAREER_LEVEL} activeChipList={[]} />
+        <ChipField
+          field='memberInfo.career'
+          errorMessage={errors.memberInfo?.career ? '경력을 선택해주세요' : ''}
+          chipList={CAREER_LEVEL}
+          isSingleSelect
+        />
       </CareerWrapper>
       <article>
         <FormTitle essential breakPoint={COFFEECHAT_MOBILE_MEDIA_QUERY}>
@@ -26,22 +44,24 @@ export default function MyInfoForm() {
         </FormTitle>
         <Responsive only='desktop'>
           <TextFieldLineBreak
-            value=''
+            value={watch('memberInfo.introduction') ?? ''}
             maxLength={200}
             fixedHeight={126}
             lineBreakPlaceholder={['• 직무 경험이나 관심 분야를 적어주면 더 좋아요!']}
-            isError
+            isError={!!errors.memberInfo?.introduction}
             errorMessage='자기소개를 입력해주세요'
+            onChange={(e) => handleChange('memberInfo.introduction', e)}
           />
         </Responsive>
         <Responsive only='mobile'>
           <TextFieldLineBreak
-            value=''
+            value={watch('memberInfo.introduction') ?? ''}
             maxLength={200}
             fixedHeight={150}
             lineBreakPlaceholder={['• 직무 경험이나 관심 분야를 적어주면 더 좋아요!']}
-            isError
+            isError={!!errors.memberInfo?.introduction}
             errorMessage='자기소개를 입력해주세요'
+            onChange={(e) => handleChange('memberInfo.introduction', e)}
           />
         </Responsive>
       </article>

--- a/src/components/coffeechat/upload/CoffeechatForm/MyInfoForm/index.tsx
+++ b/src/components/coffeechat/upload/CoffeechatForm/MyInfoForm/index.tsx
@@ -43,6 +43,7 @@ export default function MyInfoForm() {
             <>
               <Responsive only='desktop'>
                 <TextFieldLineBreak
+                  name={field.name}
                   value={field.value ?? ''}
                   maxLength={200}
                   fixedHeight={126}
@@ -54,6 +55,7 @@ export default function MyInfoForm() {
               </Responsive>
               <Responsive only='mobile'>
                 <TextFieldLineBreak
+                  name={field.name}
                   value={field.value ?? ''}
                   maxLength={200}
                   fixedHeight={150}

--- a/src/components/coffeechat/upload/CoffeechatForm/SubmitDialog/index.stories.tsx
+++ b/src/components/coffeechat/upload/CoffeechatForm/SubmitDialog/index.stories.tsx
@@ -1,0 +1,52 @@
+import { coffeeChatchema } from '@/components/coffeechat/upload/CoffeechatForm/schema';
+import SubmitDialog from '@/components/coffeechat/upload/CoffeechatForm/SubmitDialog';
+import { CoffeechatFormContent } from '@/components/coffeechat/upload/CoffeechatForm/types';
+import { yupResolver } from '@hookform/resolvers/yup';
+import { Meta } from '@storybook/react';
+import { FormProvider, useForm } from 'react-hook-form';
+
+const form = {
+  memberInfo: {
+    career: '주니어',
+    introduction: '안녕하세요! 저는 프론트엔드 개발자로 다양한 프로젝트 경험을 쌓고 있습니다.',
+  },
+  coffeeChatInfo: {
+    sections: ['프론트엔드', '디자인'], // 다중 선택 가능 (전체, 기획, 디자인, 웹, 서버, 안드로이드, iOS)
+    bio: '프론트엔드 커리어 상담',
+    topicTypes: ['커리어', '포트폴리오'], // 창업, 네트워킹, 프로젝트, 커리어 등 다중 선택 가능
+    topic: '프론트엔드 개발자로서의 커리어에 대해 상담하고 싶습니다.\n포트폴리오 제작과 인터뷰 팁도 나누고자 합니다.',
+    meetingType: '온라인', // 무관, 온라인, 오프라인 중 하나 선택
+    guideline: '시간 약속을 꼭 지켜주세요.\n질문은 미리 준비해 오시면 더욱 좋습니다.',
+  },
+};
+
+export default {
+  component: SubmitDialog,
+  decorators: [
+    (Story) => {
+      const formMethods = useForm<CoffeechatFormContent>({
+        resolver: yupResolver(coffeeChatchema),
+        defaultValues: form,
+        mode: 'onChange',
+      });
+      return (
+        <FormProvider {...formMethods}>
+          <Story />
+          <SubmitDialog
+            isOpen={true}
+            onClose={() => {
+              //
+            }}
+            onSubmit={() => {
+              //
+            }}
+          />
+        </FormProvider>
+      );
+    },
+  ],
+} as Meta<typeof SubmitDialog>;
+
+export const Default = {
+  name: '기본',
+};

--- a/src/components/coffeechat/upload/CoffeechatForm/SubmitDialog/index.tsx
+++ b/src/components/coffeechat/upload/CoffeechatForm/SubmitDialog/index.tsx
@@ -1,0 +1,65 @@
+import Responsive from '@/components/common/Responsive';
+import { MOBILE_MEDIA_QUERY } from '@/styles/mediaQuery';
+import styled from '@emotion/styled';
+import { Button, Dialog } from '@sopt-makers/ui';
+import { FieldValues, useFormContext } from 'react-hook-form';
+
+interface SubmitDialogProps {
+  isOpen: boolean;
+  onClose: () => void;
+  onSubmit: <T extends FieldValues>(values: T) => void;
+}
+
+export default function SubmitDialog({ isOpen, onClose, onSubmit }: SubmitDialogProps) {
+  const { getValues } = useFormContext();
+
+  return (
+    <>
+      <Dialog isOpen={isOpen} onClose={onClose}>
+        <Dialog.Title>커피챗을 오픈하시겠습니까?</Dialog.Title>
+        <DescriptionWrapper>
+          <Dialog.Description>
+            커피챗은 한 개만 오픈할 수 있어요. 커피챗에 대한 설명이 충분히 작성되었는지 확인해주세요.
+          </Dialog.Description>
+        </DescriptionWrapper>
+        <Responsive only='desktop'>
+          <Dialog.Footer align={'right'}>
+            <Button type='button' onClick={onClose} rounded='md' size='md' theme='black'>
+              취소
+            </Button>
+            <Button type='button' onClick={() => onSubmit(getValues())} rounded='md' size='md' theme='white'>
+              오픈하기
+            </Button>
+          </Dialog.Footer>
+        </Responsive>
+        <Responsive only='mobile'>
+          <Dialog.Footer align={'center'}>
+            <Button type='button' onClick={onClose} rounded='md' size='md' theme='black' style={{ width: '100%' }}>
+              취소
+            </Button>
+            <Button
+              type='button'
+              onClick={() => onSubmit(getValues())}
+              rounded='md'
+              size='md'
+              theme='white'
+              style={{ width: '100%' }}
+            >
+              오픈하기
+            </Button>
+          </Dialog.Footer>
+        </Responsive>
+      </Dialog>
+    </>
+  );
+}
+
+const DescriptionWrapper = styled.div`
+  margin-top: 12px;
+  margin-bottom: 36px;
+
+  @media ${MOBILE_MEDIA_QUERY} {
+    margin-top: 8px;
+    margin-bottom: 24px;
+  }
+`;

--- a/src/components/coffeechat/upload/CoffeechatForm/UploadButton/index.tsx
+++ b/src/components/coffeechat/upload/CoffeechatForm/UploadButton/index.tsx
@@ -4,24 +4,20 @@ import { Button } from '@sopt-makers/ui';
 
 import Responsive from '@/components/common/Responsive';
 
-interface UploadButtonProps {
-  onClick?: () => void;
-}
-
-export default function UploadButton({ onClick }: UploadButtonProps) {
+export default function UploadButton() {
   return (
-    <div onClick={onClick}>
+    <>
       <Responsive only='desktop'>
-        <Button size='md' LeftIcon={IconPlus} type='submit'>
+        <Button size='md' LeftIcon={IconPlus} type='submit' form='coffeechatForm'>
           커피챗 오픈하기
         </Button>
       </Responsive>
       <Responsive only='mobile'>
-        <MobileButton size='lg' LeftIcon={IconPlus} type='submit'>
+        <MobileButton size='lg' LeftIcon={IconPlus} type='submit' form='coffeechatForm'>
           커피챗 오픈하기
         </MobileButton>
       </Responsive>
-    </div>
+    </>
   );
 }
 

--- a/src/components/coffeechat/upload/CoffeechatForm/UploadButton/index.tsx
+++ b/src/components/coffeechat/upload/CoffeechatForm/UploadButton/index.tsx
@@ -1,56 +1,3 @@
-// import styled from '@emotion/styled';
-// import { IconPlus } from '@sopt-makers/icons';
-// import { Button } from '@sopt-makers/ui';
-// import { useFormContext } from 'react-hook-form';
-
-// import { CoffeechatFormContent } from '@/components/coffeechat/upload/CoffeechatForm/types';
-// import Responsive from '@/components/common/Responsive';
-
-// interface UploadButtonProps {
-//   onSubmit: (data: CoffeechatFormContent) => void;
-// }
-
-// export default function UploadButton({ onSubmit }: UploadButtonProps) {
-//   const { handleSubmit, getValues } = useFormContext();
-
-//   const submitCoffeechat = () => {
-//     console.log('Asdf');
-//     onSubmit({
-//       memberInfo: {
-//         career: getValues('memberInfo.career') ? getValues('memberInfo.career')[0] : null,
-//         introduction: getValues('memberInfo.introduction'),
-//       },
-//       coffeeChatInfo: {
-//         sections: getValues('coffeeChatInfo.sections'),
-//         bio: getValues('coffeeChatInfo.bio'),
-//         topicTypes: getValues('coffeeChatInfo.topicTypes'),
-//         topic: getValues('coffeeChatInfo.topic'),
-//         meetingType: getValues('coffeeChatInfo.meetingType'),
-//         guideline: getValues('coffeeChatInfo.guideline'),
-//       },
-//     });
-//   };
-
-//   return (
-//     <div onClick={handleSubmit(submitCoffeechat)}>
-//       <Responsive only='desktop'>
-//         <Button size='md' LeftIcon={IconPlus} type='button'>
-//           커피챗 오픈하기
-//         </Button>
-//       </Responsive>
-//       <Responsive only='mobile'>
-//         <MobileButton size='lg' LeftIcon={IconPlus} type='button'>
-//           커피챗 오픈하기
-//         </MobileButton>
-//       </Responsive>
-//     </div>
-//   );
-// }
-
-// const MobileButton = styled(Button)`
-//   width: 100%;
-// `;
-
 import styled from '@emotion/styled';
 import { IconPlus } from '@sopt-makers/icons';
 import { Button } from '@sopt-makers/ui';
@@ -61,12 +8,12 @@ export default function UploadButton() {
   return (
     <div>
       <Responsive only='desktop'>
-        <Button size='md' LeftIcon={IconPlus} type='submit'>
+        <Button size='md' LeftIcon={IconPlus} type='button'>
           커피챗 오픈하기
         </Button>
       </Responsive>
       <Responsive only='mobile'>
-        <MobileButton size='lg' LeftIcon={IconPlus} type='submit'>
+        <MobileButton size='lg' LeftIcon={IconPlus} type='button'>
           커피챗 오픈하기
         </MobileButton>
       </Responsive>

--- a/src/components/coffeechat/upload/CoffeechatForm/UploadButton/index.tsx
+++ b/src/components/coffeechat/upload/CoffeechatForm/UploadButton/index.tsx
@@ -4,17 +4,21 @@ import { Button } from '@sopt-makers/ui';
 
 import Responsive from '@/components/common/Responsive';
 
-export default function UploadButton() {
+interface UploadButtonProp {
+  uploadType: '오픈' | '수정';
+}
+
+export default function UploadButton({ uploadType }: UploadButtonProp) {
   return (
     <div>
       <Responsive only='desktop'>
         <Button size='md' LeftIcon={IconPlus} type='submit'>
-          커피챗 오픈하기
+          커피챗 {uploadType}하기
         </Button>
       </Responsive>
       <Responsive only='mobile'>
         <MobileButton size='lg' LeftIcon={IconPlus} type='submit'>
-          커피챗 오픈하기
+          커피챗 {uploadType}하기
         </MobileButton>
       </Responsive>
     </div>

--- a/src/components/coffeechat/upload/CoffeechatForm/UploadButton/index.tsx
+++ b/src/components/coffeechat/upload/CoffeechatForm/UploadButton/index.tsx
@@ -8,12 +8,12 @@ export default function UploadButton() {
   return (
     <div>
       <Responsive only='desktop'>
-        <Button size='md' LeftIcon={IconPlus} type='button'>
+        <Button size='md' LeftIcon={IconPlus} type='submit'>
           커피챗 오픈하기
         </Button>
       </Responsive>
       <Responsive only='mobile'>
-        <MobileButton size='lg' LeftIcon={IconPlus} type='button'>
+        <MobileButton size='lg' LeftIcon={IconPlus} type='submit'>
           커피챗 오픈하기
         </MobileButton>
       </Responsive>

--- a/src/components/coffeechat/upload/CoffeechatForm/UploadButton/index.tsx
+++ b/src/components/coffeechat/upload/CoffeechatForm/UploadButton/index.tsx
@@ -1,3 +1,4 @@
+import styled from '@emotion/styled';
 import { IconPlus } from '@sopt-makers/icons';
 import { Button } from '@sopt-makers/ui';
 
@@ -16,10 +17,14 @@ export default function UploadButton({ onClick }: UploadButtonProps) {
         </Button>
       </Responsive>
       <Responsive only='mobile'>
-        <Button size='lg' LeftIcon={IconPlus} type='submit'>
+        <MobileButton size='lg' LeftIcon={IconPlus} type='submit'>
           커피챗 오픈하기
-        </Button>
+        </MobileButton>
       </Responsive>
     </div>
   );
 }
+
+const MobileButton = styled(Button)`
+  width: 100%;
+`;

--- a/src/components/coffeechat/upload/CoffeechatForm/UploadButton/index.tsx
+++ b/src/components/coffeechat/upload/CoffeechatForm/UploadButton/index.tsx
@@ -1,3 +1,56 @@
+// import styled from '@emotion/styled';
+// import { IconPlus } from '@sopt-makers/icons';
+// import { Button } from '@sopt-makers/ui';
+// import { useFormContext } from 'react-hook-form';
+
+// import { CoffeechatFormContent } from '@/components/coffeechat/upload/CoffeechatForm/types';
+// import Responsive from '@/components/common/Responsive';
+
+// interface UploadButtonProps {
+//   onSubmit: (data: CoffeechatFormContent) => void;
+// }
+
+// export default function UploadButton({ onSubmit }: UploadButtonProps) {
+//   const { handleSubmit, getValues } = useFormContext();
+
+//   const submitCoffeechat = () => {
+//     console.log('Asdf');
+//     onSubmit({
+//       memberInfo: {
+//         career: getValues('memberInfo.career') ? getValues('memberInfo.career')[0] : null,
+//         introduction: getValues('memberInfo.introduction'),
+//       },
+//       coffeeChatInfo: {
+//         sections: getValues('coffeeChatInfo.sections'),
+//         bio: getValues('coffeeChatInfo.bio'),
+//         topicTypes: getValues('coffeeChatInfo.topicTypes'),
+//         topic: getValues('coffeeChatInfo.topic'),
+//         meetingType: getValues('coffeeChatInfo.meetingType'),
+//         guideline: getValues('coffeeChatInfo.guideline'),
+//       },
+//     });
+//   };
+
+//   return (
+//     <div onClick={handleSubmit(submitCoffeechat)}>
+//       <Responsive only='desktop'>
+//         <Button size='md' LeftIcon={IconPlus} type='button'>
+//           커피챗 오픈하기
+//         </Button>
+//       </Responsive>
+//       <Responsive only='mobile'>
+//         <MobileButton size='lg' LeftIcon={IconPlus} type='button'>
+//           커피챗 오픈하기
+//         </MobileButton>
+//       </Responsive>
+//     </div>
+//   );
+// }
+
+// const MobileButton = styled(Button)`
+//   width: 100%;
+// `;
+
 import styled from '@emotion/styled';
 import { IconPlus } from '@sopt-makers/icons';
 import { Button } from '@sopt-makers/ui';
@@ -6,18 +59,18 @@ import Responsive from '@/components/common/Responsive';
 
 export default function UploadButton() {
   return (
-    <>
+    <div>
       <Responsive only='desktop'>
-        <Button size='md' LeftIcon={IconPlus} type='submit' form='coffeechatForm'>
+        <Button size='md' LeftIcon={IconPlus} type='submit'>
           커피챗 오픈하기
         </Button>
       </Responsive>
       <Responsive only='mobile'>
-        <MobileButton size='lg' LeftIcon={IconPlus} type='submit' form='coffeechatForm'>
+        <MobileButton size='lg' LeftIcon={IconPlus} type='submit'>
           커피챗 오픈하기
         </MobileButton>
       </Responsive>
-    </>
+    </div>
   );
 }
 

--- a/src/components/coffeechat/upload/CoffeechatForm/constants.ts
+++ b/src/components/coffeechat/upload/CoffeechatForm/constants.ts
@@ -26,14 +26,14 @@ export const MEETING_TYPE = ['온라인', '오프라인', '온/오프라인'] as
 export const MEETING_TYPE_OPTIONS = [
   {
     label: '온라인',
-    value: 1,
+    value: '온라인',
   },
   {
     label: '오프라인',
-    value: 2,
+    value: '오프라인',
   },
   {
     label: '온/오프라인',
-    value: 3,
+    value: '온/오프라인',
   },
 ];

--- a/src/components/coffeechat/upload/CoffeechatForm/index.stories.tsx
+++ b/src/components/coffeechat/upload/CoffeechatForm/index.stories.tsx
@@ -34,7 +34,7 @@ export default {
       return (
         <FormProvider {...formMethods}>
           <Story />
-          <UploadButton onClick={() => formMethods.handleSubmit((formData) => console.log(formData))} />
+          <UploadButton />
         </FormProvider>
       );
     },

--- a/src/components/coffeechat/upload/CoffeechatForm/index.stories.tsx
+++ b/src/components/coffeechat/upload/CoffeechatForm/index.stories.tsx
@@ -3,7 +3,7 @@ import { Meta } from '@storybook/react';
 import { FormProvider, useForm } from 'react-hook-form';
 
 import CoffeechatForm from '@/components/coffeechat/upload/CoffeechatForm';
-import { coffeChatchema } from '@/components/coffeechat/upload/CoffeechatForm/schema';
+import { coffeeChatchema } from '@/components/coffeechat/upload/CoffeechatForm/schema';
 import { CoffeechatFormContent } from '@/components/coffeechat/upload/CoffeechatForm/types';
 import UploadButton from '@/components/coffeechat/upload/CoffeechatForm/UploadButton';
 
@@ -27,7 +27,7 @@ export default {
   decorators: [
     (Story) => {
       const formMethods = useForm<CoffeechatFormContent>({
-        resolver: yupResolver(coffeChatchema),
+        resolver: yupResolver(coffeeChatchema),
         defaultValues: form,
         mode: 'onChange',
       });

--- a/src/components/coffeechat/upload/CoffeechatForm/index.stories.tsx
+++ b/src/components/coffeechat/upload/CoffeechatForm/index.stories.tsx
@@ -9,13 +9,13 @@ import UploadButton from '@/components/coffeechat/upload/CoffeechatForm/UploadBu
 
 const form = {
   memberInfo: {
-    career: '주니어',
+    career: '주니어 (0-3년)',
     introduction: '안녕하세요! 저는 프론트엔드 개발자로 다양한 프로젝트 경험을 쌓고 있습니다.',
   },
   coffeeChatInfo: {
-    sections: ['프론트엔드', '디자인'], // 다중 선택 가능 (전체, 기획, 디자인, 웹, 서버, 안드로이드, iOS)
+    sections: ['프론트', '디자인'], // 다중 선택 가능 (전체, 기획, 디자인, 웹, 서버, 안드로이드, iOS)
     bio: '프론트엔드 커리어 상담',
-    topicTypes: ['커리어', '포트폴리오'], // 창업, 네트워킹, 프로젝트, 커리어 등 다중 선택 가능
+    topicTypes: ['포트폴리오', '이력서/자소서'], // 창업, 네트워킹, 프로젝트, 커리어 등 다중 선택 가능
     topic: '프론트엔드 개발자로서의 커리어에 대해 상담하고 싶습니다.\n포트폴리오 제작과 인터뷰 팁도 나누고자 합니다.',
     meetingType: '온라인', // 무관, 온라인, 오프라인 중 하나 선택
     guideline: '시간 약속을 꼭 지켜주세요.\n질문은 미리 준비해 오시면 더욱 좋습니다.',

--- a/src/components/coffeechat/upload/CoffeechatForm/index.stories.tsx
+++ b/src/components/coffeechat/upload/CoffeechatForm/index.stories.tsx
@@ -34,7 +34,7 @@ export default {
       return (
         <FormProvider {...formMethods}>
           <Story />
-          <UploadButton />
+          <UploadButton uploadType='오픈' />
         </FormProvider>
       );
     },

--- a/src/components/coffeechat/upload/CoffeechatForm/schema.ts
+++ b/src/components/coffeechat/upload/CoffeechatForm/schema.ts
@@ -1,20 +1,31 @@
 import * as yup from 'yup';
 
 const myInfoSchema = yup.object().shape({
-  career: yup.string().required('경력을 선택해주세요'),
+  career: yup
+    .mixed()
+    .test(
+      'is-string-or-array',
+      '경력을 선택해주세요',
+      (value) => typeof value === 'string' || (Array.isArray(value) && value.length > 0),
+    )
+    .required('경력을 선택해주세요'),
   introduction: yup.string().required('자기소개를 입력해주세요'),
 });
 
 const coffeeChatInfoSchema = yup.object().shape({
-  sections: yup.array().of(yup.string()).required('관련 분야를 선택해주세요'),
+  sections: yup.array().of(yup.string()).min(1, '관련 분야를 선택해주세요').required('관련 분야를 선택해주세요'),
   bio: yup.string().required('커피챗 제목을 입력해주세요'),
-  topicTypes: yup.array().of(yup.string()).required('커피챗 주제 키워드를 선택해주세요'),
+  topicTypes: yup
+    .array()
+    .of(yup.string())
+    .min(1, '커피챗 주제 키워드를 선택해주세요')
+    .required('커피챗 주제 키워드를 선택해주세요'),
   topic: yup.string().required('커피챗 주제 소개를 입력해주세요'),
   meetingType: yup.string().nullable(),
   guideline: yup.string().nullable(),
 });
 
-export const coffeChatchema = yup.object().shape({
+export const coffeeChatchema = yup.object().shape({
   memberInfo: myInfoSchema,
   coffeeChatInfo: coffeeChatInfoSchema,
 });

--- a/src/components/coffeechat/upload/CoffeechatForm/types.ts
+++ b/src/components/coffeechat/upload/CoffeechatForm/types.ts
@@ -1,14 +1,23 @@
 export interface CoffeechatFormContent {
   memberInfo: {
-    career: string;
-    introduction: string;
+    career: string | null;
+    introduction: string | null;
   };
   coffeeChatInfo: {
     sections: string[];
-    bio: string;
+    bio: string | null;
     topicTypes: string[];
-    topic: string;
-    meetingType: string;
-    guideline: string;
+    topic: string | null;
+    meetingType: string | null;
+    guideline: string | null;
   };
 }
+
+// MEMO: 모든 경로를 문자열로 만드는 유틸리티 타입
+type Path<T, K extends keyof T = keyof T> = K extends string
+  ? T[K] extends Record<string, unknown>
+    ? `${K}.${Path<T[K]>}` | K
+    : K
+  : never;
+
+export type CoffeechatFormPaths = Path<CoffeechatFormContent>;

--- a/src/components/coffeechat/upload/CoffeechatForm/types.ts
+++ b/src/components/coffeechat/upload/CoffeechatForm/types.ts
@@ -1,6 +1,6 @@
 export interface CoffeechatFormContent {
   memberInfo: {
-    career: string | null;
+    career: string[] | string | null;
     introduction: string | null;
   };
   coffeeChatInfo: {

--- a/src/components/coffeechat/upload/ProgressBox/index.tsx
+++ b/src/components/coffeechat/upload/ProgressBox/index.tsx
@@ -74,7 +74,7 @@ const ProgressWrapper = styled.div`
     bottom: 20px;
     left: 7px;
     transform: translateX(-50%);
-    background-color: ${colors.gray800};
+    background-color: ${colors.gray600};
     width: 1px;
     content: '';
   }

--- a/src/components/coffeechat/upload/ProgressBox/index.tsx
+++ b/src/components/coffeechat/upload/ProgressBox/index.tsx
@@ -30,16 +30,17 @@ export default function ProgressBox({ uploadType, myInfoInprogress, coffeechatIn
   );
 }
 
-const Box = styled.aside`
+const Box = styled.div`
   display: flex;
-  position: fixed;
+  position: sticky;
+  top: 80px;
   flex-direction: column;
   gap: 36px;
   align-items: flex-start;
   border: 1px solid ${colors.gray800};
   border-radius: 15px;
   padding: 50px 40px 60px;
-  width: 100%;
+  width: 290px;
   color: ${colors.gray10};
 `;
 

--- a/src/components/coffeechat/upload/UploadHeader/index.tsx
+++ b/src/components/coffeechat/upload/UploadHeader/index.tsx
@@ -19,11 +19,13 @@ export default function UploadHeader({ uploadType }: UploadHeaderProp) {
 }
 
 const Title = styled.h1`
+  margin-top: 44px;
   margin-bottom: 20px;
   color: ${colors.gray10};
   ${fonts.HEADING_32_B};
 
   @media ${COFFEECHAT_MOBILE_MEDIA_QUERY} {
+    margin-top: 0;
     ${fonts.HEADING_24_B};
   }
 `;

--- a/src/components/common/form/TextFieldLineBreak/index.tsx
+++ b/src/components/common/form/TextFieldLineBreak/index.tsx
@@ -32,6 +32,7 @@ export default function TextFieldLineBreak({
         isError={isError}
         errorMessage={errorMessage}
         onChange={onChange}
+        autoFocus={isError}
       />
       {!value && (
         <Placeholder>

--- a/src/components/common/form/TextFieldLineBreak/index.tsx
+++ b/src/components/common/form/TextFieldLineBreak/index.tsx
@@ -49,6 +49,8 @@ const TextAreaWrapper = styled.div`
 const Placeholder = styled.div`
   position: absolute;
   top: 8px;
+  right: 16px;
+  bottom: 8px;
   left: 16px;
   white-space: pre-wrap;
   color: ${colors.gray300};

--- a/src/components/common/form/TextFieldLineBreak/index.tsx
+++ b/src/components/common/form/TextFieldLineBreak/index.tsx
@@ -10,6 +10,7 @@ interface TextFieldLineBreakProps {
   lineBreakPlaceholder: string[];
   isError?: boolean;
   errorMessage?: string;
+  onChange: (e: React.ChangeEvent<HTMLTextAreaElement>) => void;
 }
 
 export default function TextFieldLineBreak({
@@ -19,6 +20,7 @@ export default function TextFieldLineBreak({
   lineBreakPlaceholder,
   isError = false,
   errorMessage,
+  onChange,
 }: TextFieldLineBreakProps) {
   return (
     <TextAreaWrapper>
@@ -29,6 +31,7 @@ export default function TextFieldLineBreak({
         maxHeight={fixedHeight}
         isError={isError}
         errorMessage={errorMessage}
+        onChange={onChange}
       />
       {!value && (
         <Placeholder>

--- a/src/components/common/form/TextFieldLineBreak/index.tsx
+++ b/src/components/common/form/TextFieldLineBreak/index.tsx
@@ -3,7 +3,10 @@ import { colors } from '@sopt-makers/colors';
 import { fonts } from '@sopt-makers/fonts';
 import { TextArea } from '@sopt-makers/ui';
 
+import { CoffeechatFormPaths } from '@/components/coffeechat/upload/CoffeechatForm/types';
+
 interface TextFieldLineBreakProps {
+  name: CoffeechatFormPaths;
   value: string;
   maxLength: number;
   fixedHeight: number;
@@ -14,6 +17,7 @@ interface TextFieldLineBreakProps {
 }
 
 export default function TextFieldLineBreak({
+  name,
   value,
   maxLength,
   fixedHeight,
@@ -25,6 +29,7 @@ export default function TextFieldLineBreak({
   return (
     <TextAreaWrapper>
       <TextArea
+        name={name}
         value={value}
         maxLength={maxLength}
         fixedHeight={fixedHeight}

--- a/src/constants/links.ts
+++ b/src/constants/links.ts
@@ -36,4 +36,6 @@ export const playgroundLink = {
   feedUpload: () => `/feed/upload`,
   feedEdit: (id: string | number) => `/feed/edit/${id}`,
   remember: () => `/remember`,
+  coffeechatUpload: () => `/coffeechat/upload`,
+  coffeechatEdit: (id: string | number) => `/coffeechat/edit/${id}`,
 };

--- a/src/pages/coffeechat/edit/[id].tsx
+++ b/src/pages/coffeechat/edit/[id].tsx
@@ -5,7 +5,7 @@ import { CoffeechatFormContent } from '@/components/coffeechat/upload/Coffeechat
 import Loading from '@/components/common/Loading';
 import { setLayout } from '@/utils/layout';
 import { useMutation } from '@tanstack/react-query';
-import { SubmitHandler } from 'react-hook-form';
+import { FieldValues } from 'react-hook-form';
 
 const CoffeechatEdit = () => {
   // const router = useRouter();
@@ -15,8 +15,10 @@ const CoffeechatEdit = () => {
     mutationFn: (reqeustBody: CoffeechatFormContent) => editCoffeechat.request({ ...reqeustBody }),
   });
 
-  const onSubmit: SubmitHandler<CoffeechatFormContent> = (data: CoffeechatFormContent) => {
+  const onSubmit = <T extends FieldValues>(values: T) => {
+    const data: CoffeechatFormContent = values as unknown as CoffeechatFormContent;
     const { memberInfo, coffeeChatInfo } = data;
+
     mutate(
       {
         memberInfo: { ...memberInfo, career: memberInfo.career ? memberInfo.career[0] : null },

--- a/src/pages/coffeechat/edit/[id].tsx
+++ b/src/pages/coffeechat/edit/[id].tsx
@@ -52,6 +52,7 @@ const CoffeechatEdit = () => {
   };
 
   if (isPending) {
+    // TODO: 데이터 get 해올 때의 isPending도 추가
     return <Loading />;
   }
 

--- a/src/pages/coffeechat/edit/[id].tsx
+++ b/src/pages/coffeechat/edit/[id].tsx
@@ -1,26 +1,63 @@
+import { editCoffeechat } from '@/api/endpoint/coffeechat/editCoffeechat';
 import AuthRequired from '@/components/auth/AuthRequired';
 import CoffeechatUploadPage from '@/components/coffeechat/page/CoffeechatUploadPage';
+import { CoffeechatFormContent } from '@/components/coffeechat/upload/CoffeechatForm/types';
+import Loading from '@/components/common/Loading';
 import { setLayout } from '@/utils/layout';
+import { useMutation } from '@tanstack/react-query';
+import { SubmitHandler } from 'react-hook-form';
 
 const CoffeechatEdit = () => {
+  // const router = useRouter();
+  // const queryClient = useQueryClient();
+
+  const { mutate, isPending } = useMutation({
+    mutationFn: (reqeustBody: CoffeechatFormContent) => editCoffeechat.request({ ...reqeustBody }),
+  });
+
+  const onSubmit: SubmitHandler<CoffeechatFormContent> = (data: CoffeechatFormContent) => {
+    const { memberInfo, coffeeChatInfo } = data;
+    mutate(
+      {
+        memberInfo: { ...memberInfo, career: memberInfo.career ? memberInfo.career[0] : null },
+        coffeeChatInfo: { ...coffeeChatInfo },
+      },
+      {
+        onSuccess: async () => {
+          // TODO: 쿼리 무효화 및 페이지 이동 처리
+          // queryClient.invalidateQueries({ queryKey: 'coffeechat' });
+          // await router.push(playgroundLink.coffeechatdetail());
+        },
+        onError: (error) => {
+          console.error('업로드 실패:', error);
+        },
+      },
+    );
+  };
+
+  // TODO: 데이터 get api 패칭 필요
   const defaultForm = {
     memberInfo: {
-      career: '주니어',
+      career: ['주니어 (0-3년)'], //TODO: 데이터 가져와서 배열에 담기
       introduction: '안녕하세요! 저는 프론트엔드 개발자로 다양한 프로젝트 경험을 쌓고 있습니다.',
     },
     coffeeChatInfo: {
-      sections: ['프론트엔드', '디자인'], // 다중 선택 가능 (전체, 기획, 디자인, 웹, 서버, 안드로이드, iOS)
+      sections: ['프론트엔드', '디자인'],
       bio: '프론트엔드 커리어 상담',
-      topicTypes: ['커리어', '포트폴리오'], // 창업, 네트워킹, 프로젝트, 커리어 등 다중 선택 가능
+      topicTypes: ['커리어', '포트폴리오'],
       topic: '프론트엔드 개발자로서의 커리어에 대해 상담하고 싶습니다.\n포트폴리오 제작과 인터뷰 팁도 나누고자 합니다.',
-      meetingType: '온라인', // 무관, 온라인, 오프라인 중 하나 선택
+      meetingType: '온라인',
       guideline: '시간 약속을 꼭 지켜주세요.\n질문은 미리 준비해 오시면 더욱 좋습니다.',
     },
   };
 
+  if (isPending) {
+    return <Loading />;
+  }
+
   return (
     <AuthRequired>
-      <CoffeechatUploadPage uploadType='수정' form={defaultForm} onSubmit={() => console.log('클릭')} />
+      <CoffeechatUploadPage uploadType='수정' form={defaultForm} onSubmit={onSubmit} />
     </AuthRequired>
   );
 };

--- a/src/pages/coffeechat/edit/[id].tsx
+++ b/src/pages/coffeechat/edit/[id].tsx
@@ -40,13 +40,13 @@ const CoffeechatEdit = () => {
   // TODO: 데이터 get api 패칭 필요
   const defaultForm = {
     memberInfo: {
-      career: ['주니어 (0-3년)'], //TODO: 데이터 가져와서 배열에 담기
+      career: '주니어 (0-3년)', //TODO: 데이터 가져와서 배열에 담기
       introduction: '안녕하세요! 저는 프론트엔드 개발자로 다양한 프로젝트 경험을 쌓고 있습니다.',
     },
     coffeeChatInfo: {
-      sections: ['프론트엔드', '디자인'],
+      sections: ['프론트', '디자인'],
       bio: '프론트엔드 커리어 상담',
-      topicTypes: ['커리어', '포트폴리오'],
+      topicTypes: ['포트폴리오', '이력서/자소서'],
       topic: '프론트엔드 개발자로서의 커리어에 대해 상담하고 싶습니다.\n포트폴리오 제작과 인터뷰 팁도 나누고자 합니다.',
       meetingType: '온라인',
       guideline: '시간 약속을 꼭 지켜주세요.\n질문은 미리 준비해 오시면 더욱 좋습니다.',

--- a/src/pages/coffeechat/edit/[id].tsx
+++ b/src/pages/coffeechat/edit/[id].tsx
@@ -1,0 +1,30 @@
+import AuthRequired from '@/components/auth/AuthRequired';
+import CoffeechatUploadPage from '@/components/coffeechat/page/CoffeechatUploadPage';
+import { setLayout } from '@/utils/layout';
+
+const CoffeechatEdit = () => {
+  const defaultForm = {
+    memberInfo: {
+      career: '주니어',
+      introduction: '안녕하세요! 저는 프론트엔드 개발자로 다양한 프로젝트 경험을 쌓고 있습니다.',
+    },
+    coffeeChatInfo: {
+      sections: ['프론트엔드', '디자인'], // 다중 선택 가능 (전체, 기획, 디자인, 웹, 서버, 안드로이드, iOS)
+      bio: '프론트엔드 커리어 상담',
+      topicTypes: ['커리어', '포트폴리오'], // 창업, 네트워킹, 프로젝트, 커리어 등 다중 선택 가능
+      topic: '프론트엔드 개발자로서의 커리어에 대해 상담하고 싶습니다.\n포트폴리오 제작과 인터뷰 팁도 나누고자 합니다.',
+      meetingType: '온라인', // 무관, 온라인, 오프라인 중 하나 선택
+      guideline: '시간 약속을 꼭 지켜주세요.\n질문은 미리 준비해 오시면 더욱 좋습니다.',
+    },
+  };
+
+  return (
+    <AuthRequired>
+      <CoffeechatUploadPage uploadType='수정' form={defaultForm} onSubmit={() => console.log('클릭')} />
+    </AuthRequired>
+  );
+};
+
+setLayout(CoffeechatEdit, 'header');
+
+export default CoffeechatEdit;

--- a/src/pages/coffeechat/upload.tsx
+++ b/src/pages/coffeechat/upload.tsx
@@ -17,7 +17,6 @@ const CoffeechatUpload = () => {
   });
 
   const onSubmit: SubmitHandler<CoffeechatFormContent> = (data: CoffeechatFormContent) => {
-    console.log(data);
     const { memberInfo, coffeeChatInfo } = data;
     mutate(
       {
@@ -26,7 +25,6 @@ const CoffeechatUpload = () => {
       },
       {
         onSuccess: async () => {
-          console.log('업로드 성공!');
           // TODO: 쿼리 무효화 및 페이지 이동 처리
           // queryClient.invalidateQueries({ queryKey: 'coffeechat' });
           // await router.push(playgroundLink.coffeechat());

--- a/src/pages/coffeechat/upload.tsx
+++ b/src/pages/coffeechat/upload.tsx
@@ -16,24 +16,27 @@ const CoffeechatUpload = () => {
     mutationFn: (reqeustBody: CoffeechatFormContent) => uploadCoffeechat.request({ ...reqeustBody }),
   });
 
-  const handleUploadSubmit: SubmitHandler<CoffeechatFormContent> = (data) => {
-    console.log('폼 제출 데이터:', data);
-    // mutate(data, {
-    //   onSuccess: async () => {
-    //     console.log('업로드 성공!');
-    //     // TODO: 쿼리 무효화 및 페이지 이동 처리
-    //     // queryClient.invalidateQueries({ queryKey: 'coffeechat' });
-    //     // await router.push(playgroundLink.coffeechat());
-    //   },
-    //   onError: (error) => {
-    //     console.error('업로드 실패:', error);
-    //   },
-    // });
+  const onSubmit: SubmitHandler<CoffeechatFormContent> = (data: CoffeechatFormContent) => {
+    console.log(data);
+    const { memberInfo, coffeeChatInfo } = data;
+    mutate(
+      {
+        memberInfo: { ...memberInfo, career: memberInfo.career ? memberInfo.career[0] : null },
+        coffeeChatInfo: { ...coffeeChatInfo },
+      },
+      {
+        onSuccess: async () => {
+          console.log('업로드 성공!');
+          // TODO: 쿼리 무효화 및 페이지 이동 처리
+          // queryClient.invalidateQueries({ queryKey: 'coffeechat' });
+          // await router.push(playgroundLink.coffeechat());
+        },
+        onError: (error) => {
+          console.error('업로드 실패:', error);
+        },
+      },
+    );
   };
-
-  // const handleUploadSubmit = (data: CoffeechatFormContent) => {
-  //   console.log(data);
-  // };
 
   const defaultForm = {
     memberInfo: {
@@ -56,7 +59,7 @@ const CoffeechatUpload = () => {
 
   return (
     <AuthRequired>
-      <CoffeechatUploadPage uploadType='오픈' form={defaultForm} onSubmit={handleUploadSubmit} />
+      <CoffeechatUploadPage uploadType='오픈' form={defaultForm} onSubmit={onSubmit} />
     </AuthRequired>
   );
 };

--- a/src/pages/coffeechat/upload.tsx
+++ b/src/pages/coffeechat/upload.tsx
@@ -1,5 +1,4 @@
 import { useMutation } from '@tanstack/react-query';
-import { SubmitHandler } from 'react-hook-form';
 
 import { uploadCoffeechat } from '@/api/endpoint/coffeechat/uploadCoffeechat';
 import AuthRequired from '@/components/auth/AuthRequired';
@@ -7,6 +6,7 @@ import CoffeechatUploadPage from '@/components/coffeechat/page/CoffeechatUploadP
 import { CoffeechatFormContent } from '@/components/coffeechat/upload/CoffeechatForm/types';
 import Loading from '@/components/common/Loading';
 import { setLayout } from '@/utils/layout';
+import { FieldValues } from 'react-hook-form';
 
 const CoffeechatUpload = () => {
   // const router = useRouter();
@@ -16,8 +16,10 @@ const CoffeechatUpload = () => {
     mutationFn: (reqeustBody: CoffeechatFormContent) => uploadCoffeechat.request({ ...reqeustBody }),
   });
 
-  const onSubmit: SubmitHandler<CoffeechatFormContent> = (data: CoffeechatFormContent) => {
+  const onSubmit = <T extends FieldValues>(values: T) => {
+    const data: CoffeechatFormContent = values as unknown as CoffeechatFormContent;
     const { memberInfo, coffeeChatInfo } = data;
+
     mutate(
       {
         memberInfo: { ...memberInfo, career: memberInfo.career ? memberInfo.career[0] : null },
@@ -35,6 +37,26 @@ const CoffeechatUpload = () => {
       },
     );
   };
+
+  // const onSubmit = (data: CoffeechatFormContent) => {
+  //   const { memberInfo, coffeeChatInfo } = data;
+  //   mutate(
+  //     {
+  //       memberInfo: { ...memberInfo, career: memberInfo.career ? memberInfo.career[0] : null },
+  //       coffeeChatInfo: { ...coffeeChatInfo },
+  //     },
+  //     {
+  //       onSuccess: async () => {
+  //         // TODO: 쿼리 무효화 및 페이지 이동 처리
+  //         // queryClient.invalidateQueries({ queryKey: 'coffeechat' });
+  //         // await router.push(playgroundLink.coffeechat());
+  //       },
+  //       onError: (error) => {
+  //         console.error('업로드 실패:', error);
+  //       },
+  //     },
+  //   );
+  // };
 
   const defaultForm = {
     memberInfo: {

--- a/src/pages/coffeechat/upload.tsx
+++ b/src/pages/coffeechat/upload.tsx
@@ -2,7 +2,7 @@ import AuthRequired from '@/components/auth/AuthRequired';
 import CoffeechatUploadPage from '@/components/coffeechat/page/CoffeechatUploadPage';
 import { setLayout } from '@/utils/layout';
 
-export default function CoffeechatUpload() {
+const CoffeechatUpload = () => {
   const defaultForm = {
     memberInfo: {
       career: '주니어',
@@ -23,6 +23,8 @@ export default function CoffeechatUpload() {
       <CoffeechatUploadPage uploadType='오픈' form={defaultForm} onSubmit={() => console.log('클릭')} />
     </AuthRequired>
   );
-}
+};
 
 setLayout(CoffeechatUpload, 'header');
+
+export default CoffeechatUpload;

--- a/src/pages/coffeechat/upload.tsx
+++ b/src/pages/coffeechat/upload.tsx
@@ -1,26 +1,62 @@
+import { useMutation } from '@tanstack/react-query';
+import { SubmitHandler } from 'react-hook-form';
+
+import { uploadCoffeechat } from '@/api/endpoint/coffeechat/uploadCoffeechat';
 import AuthRequired from '@/components/auth/AuthRequired';
 import CoffeechatUploadPage from '@/components/coffeechat/page/CoffeechatUploadPage';
+import { CoffeechatFormContent } from '@/components/coffeechat/upload/CoffeechatForm/types';
+import Loading from '@/components/common/Loading';
 import { setLayout } from '@/utils/layout';
 
 const CoffeechatUpload = () => {
+  // const router = useRouter();
+  // const queryClient = useQueryClient();
+
+  const { mutate, isPending } = useMutation({
+    mutationFn: (reqeustBody: CoffeechatFormContent) => uploadCoffeechat.request({ ...reqeustBody }),
+  });
+
+  const handleUploadSubmit: SubmitHandler<CoffeechatFormContent> = (data) => {
+    console.log('폼 제출 데이터:', data);
+    // mutate(data, {
+    //   onSuccess: async () => {
+    //     console.log('업로드 성공!');
+    //     // TODO: 쿼리 무효화 및 페이지 이동 처리
+    //     // queryClient.invalidateQueries({ queryKey: 'coffeechat' });
+    //     // await router.push(playgroundLink.coffeechat());
+    //   },
+    //   onError: (error) => {
+    //     console.error('업로드 실패:', error);
+    //   },
+    // });
+  };
+
+  // const handleUploadSubmit = (data: CoffeechatFormContent) => {
+  //   console.log(data);
+  // };
+
   const defaultForm = {
     memberInfo: {
-      career: '주니어',
-      introduction: '안녕하세요! 저는 프론트엔드 개발자로 다양한 프로젝트 경험을 쌓고 있습니다.',
+      career: null,
+      introduction: null,
     },
     coffeeChatInfo: {
-      sections: ['프론트엔드', '디자인'], // 다중 선택 가능 (전체, 기획, 디자인, 웹, 서버, 안드로이드, iOS)
-      bio: '프론트엔드 커리어 상담',
-      topicTypes: ['커리어', '포트폴리오'], // 창업, 네트워킹, 프로젝트, 커리어 등 다중 선택 가능
-      topic: '프론트엔드 개발자로서의 커리어에 대해 상담하고 싶습니다.\n포트폴리오 제작과 인터뷰 팁도 나누고자 합니다.',
-      meetingType: '온라인', // 무관, 온라인, 오프라인 중 하나 선택
-      guideline: '시간 약속을 꼭 지켜주세요.\n질문은 미리 준비해 오시면 더욱 좋습니다.',
+      sections: [],
+      bio: null,
+      topicTypes: [],
+      topic: null,
+      meetingType: null,
+      guideline: null,
     },
   };
 
+  if (isPending) {
+    return <Loading />;
+  }
+
   return (
     <AuthRequired>
-      <CoffeechatUploadPage uploadType='오픈' form={defaultForm} onSubmit={() => console.log('클릭')} />
+      <CoffeechatUploadPage uploadType='오픈' form={defaultForm} onSubmit={handleUploadSubmit} />
     </AuthRequired>
   );
 };

--- a/src/pages/coffeechat/upload.tsx
+++ b/src/pages/coffeechat/upload.tsx
@@ -1,0 +1,28 @@
+import AuthRequired from '@/components/auth/AuthRequired';
+import CoffeechatUploadPage from '@/components/coffeechat/page/CoffeechatUploadPage';
+import { setLayout } from '@/utils/layout';
+
+export default function CoffeechatUpload() {
+  const defaultForm = {
+    memberInfo: {
+      career: '주니어',
+      introduction: '안녕하세요! 저는 프론트엔드 개발자로 다양한 프로젝트 경험을 쌓고 있습니다.',
+    },
+    coffeeChatInfo: {
+      sections: ['프론트엔드', '디자인'], // 다중 선택 가능 (전체, 기획, 디자인, 웹, 서버, 안드로이드, iOS)
+      bio: '프론트엔드 커리어 상담',
+      topicTypes: ['커리어', '포트폴리오'], // 창업, 네트워킹, 프로젝트, 커리어 등 다중 선택 가능
+      topic: '프론트엔드 개발자로서의 커리어에 대해 상담하고 싶습니다.\n포트폴리오 제작과 인터뷰 팁도 나누고자 합니다.',
+      meetingType: '온라인', // 무관, 온라인, 오프라인 중 하나 선택
+      guideline: '시간 약속을 꼭 지켜주세요.\n질문은 미리 준비해 오시면 더욱 좋습니다.',
+    },
+  };
+
+  return (
+    <AuthRequired>
+      <CoffeechatUploadPage uploadType='오픈' form={defaultForm} onSubmit={() => console.log('클릭')} />
+    </AuthRequired>
+  );
+}
+
+setLayout(CoffeechatUpload, 'header');

--- a/yarn.lock
+++ b/yarn.lock
@@ -6263,9 +6263,9 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@sopt-makers/ui@npm:^2.4.4":
-  version: 2.4.4
-  resolution: "@sopt-makers/ui@npm:2.4.4"
+"@sopt-makers/ui@npm:^2.5.0":
+  version: 2.5.0
+  resolution: "@sopt-makers/ui@npm:2.5.0"
   dependencies:
     "@radix-ui/react-dialog": ^1.0.5
     "@radix-ui/react-switch": ^1.0.3
@@ -6278,7 +6278,7 @@ __metadata:
   peerDependencies:
     react: ^18.2.0
     react-dom: ^18.2.0
-  checksum: cddae8b5328294c56a4a2997160e1cb879afeef14d16fbabd1ee73cddea842bc206dc6014b96c48765cd226e09e1e8f580d1bff0f27613ac972b908bfb005ee6
+  checksum: 97a22845b2eeebd19d67fdbaf22c1fc29ebea690e6d8e1577c4f3d2b357fbe7f5973fcd095ef7f5bfef94aacd6436ca5d26c6706ebbcf4d53b0f78515645e9c4
   languageName: node
   linkType: hard
 
@@ -19739,7 +19739,7 @@ __metadata:
     "@sopt-makers/colors": ^3.0.0
     "@sopt-makers/fonts": ^1.0.0
     "@sopt-makers/icons": ^1.0.5
-    "@sopt-makers/ui": ^2.4.4
+    "@sopt-makers/ui": ^2.5.0
     "@storybook/addon-actions": ^7.0.23
     "@storybook/addon-docs": ^7.0.23
     "@storybook/addon-essentials": ^7.0.23


### PR DESCRIPTION
### 한 브랜치에 넘 많은 작업을 했습니다... 반성합니다.,,
### 🤫 쉿, 나한테만 말해줘요. 이슈넘버
- close #

### 🧐 어떤 것을 변경했어요~?
<!-- 실제로 변경한 사항을 설명해주세요.-->
- 커피챗 오픈/수정 로직을 구현했어요.

### 🤔 그렇다면, 어떻게 구현했어요~?
<!-- 실제로 구현한 로직에 대해 설명해주세요.-->

> react-hook-form 사용
- yup으로 작성한 스키마의 에러 메시지가 자동으로 잡힐 수 있도록 methods의 handleSubmit을 사용하기 위해, 각 필드에 다 Controller를 붙여주었어요.

> 에러 발생 시, 인풋 필드 자동 포커싱
- 에러가 발생한 필드 중에서 가장 첫번째 필드로 포커싱되도록 스크롤 이벤트를 넣어주었습니다. (onError)

> 커피챗 업로드 여부를 묻는 모달 구현
- 모든 필드에 에러가 없다면 모달이 띄워지는 onOpen함수를 실행하도록 했어요, 원래는 mds의 open(option) useDialog 훅을 사용하려고 했는데, open(option) 함수가 submit 타입과 맞지 않는다는 에러가 나서 mds 다이얼로그 컴포넌트를 조합해 다이얼로그를 직접 구현해주었습니다.

### ❤️‍🔥 당신이 생각하는 PR포인트, 내겐 매력포인트.
<!-- 해당 PR에서 논의가 필요한 사항을 적어주세요. -->
- [수정완료됨] 필드에 넣을 수 있는 값이 백엔드와 싱크가 맞지 않아서 지금 400에러가 납니다...! 이 부분은 예준이에게 요청해두었어요. 
    - ex. 프론트에서 주는 값 : 주니어 (0~3년) / 서버에서 받을 수 있는 값 : 주니어 
- 업로드 후 리패치 및 라우터 이동, 커피챗 수정 시의 데이터 패칭 작업이 TODO 로 남아있습니다! 이 부분은 커피챗 홈이랑 상세 페이지 연결하면서 채워둘게요!
- select v2가 다른 필드보다 위계가 뒤로 잡혀서 가려지는 현상이 있어 mds 측에 문의했어요!
- 로직 구현하면서도 스토리북에 이슈없도록 신경썼어요!

### 📸 스크린샷, 없으면 이것 참,, 섭섭한데요?
<img width="628" alt="스크린샷 2024-10-26 오전 12 37 17" src="https://github.com/user-attachments/assets/a189c85e-78f6-4089-ad5b-795c265a2697">

<img width="773" alt="스크린샷 2024-10-26 오전 12 37 36" src="https://github.com/user-attachments/assets/e8917ce8-9a55-4805-b8ed-2c1db115cd73">


