### PR TITLE
feat: 커피챗 상세 페이지 구현

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "@sopt-makers/colors": "^3.0.0",
     "@sopt-makers/fonts": "^1.0.0",
     "@sopt-makers/icons": "^1.0.5",
-    "@sopt-makers/ui": "2.4.4",
+    "@sopt-makers/ui": "^2.7.1",
     "@tanstack/react-query": "^5.4.3",
     "@toss/emotion-utils": "^1.1.10",
     "@toss/error-boundary": "^1.4.6",

--- a/src/api/endpoint/coffeechat/changeIsBlindCoffeechat.ts
+++ b/src/api/endpoint/coffeechat/changeIsBlindCoffeechat.ts
@@ -1,0 +1,12 @@
+import { z } from 'zod';
+
+import { createEndpoint } from '@/api/typedAxios';
+
+export const changeIsBlindCoffeechat = createEndpoint({
+  request: (open: boolean) => ({
+    method: 'POST',
+    url: 'api/v1/members/coffeechat/open',
+    data: { open: open },
+  }),
+  serverResponseScheme: z.unknown(),
+});

--- a/src/api/endpoint/coffeechat/getCoffeechatDetail.ts
+++ b/src/api/endpoint/coffeechat/getCoffeechatDetail.ts
@@ -9,17 +9,18 @@ const CoffeechatDetailSchema = z.object({
   name: z.string(),
   career: z.string(),
   organization: z.string().nullable(),
-  companyJob: z.string().nullable(),
+  memberCareerTitle: z.string().nullable(),
   phone: z.string(),
   email: z.string(),
   introduction: z.string(),
   topicTypeList: z.array(z.string()),
   topic: z.string(),
   meetingType: z.string(),
-  guideline: z.string(),
+  guideline: z.string().nullable(),
   isMine: z.boolean().nullable(),
   isBlind: z.boolean().nullable(),
-  profileImage: z.string(),
+  profileImage: z.string().nullable(),
+  isCoffeeChatActivate: z.boolean().nullable(),
 });
 
 export const getCoffeechatDetail = createEndpoint({

--- a/src/api/endpoint/coffeechat/getCoffeechatDetail.ts
+++ b/src/api/endpoint/coffeechat/getCoffeechatDetail.ts
@@ -1,0 +1,41 @@
+import { z } from 'zod';
+
+import { createEndpoint } from '@/api/typedAxios';
+import { useQuery } from '@tanstack/react-query';
+
+const CoffeechatDetailSchema = z.object({
+  bio: z.string(),
+  memberId: z.number(),
+  name: z.string(),
+  career: z.string(),
+  organization: z.string().nullable(),
+  companyJob: z.string().nullable(),
+  phone: z.string(),
+  email: z.string(),
+  introduction: z.string(),
+  topicTypeList: z.array(z.string()),
+  topic: z.string(),
+  meetingType: z.string(),
+  guideline: z.string(),
+  isMine: z.boolean().nullable(),
+  isBlind: z.boolean().nullable(),
+  profileImage: z.string(),
+});
+
+export const getCoffeechatDetail = createEndpoint({
+  request: (memberId: string) => ({
+    method: 'GET',
+    url: `api/v1/members/coffeechat/${memberId}`,
+  }),
+  serverResponseScheme: CoffeechatDetailSchema,
+});
+
+export const useGetCoffeechatDetail = (memberId: string | undefined) => {
+  const id = memberId ?? '';
+
+  return useQuery({
+    queryKey: getCoffeechatDetail.cacheKey(id),
+    queryFn: () => getCoffeechatDetail.request(id),
+    enabled: !!memberId,
+  });
+};

--- a/src/api/endpoint/coffeechat/postCoffeechatIsBlind.ts
+++ b/src/api/endpoint/coffeechat/postCoffeechatIsBlind.ts
@@ -1,9 +1,10 @@
-import { createEndpoint } from '@/api/typedAxios';
 import { z } from 'zod';
+
+import { createEndpoint } from '@/api/typedAxios';
 
 export const changeIsBlindCoffeechat = createEndpoint({
   request: (open: boolean) => ({
-    method: 'POST',
+    method: 'PATCH',
     url: 'api/v1/members/coffeechat/open',
     data: { open: open },
   }),

--- a/src/api/endpoint/coffeechat/postCoffeechatIsBlind.ts
+++ b/src/api/endpoint/coffeechat/postCoffeechatIsBlind.ts
@@ -1,6 +1,5 @@
-import { z } from 'zod';
-
 import { createEndpoint } from '@/api/typedAxios';
+import { z } from 'zod';
 
 export const changeIsBlindCoffeechat = createEndpoint({
   request: (open: boolean) => ({

--- a/src/components/coffeechat/detail/CoffeechatContents/index.tsx
+++ b/src/components/coffeechat/detail/CoffeechatContents/index.tsx
@@ -1,0 +1,33 @@
+import { useGetCoffeechatDetail } from '@/api/endpoint/coffeechat/getCoffeechatDetail';
+import { Tag } from '@sopt-makers/ui';
+
+interface CoffeechatContentsProps {
+  memberId: string;
+}
+
+export default function CoffeechatContents({ memberId }: CoffeechatContentsProps) {
+  const { data: openerProfile } = useGetCoffeechatDetail(memberId);
+
+  return (
+    <>
+      {openerProfile && (
+        <>
+          <>{openerProfile.introduction}</>
+          <p>제가 이야기 나누고 싶은 주제는</p>
+          {openerProfile.topicTypeList.map((topicType) => {
+            return (
+              <Tag key={topicType} shape='pill' size='lg' type='solid' variant='default'>
+                {topicType}
+              </Tag>
+            );
+          })}
+          <>{openerProfile.introduction}</>
+          <p>제가 이야기 나누고 싶은 주제는</p>
+          <Tag shape='pill' size='lg' type='solid' variant='default'>
+            {openerProfile.meetingType}
+          </Tag>
+        </>
+      )}
+    </>
+  );
+}

--- a/src/components/coffeechat/detail/CoffeechatContents/index.tsx
+++ b/src/components/coffeechat/detail/CoffeechatContents/index.tsx
@@ -1,5 +1,10 @@
-import { useGetCoffeechatDetail } from '@/api/endpoint/coffeechat/getCoffeechatDetail';
+import styled from '@emotion/styled';
+import { colors } from '@sopt-makers/colors';
+import { fonts } from '@sopt-makers/fonts';
 import { Tag } from '@sopt-makers/ui';
+
+import { useGetCoffeechatDetail } from '@/api/endpoint/coffeechat/getCoffeechatDetail';
+import { MOBILE_MEDIA_QUERY } from '@/styles/mediaQuery';
 
 interface CoffeechatContentsProps {
   memberId: string;
@@ -11,23 +16,101 @@ export default function CoffeechatContents({ memberId }: CoffeechatContentsProps
   return (
     <>
       {openerProfile && (
-        <>
-          <>{openerProfile.introduction}</>
-          <p>제가 이야기 나누고 싶은 주제는</p>
-          {openerProfile.topicTypeList.map((topicType) => {
-            return (
-              <Tag key={topicType} shape='pill' size='lg' type='solid' variant='default'>
-                {topicType}
+        <CoffeechatContentsWrapper>
+          <ContentsBox>
+            <Text>{openerProfile.introduction}</Text>
+          </ContentsBox>
+          <ContentsBox>
+            <EachContent>
+              <Subtitle>제가 이야기 나누고 싶은 주제는</Subtitle>
+              <Tags>
+                {openerProfile.topicTypeList.map((topicType) => {
+                  return (
+                    <CoffeechatTag key={topicType} shape='pill' size='lg' type='solid' variant='default'>
+                      {topicType}
+                    </CoffeechatTag>
+                  );
+                })}
+              </Tags>
+              <Text>{openerProfile.topic}</Text>
+            </EachContent>
+            <EachContent>
+              <Subtitle>진행방법</Subtitle>
+              <Tag shape='pill' size='lg' type='solid' variant='default'>
+                {openerProfile.meetingType}
               </Tag>
-            );
-          })}
-          <>{openerProfile.introduction}</>
-          <p>제가 이야기 나누고 싶은 주제는</p>
-          <Tag shape='pill' size='lg' type='solid' variant='default'>
-            {openerProfile.meetingType}
-          </Tag>
-        </>
+            </EachContent>
+            <EachContent>
+              <Subtitle>유의사항</Subtitle>
+              <Text>{openerProfile.guideline}</Text>
+            </EachContent>
+          </ContentsBox>
+        </CoffeechatContentsWrapper>
       )}
     </>
   );
 }
+
+const Subtitle = styled.p`
+  color: ${colors.gray300};
+  ${fonts.TITLE_16_SB};
+
+  @media ${MOBILE_MEDIA_QUERY} {
+    ${fonts.TITLE_14_SB};
+  }
+`;
+
+const EachContent = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+`;
+
+const Text = styled.p`
+  white-space: pre-wrap;
+  word-break: break-word;
+  overflow-wrap: break-word;
+  color: ${colors.white};
+  ${fonts.BODY_18_M};
+
+  @media ${MOBILE_MEDIA_QUERY} {
+    ${fonts.BODY_16_M};
+  }
+`;
+
+const ContentsBox = styled.section`
+  display: flex;
+  flex-direction: column;
+  gap: 32px;
+  border-radius: 20px;
+  background-color: ${colors.gray900};
+  padding: 32px 40px;
+
+  @media ${MOBILE_MEDIA_QUERY} {
+    gap: 28px;
+  }
+`;
+
+const CoffeechatContentsWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+  margin-top: 28px;
+  margin-bottom: 24px;
+
+  @media ${MOBILE_MEDIA_QUERY} {
+    gap: 18px;
+    margin-top: 24px;
+    margin-bottom: 18px;
+  }
+`;
+
+const Tags = styled.div`
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+`;
+
+const CoffeechatTag = styled(Tag)`
+  padding: 4px 14px;
+`;

--- a/src/components/coffeechat/detail/OpenerProfile/index.tsx
+++ b/src/components/coffeechat/detail/OpenerProfile/index.tsx
@@ -103,7 +103,7 @@ const InfoWrapper = styled.div`
 const IconInfo = styled.div`
   display: flex;
   gap: 4px;
-  align-items: center;
+  align-items: flex-start;
 `;
 
 const ProfileHeader = styled.header`

--- a/src/components/coffeechat/detail/OpenerProfile/index.tsx
+++ b/src/components/coffeechat/detail/OpenerProfile/index.tsx
@@ -1,3 +1,4 @@
+import { useGetCoffeechatDetail } from '@/api/endpoint/coffeechat/getCoffeechatDetail';
 import { MOBILE_MEDIA_QUERY } from '@/styles/mediaQuery';
 import styled from '@emotion/styled';
 import { colors } from '@sopt-makers/colors';
@@ -10,18 +11,7 @@ interface OpenerProfileProps {
 }
 
 export default function OpenerProfile({ memberId }: OpenerProfileProps) {
-  //   const { data: openerProfile } = useGetCoffeechatDetail(memberId);
-  //  TODO 데이터 패칭한 내용으로 변경
-  const openerProfile = {
-    name: '서지수',
-    career: '주니어 (0~3년)',
-    organization: 'Google',
-    companyJob: 'CEOCEOCEOCEOCEOCEOCEOCEOCEOCEO',
-    phone: '01011111111',
-    email: '111@gmail.com',
-    profileImage:
-      'https://s3.ap-northeast-2.amazonaws.com/sopt-makers-internal//prod/image/project/5193f63e-6910-4bd4-9591-8b42c5132419-IMG_6957.jpeg',
-  };
+  const { data: openerProfile } = useGetCoffeechatDetail(memberId);
 
   return (
     <>
@@ -40,8 +30,8 @@ export default function OpenerProfile({ memberId }: OpenerProfileProps) {
               <Career>{openerProfile.career}</Career>
             </ProfileHeader>
             <Company>
-              {openerProfile.organization && openerProfile.organization + ' | '}
-              {openerProfile.companyJob && openerProfile.companyJob}
+              {openerProfile.organization && openerProfile.organization}
+              {openerProfile.memberCareerTitle && ' | ' + openerProfile.memberCareerTitle}
             </Company>
             <InfoWrapper>
               <PhoneInfo>

--- a/src/components/coffeechat/detail/OpenerProfile/index.tsx
+++ b/src/components/coffeechat/detail/OpenerProfile/index.tsx
@@ -1,10 +1,14 @@
-import { useGetCoffeechatDetail } from '@/api/endpoint/coffeechat/getCoffeechatDetail';
-import { MOBILE_MEDIA_QUERY } from '@/styles/mediaQuery';
+import { css } from '@emotion/react';
 import styled from '@emotion/styled';
 import { colors } from '@sopt-makers/colors';
 import { fonts } from '@sopt-makers/fonts';
 import { IconMail } from '@sopt-makers/icons';
 import ProfileIcon from 'public/icons/icon-profile.svg';
+
+import { useGetCoffeechatDetail } from '@/api/endpoint/coffeechat/getCoffeechatDetail';
+import RegisterCoffeechatButton from '@/components/coffeechat/detail/RegisterCoffeechatButton';
+import ShowCoffeechatToggle from '@/components/coffeechat/detail/ShowCoffeechatToggle';
+import { MOBILE_MEDIA_QUERY } from '@/styles/mediaQuery';
 
 interface OpenerProfileProps {
   memberId: string;
@@ -16,7 +20,7 @@ export default function OpenerProfile({ memberId }: OpenerProfileProps) {
   return (
     <>
       {openerProfile && (
-        <OpenerProfileSection>
+        <OpenerProfileSection isMine={!!openerProfile.isMine}>
           <ProfileImageBox>
             {openerProfile.profileImage ? (
               <ProfileImage src={openerProfile.profileImage} alt='프로필 이미지' />
@@ -34,19 +38,53 @@ export default function OpenerProfile({ memberId }: OpenerProfileProps) {
               {openerProfile.memberCareerTitle && ' | ' + openerProfile.memberCareerTitle}
             </Company>
             <InfoWrapper>
-              <PhoneInfo>
-                <PhoneIcon /> <>{openerProfile.phone}</>
-              </PhoneInfo>
-              <MailInfo>
-                <MailIcon /> <>{openerProfile.email}</>
-              </MailInfo>
+              <IconInfo>
+                <PhoneIcon /> <InfoText>{openerProfile.phone}</InfoText>
+              </IconInfo>
+              <IconInfo>
+                <MailIcon /> <InfoText>{openerProfile.email}</InfoText>
+              </IconInfo>
             </InfoWrapper>
           </ProfileInfoBox>
+          <ButtonSection>
+            {openerProfile.isMine ? (
+              <ShowCoffeechatToggle isBlind={!!openerProfile.isCoffeeChatActivate} memberId={memberId} />
+            ) : (
+              <RegisterCoffeechatButton
+                onClick={() => {
+                  console.log('TODO: 커피챗 모달 열기 추가');
+                }}
+              />
+            )}
+          </ButtonSection>
         </OpenerProfileSection>
       )}
     </>
   );
 }
+
+const IconPhone = () => {
+  return (
+    <svg xmlns='http://www.w3.org/2000/svg' width='20' height='21' viewBox='0 0 20 21' fill='none'>
+      <path
+        d='M17.2202 16.1423C17.2202 16.1423 16.2546 17.0906 16.018 17.3686C15.6325 17.78 15.1784 17.9742 14.583 17.9742C14.5258 17.9742 14.4647 17.9742 14.4075 17.9704C13.274 17.898 12.2207 17.4562 11.4307 17.0792C9.27058 16.0356 7.37382 14.5541 5.79764 12.6764C4.49624 11.1111 3.6261 9.66381 3.04982 8.10989C2.6949 7.16155 2.56514 6.42268 2.62238 5.7257C2.66055 5.28009 2.83229 4.91066 3.14905 4.59454L4.45045 3.2958C4.63745 3.12061 4.83591 3.02539 5.03054 3.02539C5.27098 3.02539 5.46561 3.17012 5.58774 3.29199C5.59156 3.2958 5.59537 3.29961 5.59919 3.30342C5.83199 3.52051 6.05334 3.74522 6.28614 3.98516C6.40445 4.10704 6.52658 4.22891 6.6487 4.3546L7.69058 5.39435C8.09512 5.79806 8.09512 6.17131 7.69058 6.57502C7.57991 6.68547 7.47305 6.79592 7.36237 6.90256C7.04179 7.2301 7.29363 6.97878 6.9616 7.27586C6.95397 7.28347 6.94633 7.28728 6.94252 7.2949C6.6143 7.62244 6.67537 7.94236 6.74406 8.15946C6.74788 8.17088 6.7517 8.18231 6.75551 8.19373C7.02648 8.84881 7.40812 9.46581 7.98821 10.2009L7.99203 10.2047C9.04536 11.4996 10.1559 12.5089 11.381 13.282C11.5375 13.3811 11.6978 13.461 11.8504 13.5372C11.9878 13.6058 12.1176 13.6705 12.2283 13.7391C12.2435 13.7467 12.2588 13.7581 12.274 13.7657C12.4038 13.8305 12.5259 13.861 12.6519 13.861C12.9686 13.861 13.1671 13.6629 13.232 13.5982L13.98 12.8516C14.1098 12.7221 14.3159 12.566 14.5563 12.566C14.7929 12.566 14.9876 12.7145 15.1059 12.844C15.1097 12.8478 15.1097 12.8478 15.1135 12.8516L17.2164 14.9502C17.6094 15.3386 17.2202 16.1423 17.2202 16.1423Z'
+        stroke='#808087'
+        stroke-width='1.25'
+        stroke-linecap='round'
+        stroke-linejoin='round'
+      />
+    </svg>
+  );
+};
+
+const InfoText = styled.p`
+  width: 100%;
+  overflow-wrap: anywhere;
+`;
+
+const ButtonSection = styled.div`
+  grid-area: buttonSection;
+`;
 
 const InfoWrapper = styled.div`
   display: flex;
@@ -62,14 +100,10 @@ const InfoWrapper = styled.div`
   }
 `;
 
-const PhoneInfo = styled.div`
+const IconInfo = styled.div`
   display: flex;
   gap: 4px;
-`;
-
-const MailInfo = styled.div`
-  display: flex;
-  gap: 4px;
+  align-items: center;
 `;
 
 const ProfileHeader = styled.header`
@@ -79,6 +113,13 @@ const ProfileHeader = styled.header`
 
   @media ${MOBILE_MEDIA_QUERY} {
     gap: 8px;
+  }
+
+  @media (max-width: 360px) {
+    flex-direction: column;
+    gap: 0;
+    align-items: flex-start;
+    margin-bottom: 4px;
   }
 `;
 
@@ -117,24 +158,53 @@ const MailIcon = styled(IconMail)`
 `;
 
 // TODO: 폰 아이콘 mds에 반영되면 반영 필요
-const PhoneIcon = styled(IconMail)`
+const PhoneIcon = styled(IconPhone)`
   width: 20px;
   height: 20px;
 `;
 
-const OpenerProfileSection = styled.section`
-  display: flex;
+const OpenerProfileSection = styled.section<{ isMine: boolean }>`
+  display: grid;
+  grid: [row1-start] 'profileImageBox profileInfoBox  buttonSection' auto [row1-end]/ auto;
+  grid-template-columns: 1fr 5fr 2fr;
   gap: 28px;
   align-items: center;
+  justify-content: space-between;
+  width: 100%;
 
   @media ${MOBILE_MEDIA_QUERY} {
-    gap: 24px;
+    ${({ isMine }) =>
+      isMine
+        ? css`
+            grid:
+              [row1-start] 'profileImageBox profileInfoBox' auto [row1-end]
+              [row2-start] 'blank buttonSection' auto [row2-end]/ auto;
+            grid-template-columns: 1fr 10fr;
+          `
+        : css`
+            grid:
+              [row1-start] 'profileImageBox profileInfoBox' auto [row1-end]
+              [row2-start] 'buttonSection buttonSection' auto [row2-end]/ auto;
+            grid-template-columns: 1fr 10fr;
+          `}
+
+    gap: 16px 24px;
+    justify-content: start;
+  }
+
+  @media (max-width: 360px) {
+    grid:
+      [row1-start] 'profileImageBox profileInfoBox' auto [row1-end]
+      [row2-start] 'buttonSection buttonSection' auto [row2-end]/ auto;
+    grid-template-columns: 1fr 10fr;
+    align-items: flex-start;
   }
 `;
 
 const ProfileImageBox = styled.div`
   display: flex;
   position: relative;
+  grid-area: profileImageBox;
   align-items: center;
   justify-content: center;
   border-radius: 24px;
@@ -159,6 +229,6 @@ const ProfileImage = styled.img`
 const ProfileInfoBox = styled.div`
   display: flex;
   flex-direction: column;
-  overflow-wrap: break-word;
-  word-wrap: break-word;
+  grid-area: profileInfoBox;
+  width: 100%;
 `;

--- a/src/components/coffeechat/detail/OpenerProfile/index.tsx
+++ b/src/components/coffeechat/detail/OpenerProfile/index.tsx
@@ -1,0 +1,174 @@
+import { MOBILE_MEDIA_QUERY } from '@/styles/mediaQuery';
+import styled from '@emotion/styled';
+import { colors } from '@sopt-makers/colors';
+import { fonts } from '@sopt-makers/fonts';
+import { IconMail } from '@sopt-makers/icons';
+import ProfileIcon from 'public/icons/icon-profile.svg';
+
+interface OpenerProfileProps {
+  memberId: string;
+}
+
+export default function OpenerProfile({ memberId }: OpenerProfileProps) {
+  //   const { data: openerProfile } = useGetCoffeechatDetail(memberId);
+  //  TODO 데이터 패칭한 내용으로 변경
+  const openerProfile = {
+    name: '서지수',
+    career: '주니어 (0~3년)',
+    organization: 'Google',
+    companyJob: 'CEOCEOCEOCEOCEOCEOCEOCEOCEOCEO',
+    phone: '01011111111',
+    email: '111@gmail.com',
+    profileImage:
+      'https://s3.ap-northeast-2.amazonaws.com/sopt-makers-internal//prod/image/project/5193f63e-6910-4bd4-9591-8b42c5132419-IMG_6957.jpeg',
+  };
+
+  return (
+    <>
+      {openerProfile && (
+        <OpenerProfileSection>
+          <ProfileImageBox>
+            {openerProfile.profileImage ? (
+              <ProfileImage src={openerProfile.profileImage} alt='프로필 이미지' />
+            ) : (
+              <ProfileIcon />
+            )}
+          </ProfileImageBox>
+          <ProfileInfoBox>
+            <ProfileHeader>
+              <Name>{openerProfile.name}</Name>
+              <Career>{openerProfile.career}</Career>
+            </ProfileHeader>
+            <Company>
+              {openerProfile.organization && openerProfile.organization + ' | '}
+              {openerProfile.companyJob && openerProfile.companyJob}
+            </Company>
+            <InfoWrapper>
+              <PhoneInfo>
+                <PhoneIcon /> <>{openerProfile.phone}</>
+              </PhoneInfo>
+              <MailInfo>
+                <MailIcon /> <>{openerProfile.email}</>
+              </MailInfo>
+            </InfoWrapper>
+          </ProfileInfoBox>
+        </OpenerProfileSection>
+      )}
+    </>
+  );
+}
+
+const InfoWrapper = styled.div`
+  display: flex;
+  gap: 12px;
+  margin-top: 16px;
+  color: ${colors.gray300};
+  ${fonts.BODY_13_M};
+
+  @media ${MOBILE_MEDIA_QUERY} {
+    flex-direction: column;
+    gap: 4px;
+    ${fonts.BODY_13_M};
+  }
+`;
+
+const PhoneInfo = styled.div`
+  display: flex;
+  gap: 4px;
+`;
+
+const MailInfo = styled.div`
+  display: flex;
+  gap: 4px;
+`;
+
+const ProfileHeader = styled.header`
+  display: flex;
+  gap: 11px;
+  align-items: center;
+
+  @media ${MOBILE_MEDIA_QUERY} {
+    gap: 8px;
+  }
+`;
+
+const Company = styled.p`
+  overflow-wrap: break-word;
+  word-wrap: break-word;
+  color: ${colors.gray200};
+  ${fonts.BODY_16_M};
+
+  @media ${MOBILE_MEDIA_QUERY} {
+    ${fonts.BODY_14_M};
+  }
+`;
+
+const Name = styled.h1`
+  color: ${colors.white};
+  ${fonts.HEADING_28_B};
+
+  @media ${MOBILE_MEDIA_QUERY} {
+    ${fonts.HEADING_24_B};
+  }
+`;
+
+const Career = styled.h2`
+  color: ${colors.gray100};
+  ${fonts.BODY_18_M};
+
+  @media ${MOBILE_MEDIA_QUERY} {
+    ${fonts.BODY_14_M};
+  }
+`;
+
+const MailIcon = styled(IconMail)`
+  width: 20px;
+  height: 20px;
+`;
+
+// TODO: 폰 아이콘 mds에 반영되면 반영 필요
+const PhoneIcon = styled(IconMail)`
+  width: 20px;
+  height: 20px;
+`;
+
+const OpenerProfileSection = styled.section`
+  display: flex;
+  gap: 28px;
+  align-items: center;
+
+  @media ${MOBILE_MEDIA_QUERY} {
+    gap: 24px;
+  }
+`;
+
+const ProfileImageBox = styled.div`
+  display: flex;
+  position: relative;
+  align-items: center;
+  justify-content: center;
+  border-radius: 24px;
+  background: ${colors.gray700};
+  width: 134px;
+  height: 134px;
+  overflow: hidden;
+
+  @media ${MOBILE_MEDIA_QUERY} {
+    border-radius: 21px;
+    width: 120px;
+    height: 120px;
+  }
+`;
+
+const ProfileImage = styled.img`
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+`;
+
+const ProfileInfoBox = styled.div`
+  display: flex;
+  flex-direction: column;
+  overflow-wrap: break-word;
+  word-wrap: break-word;
+`;

--- a/src/components/coffeechat/detail/RegisterCoffeechatButton/index.tsx
+++ b/src/components/coffeechat/detail/RegisterCoffeechatButton/index.tsx
@@ -1,0 +1,21 @@
+import Responsive from '@/components/common/Responsive';
+import { Button } from '@sopt-makers/ui';
+
+interface RegisterCoffeechatButtonProps {
+  onClick: () => void;
+}
+
+export default function RegisterCoffeechatButton({ onClick }: RegisterCoffeechatButtonProps) {
+  return (
+    <div onClick={onClick}>
+      <Responsive only='desktop'>
+        <Button size='lg'>커피챗 제안하기</Button>
+      </Responsive>
+      <Responsive only='mobile'>
+        <Button size='md' style={{ width: '100%' }}>
+          커피챗 제안하기
+        </Button>
+      </Responsive>
+    </div>
+  );
+}

--- a/src/components/coffeechat/detail/RegisterCoffeechatButton/index.tsx
+++ b/src/components/coffeechat/detail/RegisterCoffeechatButton/index.tsx
@@ -1,5 +1,6 @@
-import Responsive from '@/components/common/Responsive';
 import { Button } from '@sopt-makers/ui';
+
+import Responsive from '@/components/common/Responsive';
 
 interface RegisterCoffeechatButtonProps {
   onClick: () => void;
@@ -9,7 +10,9 @@ export default function RegisterCoffeechatButton({ onClick }: RegisterCoffeechat
   return (
     <div onClick={onClick}>
       <Responsive only='desktop'>
-        <Button size='lg'>커피챗 제안하기</Button>
+        <Button size='lg' style={{ float: 'right' }}>
+          커피챗 제안하기
+        </Button>
       </Responsive>
       <Responsive only='mobile'>
         <Button size='md' style={{ width: '100%' }}>

--- a/src/components/coffeechat/detail/ShowCoffeechatToggle/index.tsx
+++ b/src/components/coffeechat/detail/ShowCoffeechatToggle/index.tsx
@@ -1,6 +1,3 @@
-import { getCoffeechatDetail } from '@/api/endpoint/coffeechat/getCoffeechatDetail';
-import { changeIsBlindCoffeechat } from '@/api/endpoint/coffeechat/postCoffeechatIsBlind';
-import useEventLogger from '@/components/eventLogger/hooks/useEventLogger';
 import styled from '@emotion/styled';
 import { colors } from '@sopt-makers/colors';
 import { fonts } from '@sopt-makers/fonts';
@@ -8,6 +5,11 @@ import { Toggle } from '@sopt-makers/ui';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { useRouter } from 'next/router';
 import { playgroundLink } from 'playground-common/export';
+
+import { getCoffeechatDetail } from '@/api/endpoint/coffeechat/getCoffeechatDetail';
+import { changeIsBlindCoffeechat } from '@/api/endpoint/coffeechat/postCoffeechatIsBlind';
+import useEventLogger from '@/components/eventLogger/hooks/useEventLogger';
+import { MOBILE_MEDIA_QUERY } from '@/styles/mediaQuery';
 
 interface ShowCoffeechatToggleProps {
   isBlind: boolean;
@@ -44,6 +46,17 @@ export default function ShowCoffeechatToggle({ isBlind, memberId }: ShowCoffeech
 const ToggleSection = styled.div`
   display: flex;
   gap: 8px;
+  justify-content: flex-end;
+  margin-bottom: 8px;
   color: ${colors.gray300};
   ${fonts.BODY_16_R};
+
+  @media ${MOBILE_MEDIA_QUERY} {
+    float: left;
+    margin-bottom: 0;
+  }
+
+  @media (max-width: 360px) {
+    float: right;
+  }
 `;

--- a/src/components/coffeechat/detail/ShowCoffeechatToggle/index.tsx
+++ b/src/components/coffeechat/detail/ShowCoffeechatToggle/index.tsx
@@ -1,0 +1,49 @@
+import { getCoffeechatDetail } from '@/api/endpoint/coffeechat/getCoffeechatDetail';
+import { changeIsBlindCoffeechat } from '@/api/endpoint/coffeechat/postCoffeechatIsBlind';
+import useEventLogger from '@/components/eventLogger/hooks/useEventLogger';
+import styled from '@emotion/styled';
+import { colors } from '@sopt-makers/colors';
+import { fonts } from '@sopt-makers/fonts';
+import { Toggle } from '@sopt-makers/ui';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { useRouter } from 'next/router';
+import { playgroundLink } from 'playground-common/export';
+
+interface ShowCoffeechatToggleProps {
+  isBlind: boolean;
+  memberId: string;
+}
+
+export default function ShowCoffeechatToggle({ isBlind, memberId }: ShowCoffeechatToggleProps) {
+  const { logSubmitEvent } = useEventLogger();
+  const queryClient = useQueryClient();
+  const router = useRouter();
+
+  const { mutate } = useMutation({
+    mutationFn: (open: boolean) => changeIsBlindCoffeechat.request(open),
+  });
+
+  const handlChangeIsBlind = () => {
+    mutate(!isBlind, {
+      onSuccess: async () => {
+        // logSubmitEvent('isBlindCoffeechat');
+        queryClient.invalidateQueries({ queryKey: getCoffeechatDetail.cacheKey(memberId) });
+        await router.push(playgroundLink.coffeechatDetail(memberId));
+      },
+    });
+  };
+
+  return (
+    <ToggleSection>
+      <>커피챗 숨기기</>
+      <Toggle checked={!isBlind} size='lg' onClick={handlChangeIsBlind} />
+    </ToggleSection>
+  );
+}
+
+const ToggleSection = styled.div`
+  display: flex;
+  gap: 8px;
+  color: ${colors.gray300};
+  ${fonts.BODY_16_R};
+`;

--- a/src/components/coffeechat/detail/index.tsx
+++ b/src/components/coffeechat/detail/index.tsx
@@ -1,0 +1,146 @@
+import styled from '@emotion/styled';
+import { colors } from '@sopt-makers/colors';
+import { fonts } from '@sopt-makers/fonts';
+import { IconDotsVertical } from '@sopt-makers/icons';
+import { useMemo } from 'react';
+
+import { useGetCoffeechatDetail } from '@/api/endpoint/coffeechat/getCoffeechatDetail';
+import { useGetMemberOfMe } from '@/api/endpoint/members/getMemberOfMe';
+import { useGetMemberProfileById } from '@/api/endpoint_LEGACY/hooks';
+import CoffeechatContents from '@/components/coffeechat/detail/CoffeechatContents';
+import OpenerProfile from '@/components/coffeechat/detail/OpenerProfile';
+import Loading from '@/components/common/Loading';
+import CareerSection from '@/components/members/detail/CareerSection';
+import ProjectSection from '@/components/members/detail/ProjectSection';
+import SoptActivitySection from '@/components/members/detail/SoptActivitySection';
+import { MOBILE_MEDIA_QUERY } from '@/styles/mediaQuery';
+import { safeParseInt } from '@/utils';
+
+interface CoffeechatDetailProp {
+  memberId: string;
+}
+
+export default function CoffeechatDetail({ memberId }: CoffeechatDetailProp) {
+  const { data: openerProfile } = useGetCoffeechatDetail(memberId);
+  const { data: profile } = useGetMemberProfileById(safeParseInt(memberId) ?? undefined);
+
+  const { data: me } = useGetMemberOfMe();
+
+  const sortedSoptActivities = useMemo(() => {
+    if (!profile?.soptActivities) {
+      return [];
+    }
+    const sorted = [...profile.soptActivities];
+    sorted.sort((a, b) => b.generation - a.generation);
+    return sorted;
+  }, [profile?.soptActivities]);
+
+  return (
+    <DetailPageLayout>
+      <DetailPage>
+        <CoffeechatLoading />
+        {openerProfile && profile && me ? (
+          <>
+            <CoffeechatHeader>
+              <CoffeechatTitle>{openerProfile.bio}</CoffeechatTitle>
+              {/* TODO: 더보기 버튼 기능 구현 */}
+              {/* <>{openerProfile.isMine && <DotsVerticalIcon />}</> */}
+            </CoffeechatHeader>
+            <OpenerProfile memberId={memberId} />
+
+            <CoffeechatContents memberId={memberId} />
+            <CareerSection
+              careers={profile.careers}
+              links={profile.links}
+              skill={profile.skill}
+              name={profile.name}
+              email={profile.email}
+              profileImage={profile.profileImage}
+              memberId={memberId}
+              isMine={profile.isMine}
+              isCoffeechatTap
+            />
+            <SoptActivityTitle>SOPT 활동 정보</SoptActivityTitle>
+            <SoptActivitySection soptActivities={sortedSoptActivities} />
+            <ProfilPojectSection>
+              <ProjectSection profile={profile} memberId={memberId} meId={me?.id} isCoffeechatTap />
+            </ProfilPojectSection>
+          </>
+        ) : (
+          <CoffeechatLoading>
+            <Loading />
+          </CoffeechatLoading>
+        )}
+      </DetailPage>
+    </DetailPageLayout>
+  );
+}
+
+const CoffeechatLoading = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+`;
+
+const ProfilPojectSection = styled.div`
+  margin-top: -56px;
+`;
+
+const SoptActivityTitle = styled.h2`
+  margin: 28px 0 32px;
+  color: ${colors.white};
+  ${fonts.HEADING_32_B};
+
+  @media ${MOBILE_MEDIA_QUERY} {
+    margin: 24px 0;
+
+    ${fonts.HEADING_28_B};
+  }
+`;
+
+const DetailPageLayout = styled.div`
+  display: flex;
+  justify-content: center;
+`;
+
+const DetailPage = styled.div`
+  margin: 120px 30px;
+  max-width: 790px;
+
+  @media ${MOBILE_MEDIA_QUERY} {
+    margin: 24px 30px;
+    width: 100%;
+  }
+`;
+
+const DotsVerticalIcon = styled(IconDotsVertical)`
+  width: 24px;
+  height: 24px;
+`;
+
+const CoffeechatTitle = styled.h1`
+  /* stylelint-disable-next-line value-no-vendor-prefix */
+  display: -webkit-box;
+  width: 100%;
+  max-width: 697px;
+  height: 90px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  color: ${colors.white};
+  ${fonts.HEADING_32_B};
+
+  @media ${MOBILE_MEDIA_QUERY} {
+    ${fonts.HEADING_28_B};
+
+    height: 84px;
+  }
+`;
+
+const CoffeechatHeader = styled.header`
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 24px;
+`;

--- a/src/components/members/detail/CareerSection/index.tsx
+++ b/src/components/members/detail/CareerSection/index.tsx
@@ -25,6 +25,7 @@ interface CareerSectionProps {
   memberId: string;
   isMine: boolean;
   shouldNeedOnlyItems?: boolean;
+  isCoffeechatTap?: boolean;
 }
 
 export default function CareerSection({
@@ -37,6 +38,7 @@ export default function CareerSection({
   memberId,
   isMine,
   shouldNeedOnlyItems = false,
+  isCoffeechatTap = false,
 }: CareerSectionProps) {
   const router = useRouter();
   const Container = shouldNeedOnlyItems ? Slot : StyledMemberDetailSection;
@@ -78,13 +80,17 @@ export default function CareerSection({
           />
         )}
       </>
-      {isMine ? (
-        <MoveButton onClick={() => router.push(playgroundLink.feedUpload())}>
-          <WriteIcon src='/icons/icon-pencil-simple.svg' />
-          직무 경험 SOPT와 공유하기
-        </MoveButton>
-      ) : (
-        <MessageSection name={name} email={email} profileImage={profileImage} memberId={memberId} />
+      {!isCoffeechatTap && (
+        <>
+          {isMine ? (
+            <MoveButton onClick={() => router.push(playgroundLink.feedUpload())}>
+              <WriteIcon src='/icons/icon-pencil-simple.svg' />
+              직무 경험 SOPT와 공유하기
+            </MoveButton>
+          ) : (
+            <MessageSection name={name} email={email} profileImage={profileImage} memberId={memberId} />
+          )}
+        </>
       )}
     </Container>
   ) : null;

--- a/src/components/members/detail/ProjectSection/index.tsx
+++ b/src/components/members/detail/ProjectSection/index.tsx
@@ -9,22 +9,30 @@ import Text from '@/components/common/Text';
 import useEventLogger from '@/components/eventLogger/hooks/useEventLogger';
 import MemberProjectCard from '@/components/members/detail/ActivitySection/MemberProjectCard';
 import { MOBILE_MEDIA_QUERY } from '@/styles/mediaQuery';
+import { fonts } from '@sopt-makers/fonts';
 
 interface ProjectActivitySectionProps {
   profile: ProfileDetail;
   memberId: string;
   meId?: number | undefined;
+  isCoffeechatTap?: boolean;
 }
 
-const ProjectSection = ({ profile, memberId, meId }: ProjectActivitySectionProps) => {
+const ProjectSection = ({ profile, memberId, meId, isCoffeechatTap = false }: ProjectActivitySectionProps) => {
   const { logClickEvent } = useEventLogger();
 
   return (
     <Container>
-      <ActivityTitle>{profile.name}님이 참여한 프로젝트</ActivityTitle>
+      {!isCoffeechatTap && <ActivityTitle>{profile.name}님이 참여한 프로젝트</ActivityTitle>}
       {profile.projects.length > 0 && (
         <>
-          <ActivitySub>{profile.projects.length}개의 프로젝트에 참여</ActivitySub>
+          {isCoffeechatTap ? (
+            <CoffeechatActivitySub>
+              {profile.name}님이 참여한 {profile.projects.length}개의 프로젝트예요!
+            </CoffeechatActivitySub>
+          ) : (
+            <ActivitySub>{profile.projects.length}개의 프로젝트에 참여</ActivitySub>
+          )}
           <ActivityDisplay>
             {profile.projects.map((project) => (
               <MemberProjectCard key={project.id} {...project} />
@@ -59,6 +67,11 @@ const ProjectSection = ({ profile, memberId, meId }: ProjectActivitySectionProps
     </Container>
   );
 };
+
+const CoffeechatActivitySub = styled.p`
+  color: ${colors.white};
+  ${fonts.HEADING_28_B};
+`;
 
 const Container = styled.section`
   margin-top: 80px;

--- a/src/constants/links.ts
+++ b/src/constants/links.ts
@@ -36,4 +36,5 @@ export const playgroundLink = {
   feedUpload: () => `/feed/upload`,
   feedEdit: (id: string | number) => `/feed/edit/${id}`,
   remember: () => `/remember`,
+  coffeechatDetail: (id: string | number) => `/coffeechat/${id}`,
 };

--- a/src/pages/coffeechat/[id].tsx
+++ b/src/pages/coffeechat/[id].tsx
@@ -1,4 +1,6 @@
+import { useGetCoffeechatDetail } from '@/api/endpoint/coffeechat/getCoffeechatDetail';
 import AuthRequired from '@/components/auth/AuthRequired';
+import CoffeechatContents from '@/components/coffeechat/detail/CoffeechatContents';
 import OpenerProfile from '@/components/coffeechat/detail/OpenerProfile';
 import RegisterCoffeechatButton from '@/components/coffeechat/detail/RegisterCoffeechatButton';
 import ShowCoffeechatToggle from '@/components/coffeechat/detail/ShowCoffeechatToggle';
@@ -13,66 +15,67 @@ import { IconDotsVertical } from '@sopt-makers/icons';
 export default function CoffeechatDetailPage() {
   const { query, status } = useStringRouterQuery(['id'] as const);
   const memberId = status === 'success' ? query.id : '';
-  //   const { data: openerProfile } = useGetCoffeechatDetail(memberId);
+  const { data: openerProfile } = useGetCoffeechatDetail(memberId);
+  console.log(openerProfile);
+  // const openerProfile = {
+  //   bio: '안녕하세요',
+  //   memberId: 209,
+  //   name: '이승헌',
+  //   career: '없음',
+  //   organization: null,
+  //   companyJob: null,
+  //   phone: '01040316120',
+  //   email: 'seungheon328@gmail.com',
+  //   introduction: '소개입니다',
+  //   topicTypeList: ['창업', '네트워킹'],
+  //   topic: '주제입니다',
+  //   meetingType: '온라인',
+  //   guideline: '주의입니다',
+  //   isMine: true,
+  //   isBlind: false,
+  //   profileImage:
+  //     'https://s3.ap-northeast-2.amazonaws.com/sopt-makers-internal//prod/image/project/5193f63e-6910-4bd4-9591-8b42c5132419-IMG_6957.jpeg',
+  // };
 
-  const openerProfile = {
-    bio: '안녕하세요',
-    memberId: 209,
-    name: '이승헌',
-    career: '없음',
-    organization: null,
-    companyJob: null,
-    phone: '01040316120',
-    email: 'seungheon328@gmail.com',
-    introduction: '소개입니다',
-    topicTypeList: ['창업', '네트워킹'],
-    topic: '주제입니다',
-    meetingType: '온라인',
-    guideline: '주의입니다',
-    isMine: true,
-    isBlind: false,
-    profileImage:
-      'https://s3.ap-northeast-2.amazonaws.com/sopt-makers-internal//prod/image/project/5193f63e-6910-4bd4-9591-8b42c5132419-IMG_6957.jpeg',
-  };
+  if (status === 'loading') {
+    return null;
+  }
 
-  //   if (status === 'loading') {
-  //     return null;
-  //   }
+  if (status === 'error') {
+    return null;
+  }
 
-  //   if (status === 'error') {
-  //     return null;
-  //   }
-
-  //   if (status === 'success') {
-  return (
-    <AuthRequired>
-      <DetailPage>
-        {openerProfile ? (
-          <>
-            <CoffeechatHeader>
-              <CoffeechatTitle>{openerProfile.bio}</CoffeechatTitle>
-              <>{openerProfile.isMine && <DotsVerticalIcon />}</>
-            </CoffeechatHeader>
-            <Profile>
-              <OpenerProfile memberId={memberId} />
-              {openerProfile.isMine ? (
-                <ShowCoffeechatToggle isBlind={openerProfile.isBlind} memberId={memberId} />
-              ) : (
-                <RegisterCoffeechatButton
-                  onClick={() => {
-                    console.log('TODO: 커피챗 모달 열기 추가');
-                  }}
-                />
-              )}
-            </Profile>
-          </>
-        ) : (
-          <Loading />
-        )}
-      </DetailPage>
-    </AuthRequired>
-  );
-  //   }
+  if (status === 'success') {
+    return (
+      <AuthRequired>
+        <DetailPage>
+          {openerProfile ? (
+            <>
+              <CoffeechatHeader>
+                <CoffeechatTitle>{openerProfile.bio}</CoffeechatTitle>
+                <>{openerProfile.isMine && <DotsVerticalIcon />}</>
+              </CoffeechatHeader>
+              <Profile>
+                <OpenerProfile memberId={memberId} />
+                {openerProfile.isMine ? (
+                  <ShowCoffeechatToggle isBlind={!!openerProfile.isBlind} memberId={memberId} />
+                ) : (
+                  <RegisterCoffeechatButton
+                    onClick={() => {
+                      console.log('TODO: 커피챗 모달 열기 추가');
+                    }}
+                  />
+                )}
+              </Profile>
+              <CoffeechatContents memberId={memberId} />
+            </>
+          ) : (
+            <Loading />
+          )}
+        </DetailPage>
+      </AuthRequired>
+    );
+  }
 }
 
 const Profile = styled.section`

--- a/src/pages/coffeechat/[id].tsx
+++ b/src/pages/coffeechat/[id].tsx
@@ -1,0 +1,115 @@
+import AuthRequired from '@/components/auth/AuthRequired';
+import OpenerProfile from '@/components/coffeechat/detail/OpenerProfile';
+import RegisterCoffeechatButton from '@/components/coffeechat/detail/RegisterCoffeechatButton';
+import ShowCoffeechatToggle from '@/components/coffeechat/detail/ShowCoffeechatToggle';
+import Loading from '@/components/common/Loading';
+import useStringRouterQuery from '@/hooks/useStringRouterQuery';
+import { MOBILE_MEDIA_QUERY } from '@/styles/mediaQuery';
+import styled from '@emotion/styled';
+import { colors } from '@sopt-makers/colors';
+import { fonts } from '@sopt-makers/fonts';
+import { IconDotsVertical } from '@sopt-makers/icons';
+
+export default function CoffeechatDetailPage() {
+  const { query, status } = useStringRouterQuery(['id'] as const);
+  const memberId = status === 'success' ? query.id : '';
+  //   const { data: openerProfile } = useGetCoffeechatDetail(memberId);
+
+  const openerProfile = {
+    bio: '안녕하세요',
+    memberId: 209,
+    name: '이승헌',
+    career: '없음',
+    organization: null,
+    companyJob: null,
+    phone: '01040316120',
+    email: 'seungheon328@gmail.com',
+    introduction: '소개입니다',
+    topicTypeList: ['창업', '네트워킹'],
+    topic: '주제입니다',
+    meetingType: '온라인',
+    guideline: '주의입니다',
+    isMine: true,
+    isBlind: false,
+    profileImage:
+      'https://s3.ap-northeast-2.amazonaws.com/sopt-makers-internal//prod/image/project/5193f63e-6910-4bd4-9591-8b42c5132419-IMG_6957.jpeg',
+  };
+
+  //   if (status === 'loading') {
+  //     return null;
+  //   }
+
+  //   if (status === 'error') {
+  //     return null;
+  //   }
+
+  //   if (status === 'success') {
+  return (
+    <AuthRequired>
+      <DetailPage>
+        {openerProfile ? (
+          <>
+            <CoffeechatHeader>
+              <CoffeechatTitle>{openerProfile.bio}</CoffeechatTitle>
+              <>{openerProfile.isMine && <DotsVerticalIcon />}</>
+            </CoffeechatHeader>
+            <Profile>
+              <OpenerProfile memberId={memberId} />
+              {openerProfile.isMine ? (
+                <ShowCoffeechatToggle isBlind={openerProfile.isBlind} memberId={memberId} />
+              ) : (
+                <RegisterCoffeechatButton
+                  onClick={() => {
+                    console.log('TODO: 커피챗 모달 열기 추가');
+                  }}
+                />
+              )}
+            </Profile>
+          </>
+        ) : (
+          <Loading />
+        )}
+      </DetailPage>
+    </AuthRequired>
+  );
+  //   }
+}
+
+const Profile = styled.section`
+  display: flex;
+`;
+
+const DetailPage = styled.div`
+  margin: 0 30px;
+`;
+
+const DotsVerticalIcon = styled(IconDotsVertical)`
+  width: 24px;
+  height: 24px;
+`;
+
+const CoffeechatTitle = styled.h1`
+  height: 96px;
+  overflow-wrap: break-word;
+  word-break: break-word;
+  color: ${colors.white};
+  ${fonts.HEADING_32_B};
+
+  @media ${MOBILE_MEDIA_QUERY} {
+    ${fonts.HEADING_28_B};
+
+    height: 84px;
+  }
+`;
+
+const CoffeechatHeader = styled.header`
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-top: 120px;
+  margin-bottom: 24px;
+
+  @media ${MOBILE_MEDIA_QUERY} {
+    margin-top: 24px;
+  }
+`;

--- a/src/pages/coffeechat/[id].tsx
+++ b/src/pages/coffeechat/[id].tsx
@@ -1,118 +1,20 @@
-import { useGetCoffeechatDetail } from '@/api/endpoint/coffeechat/getCoffeechatDetail';
 import AuthRequired from '@/components/auth/AuthRequired';
-import CoffeechatContents from '@/components/coffeechat/detail/CoffeechatContents';
-import OpenerProfile from '@/components/coffeechat/detail/OpenerProfile';
-import RegisterCoffeechatButton from '@/components/coffeechat/detail/RegisterCoffeechatButton';
-import ShowCoffeechatToggle from '@/components/coffeechat/detail/ShowCoffeechatToggle';
-import Loading from '@/components/common/Loading';
+import CoffeechatDetail from '@/components/coffeechat/detail';
 import useStringRouterQuery from '@/hooks/useStringRouterQuery';
-import { MOBILE_MEDIA_QUERY } from '@/styles/mediaQuery';
-import styled from '@emotion/styled';
-import { colors } from '@sopt-makers/colors';
-import { fonts } from '@sopt-makers/fonts';
-import { IconDotsVertical } from '@sopt-makers/icons';
+import { setLayout } from '@/utils/layout';
 
-export default function CoffeechatDetailPage() {
+const CoffeechatDetailPage = () => {
   const { query, status } = useStringRouterQuery(['id'] as const);
   const memberId = status === 'success' ? query.id : '';
-  const { data: openerProfile } = useGetCoffeechatDetail(memberId);
-  console.log(openerProfile);
-  // const openerProfile = {
-  //   bio: '안녕하세요',
-  //   memberId: 209,
-  //   name: '이승헌',
-  //   career: '없음',
-  //   organization: null,
-  //   companyJob: null,
-  //   phone: '01040316120',
-  //   email: 'seungheon328@gmail.com',
-  //   introduction: '소개입니다',
-  //   topicTypeList: ['창업', '네트워킹'],
-  //   topic: '주제입니다',
-  //   meetingType: '온라인',
-  //   guideline: '주의입니다',
-  //   isMine: true,
-  //   isBlind: false,
-  //   profileImage:
-  //     'https://s3.ap-northeast-2.amazonaws.com/sopt-makers-internal//prod/image/project/5193f63e-6910-4bd4-9591-8b42c5132419-IMG_6957.jpeg',
-  // };
 
-  if (status === 'loading') {
-    return null;
-  }
+  return (
+    <AuthRequired>
+      {(status === 'loading' || status === 'error') && null}
+      {status === 'success' ? <CoffeechatDetail memberId={memberId} /> : null}
+    </AuthRequired>
+  );
+};
 
-  if (status === 'error') {
-    return null;
-  }
+setLayout(CoffeechatDetailPage, 'header');
 
-  if (status === 'success') {
-    return (
-      <AuthRequired>
-        <DetailPage>
-          {openerProfile ? (
-            <>
-              <CoffeechatHeader>
-                <CoffeechatTitle>{openerProfile.bio}</CoffeechatTitle>
-                <>{openerProfile.isMine && <DotsVerticalIcon />}</>
-              </CoffeechatHeader>
-              <Profile>
-                <OpenerProfile memberId={memberId} />
-                {openerProfile.isMine ? (
-                  <ShowCoffeechatToggle isBlind={!!openerProfile.isBlind} memberId={memberId} />
-                ) : (
-                  <RegisterCoffeechatButton
-                    onClick={() => {
-                      console.log('TODO: 커피챗 모달 열기 추가');
-                    }}
-                  />
-                )}
-              </Profile>
-              <CoffeechatContents memberId={memberId} />
-            </>
-          ) : (
-            <Loading />
-          )}
-        </DetailPage>
-      </AuthRequired>
-    );
-  }
-}
-
-const Profile = styled.section`
-  display: flex;
-`;
-
-const DetailPage = styled.div`
-  margin: 0 30px;
-`;
-
-const DotsVerticalIcon = styled(IconDotsVertical)`
-  width: 24px;
-  height: 24px;
-`;
-
-const CoffeechatTitle = styled.h1`
-  height: 96px;
-  overflow-wrap: break-word;
-  word-break: break-word;
-  color: ${colors.white};
-  ${fonts.HEADING_32_B};
-
-  @media ${MOBILE_MEDIA_QUERY} {
-    ${fonts.HEADING_28_B};
-
-    height: 84px;
-  }
-`;
-
-const CoffeechatHeader = styled.header`
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  margin-top: 120px;
-  margin-bottom: 24px;
-
-  @media ${MOBILE_MEDIA_QUERY} {
-    margin-top: 24px;
-  }
-`;
+export default CoffeechatDetailPage;

--- a/yarn.lock
+++ b/yarn.lock
@@ -6263,9 +6263,9 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@sopt-makers/ui@npm:2.4.4":
-  version: 2.4.4
-  resolution: "@sopt-makers/ui@npm:2.4.4"
+"@sopt-makers/ui@npm:^2.7.1":
+  version: 2.7.1
+  resolution: "@sopt-makers/ui@npm:2.7.1"
   dependencies:
     "@radix-ui/react-dialog": ^1.0.5
     "@radix-ui/react-switch": ^1.0.3
@@ -6278,7 +6278,7 @@ __metadata:
   peerDependencies:
     react: ^18.2.0
     react-dom: ^18.2.0
-  checksum: cddae8b5328294c56a4a2997160e1cb879afeef14d16fbabd1ee73cddea842bc206dc6014b96c48765cd226e09e1e8f580d1bff0f27613ac972b908bfb005ee6
+  checksum: edd1ca53740b1881b2c4cfdb21902665a4a606d33a4eb2d52b1c591a651529f7a9fef4bf14327d8cba4da713236c06017ae319b708190184f7824bfa703e39c2
   languageName: node
   linkType: hard
 
@@ -19739,7 +19739,7 @@ __metadata:
     "@sopt-makers/colors": ^3.0.0
     "@sopt-makers/fonts": ^1.0.0
     "@sopt-makers/icons": ^1.0.5
-    "@sopt-makers/ui": 2.4.4
+    "@sopt-makers/ui": ^2.7.1
     "@storybook/addon-actions": ^7.0.23
     "@storybook/addon-docs": ^7.0.23
     "@storybook/addon-essentials": ^7.0.23


### PR DESCRIPTION
### 🤫 쉿, 나한테만 말해줘요. 이슈넘버
- close #1606

### 🧐 어떤 것을 변경했어요~?
<!-- 실제로 변경한 사항을 설명해주세요.-->
- 커피챗 상세 구현하기

### 🤔 그렇다면, 어떻게 구현했어요~?
<!-- 실제로 구현한 로직에 대해 설명해주세요.-->
- 페이지의 memberId를 읽어온 뒤, 해당값을 props로 내려주었어요. 분리한 컴포넌트마다 파라미터를 읽고 status 처리하는 게 불편할 것 같아서, 부모 컴포넌트에서 선언 후 props로 내려주었습니다.
- 커피챗 정보는 각 컴포넌트마다 훅으로 호출했습니다.

### ❤️‍🔥 당신이 생각하는 PR포인트, 내겐 매력포인트.
<!-- 해당 PR에서 논의가 필요한 사항을 적어주세요. -->
- mds 태그 이용했고, 도영이가 분리해준 공통 컴포넌트 잘 사용했습니다!
- 커피챗 프로필 쪽에서 데스크탑/모바일의 레이아웃이 다른 경우가 있어서 grid를 이용하여 위치를 조정해주었어요

### 📸 스크린샷, 없으면 이것 참,, 섭섭한데요?
<img width="400" alt="스크린샷 2024-10-31 오전 12 34 42" src="https://github.com/user-attachments/assets/1c062d13-2342-4529-ab58-b8d491642130">

