### PR TITLE
feat: 10/27 광고 구좌 변경

### DIFF
--- a/src/components/common/Banner/AdsBanner/AdsBox/index.tsx
+++ b/src/components/common/Banner/AdsBanner/AdsBox/index.tsx
@@ -1,6 +1,5 @@
-import styled from '@emotion/styled';
-
 import Responsive from '@/components/common/Responsive';
+import styled from '@emotion/styled';
 
 interface AdsProps {
   moImage: string;
@@ -13,7 +12,7 @@ interface AdsBoxProps extends AdsProps {
 
 export default function AdsBox({ moImage, pcImage, url }: AdsBoxProps) {
   return (
-    <AdsContainer>
+    <div>
       {url ? (
         <a href={url} target='_blank' rel='noopener noreferrer'>
           <Ads moImage={moImage} pcImage={pcImage} />
@@ -21,41 +20,26 @@ export default function AdsBox({ moImage, pcImage, url }: AdsBoxProps) {
       ) : (
         <Ads moImage={moImage} pcImage={pcImage} />
       )}
-    </AdsContainer>
+    </div>
   );
 }
 
 const Ads = ({ moImage, pcImage }: AdsProps) => {
   return (
-    <AdsWrapper>
+    <article>
       <Responsive only='desktop'>
         <AdsImage src={pcImage} alt='PC 광고' />
       </Responsive>
-      <MobileLayout only='mobile'>
+      <Responsive only='mobile'>
         <AdsImage src={moImage} alt='모바일 광고' />
-      </MobileLayout>
-    </AdsWrapper>
+      </Responsive>
+    </article>
   );
 };
 
-const MobileLayout = styled(Responsive)`
-  width: 100%;
-`;
-
 const AdsImage = styled.img`
-  height: 100%;
-`;
-
-const AdsWrapper = styled.article`
-  display: flex;
-  align-items: center;
-  justify-content: center;
   width: 100%;
-  max-width: 912px;
-  overflow: hidden;
-`;
-
-const AdsContainer = styled.div`
-  display: flex;
-  justify-content: center;
+  height: 100%;
+  object-fit: cover; 
+  object-position: center;
 `;

--- a/src/components/common/Banner/AdsBanner/AdsBox/index.tsx
+++ b/src/components/common/Banner/AdsBanner/AdsBox/index.tsx
@@ -2,26 +2,41 @@ import styled from '@emotion/styled';
 
 import Responsive from '@/components/common/Responsive';
 
-interface AdsBoxProps {
+interface AdsProps {
   moImage: string;
   pcImage: string;
+}
+
+interface AdsBoxProps extends AdsProps {
   url: string;
 }
 
 export default function AdsBox({ moImage, pcImage, url }: AdsBoxProps) {
   return (
-    <AdsContainer href={url} target='_blank' rel='noopener noreferrer'>
-      <AdsWrapper>
-        <Responsive only='desktop'>
-          <AdsImage src={pcImage} alt='PC 광고' />
-        </Responsive>
-        <MobileLayout only='mobile'>
-          <AdsImage src={moImage} alt='모바일 광고' />
-        </MobileLayout>
-      </AdsWrapper>
+    <AdsContainer>
+      {url ? (
+        <a href={url} target='_blank' rel='noopener noreferrer'>
+          <Ads moImage={moImage} pcImage={pcImage} />
+        </a>
+      ) : (
+        <Ads moImage={moImage} pcImage={pcImage} />
+      )}
     </AdsContainer>
   );
 }
+
+const Ads = ({ moImage, pcImage }: AdsProps) => {
+  return (
+    <AdsWrapper>
+      <Responsive only='desktop'>
+        <AdsImage src={pcImage} alt='PC 광고' />
+      </Responsive>
+      <MobileLayout only='mobile'>
+        <AdsImage src={moImage} alt='모바일 광고' />
+      </MobileLayout>
+    </AdsWrapper>
+  );
+};
 
 const MobileLayout = styled(Responsive)`
   width: 100%;
@@ -40,7 +55,7 @@ const AdsWrapper = styled.article`
   overflow: hidden;
 `;
 
-const AdsContainer = styled.a`
+const AdsContainer = styled.div`
   display: flex;
   justify-content: center;
 `;

--- a/src/components/common/Banner/AdsBanner/constants/ads.ts
+++ b/src/components/common/Banner/AdsBanner/constants/ads.ts
@@ -34,9 +34,8 @@ export const ADS = [
       'https://sopt-makers-internal.s3.ap-northeast-2.amazonaws.com/prod/image/advertisements/%E1%84%92%E1%85%A1%E1%86%AB%E1%84%81%E1%85%B5%E1%84%8C%E1%85%A9%E1%86%A8%E1%84%87%E1%85%A9_MOBILE.png',
     pcImage:
       'https://sopt-makers-internal.s3.ap-northeast-2.amazonaws.com/prod/image/advertisements/%E1%84%92%E1%85%A1%E1%86%AB%E1%84%81%E1%85%B5%E1%84%8C%E1%85%A9%E1%86%A8%E1%84%87%E1%85%A9_PC.png',
-    url: 'link.inpock.co.kr/hankkilink',
+    url: 'https://link.inpock.co.kr/hankkilink',
   },
-
   {
     // 메이커스 마케팅 오거나이저
     id: 6,

--- a/src/components/common/Banner/AdsBanner/constants/ads.ts
+++ b/src/components/common/Banner/AdsBanner/constants/ads.ts
@@ -1,16 +1,45 @@
 export const ADS = [
   {
-    // 픽플
+    // 손지유 님
     id: 1,
-    moImage:
-      'https://sopt-makers-internal.s3.ap-northeast-2.amazonaws.com/prod/image/advertisements/%E1%84%91%E1%85%B5%E1%86%A8%E1%84%91%E1%85%B3%E1%86%AF+MO.png',
-    pcImage:
-      'https://sopt-makers-internal.s3.ap-northeast-2.amazonaws.com/prod/image/advertisements/%E1%84%91%E1%85%B5%E1%86%A8%E1%84%91%E1%85%B3%E1%86%AF+PC.png',
-    url: 'https://pick-ple.com/class-list?category=all',
+    moImage: 'https://sopt-makers-internal.s3.ap-northeast-2.amazonaws.com/prod/image/advertisements/1027_PG_1_MO.png',
+    pcImage: 'https://sopt-makers-internal.s3.ap-northeast-2.amazonaws.com/prod/image/advertisements/1027_PG_1_PC.png',
+    url: '',
   },
   {
-    // 메이커스 마케팅 오거나이저
+    //SOPT 운영팀
     id: 2,
+    moImage: 'https://sopt-makers-internal.s3.ap-northeast-2.amazonaws.com/prod/image/advertisements/1027_PG_2_MO.png',
+    pcImage: 'https://sopt-makers-internal.s3.ap-northeast-2.amazonaws.com/prod/image/advertisements/1027_PG_2_PC.png',
+    url: 'https://www.instagram.com/sopt_timi_tmi/?hl=ko',
+  },
+  {
+    // 이현진 님
+    id: 3,
+    moImage: 'https://sopt-makers-internal.s3.ap-northeast-2.amazonaws.com/prod/image/advertisements/1027_PG_3_MO.png',
+    pcImage: 'https://sopt-makers-internal.s3.ap-northeast-2.amazonaws.com/prod/image/advertisements/1027_PG_3_PC.png',
+    url: 'https://www.instagram.com/sopt_timi_tmi/?hl=ko',
+  },
+  {
+    // 이현진 님
+    id: 4,
+    moImage: 'https://sopt-makers-internal.s3.ap-northeast-2.amazonaws.com/prod/image/advertisements/1027_PG_4_MO.png',
+    pcImage: 'https://sopt-makers-internal.s3.ap-northeast-2.amazonaws.com/prod/image/advertisements/1027_PG_4_PC.png',
+    url: 'https://www.instagram.com/sopt_timi_tmi/?hl=ko',
+  },
+  {
+    // 김지혜 님
+    id: 5,
+    moImage:
+      'https://sopt-makers-internal.s3.ap-northeast-2.amazonaws.com/prod/image/advertisements/%E1%84%92%E1%85%A1%E1%86%AB%E1%84%81%E1%85%B5%E1%84%8C%E1%85%A9%E1%86%A8%E1%84%87%E1%85%A9_MOBILE.png',
+    pcImage:
+      'https://sopt-makers-internal.s3.ap-northeast-2.amazonaws.com/prod/image/advertisements/%E1%84%92%E1%85%A1%E1%86%AB%E1%84%81%E1%85%B5%E1%84%8C%E1%85%A9%E1%86%A8%E1%84%87%E1%85%A9_PC.png',
+    url: 'link.inpock.co.kr/hankkilink',
+  },
+
+  {
+    // 메이커스 마케팅 오거나이저
+    id: 6,
     moImage:
       'https://sopt-makers-internal.s3.ap-northeast-2.amazonaws.com/prod/image/advertisements/%E1%84%91%E1%85%B3%E1%86%AF%E1%84%80%E1%85%B3+MO.png',
     pcImage:

--- a/src/components/common/Banner/AdsBanner/index.tsx
+++ b/src/components/common/Banner/AdsBanner/index.tsx
@@ -30,7 +30,7 @@ const AdsBanner: React.FC = () => {
     speed: 500,
     slidesToShow: 1,
     slidesToScroll: 1,
-    autoplay: true, // 자동 캐러셀
+    // autoplay: true, // 자동 캐러셀
     autoplaySpeed: 5000,
     arrows: true, // 좌,우 버튼
     initialSlide: 0, // 첫 컨텐츠 번호
@@ -77,6 +77,7 @@ export default AdsBanner;
 
 const SliderWrapper = styled.div`
   display: flex;
+  align-items: center;
   justify-content: center;
   margin: 16px 0;
 `;
@@ -87,6 +88,7 @@ const AdsSlider = styled(Slider as React.ComponentType<Settings>)`
   justify-content: center;
   margin: 0 30px;
   border-radius: 12px;
+  background-color: blue;
   max-width: 912px;
   overflow: hidden;
 

--- a/src/components/common/Banner/AdsBanner/index.tsx
+++ b/src/components/common/Banner/AdsBanner/index.tsx
@@ -30,7 +30,7 @@ const AdsBanner: React.FC = () => {
     speed: 500,
     slidesToShow: 1,
     slidesToScroll: 1,
-    // autoplay: true, // 자동 캐러셀
+    autoplay: true, // 자동 캐러셀
     autoplaySpeed: 5000,
     arrows: true, // 좌,우 버튼
     initialSlide: 0, // 첫 컨텐츠 번호
@@ -88,7 +88,6 @@ const AdsSlider = styled(Slider as React.ComponentType<Settings>)`
   justify-content: center;
   margin: 0 30px;
   border-radius: 12px;
-  background-color: blue;
   max-width: 912px;
   overflow: hidden;
 
@@ -177,7 +176,8 @@ const AdsSlider = styled(Slider as React.ComponentType<Settings>)`
   }
 
   @media ${MOBILE_MEDIA_QUERY} {
-    margin: -8px 20px -20px;
+    aspect-ratio: 340 / 168;
+    margin: 0 20px -4px;
   }
 `;
 


### PR DESCRIPTION
### 🤫 쉿, 나한테만 말해줘요. 이슈넘버
- close #1605

### 🧐 어떤 것을 변경했어요~?
<!-- 실제로 변경한 사항을 설명해주세요.-->
- 10.27 광고 구좌 변경했어요.
- 광고 반응형 css도 좀 수정했습니다.
    - 불필요한 css 삭제
    - 여러 이미지가 있는 경우 가장 height가 긴 이미지로 비율이 맞춰져서, 그보다 height이 짧은 이미지는 아래쪽에 여백이 생기는 문제가 있어 수정했어요.  
- 광고에 url이 없는 경우 분기처리도 추가해주었습니다.

### 🤔 그렇다면, 어떻게 구현했어요~?
<!-- 실제로 구현한 로직에 대해 설명해주세요.-->
- 처음 써보는데, `aspect-ratio: 340 / 168;` 이런식으로 이미지를 감싸는 박스에 직접 비율을 부여해주었습니다.

### ❤️‍🔥 당신이 생각하는 PR포인트, 내겐 매력포인트.
<!-- 해당 PR에서 논의가 필요한 사항을 적어주세요. -->

### 📸 스크린샷, 없으면 이것 참,, 섭섭한데요?

