### PR TITLE
fix: 멤버 검색 이후 프로필로 들어가지지 않는 오류 수정

### DIFF
--- a/src/components/members/main/MemberList/index.tsx
+++ b/src/components/members/main/MemberList/index.tsx
@@ -2,7 +2,8 @@ import { css } from '@emotion/react';
 import styled from '@emotion/styled';
 import { colors } from '@sopt-makers/colors';
 import { IconChevronDown, IconSwitchVertical } from '@sopt-makers/icons';
-import { uniq } from 'lodash-es';
+import { SearchField } from '@sopt-makers/ui';
+import { debounce, uniq } from 'lodash-es';
 import Link from 'next/link';
 import { useRouter } from 'next/router';
 import React, { ChangeEvent, FC, ReactNode, useEffect, useMemo, useState } from 'react';
@@ -38,7 +39,6 @@ import { useRunOnce } from '@/hooks/useRunOnce';
 import IconDiagonalArrow from '@/public/icons/icon-diagonal-arrow.svg';
 import { MOBILE_MEDIA_QUERY } from '@/styles/mediaQuery';
 import { textStyles } from '@/styles/typography';
-import { SearchField } from '@sopt-makers/ui';
 
 const PAGE_LIMIT = 30;
 
@@ -179,10 +179,14 @@ const MemberList: FC<MemberListProps> = ({ banner }) => {
     logClickEvent('filterOrderBy', { orderBy });
   });
 
-  const handleSearchSubmit = (searchQuery: string) => {
+  const handleSearchSubmit = debounce((searchQuery: string) => {
     addQueryParamsToUrl({ search: searchQuery });
-    logSubmitEvent('searchMember', { content: 'searchQuery' });
-  };
+    logSubmitEvent('searchMember', { content: searchQuery });
+
+    if (document.activeElement instanceof HTMLElement) {
+      document.activeElement.blur();
+    }
+  }, 0);
 
   const handleClickCard = (profile: Profile) => {
     logClickEvent('memberCard', { id: profile.id, name: profile.name });


### PR DESCRIPTION
### 🤫 쉿, 나한테만 말해줘요. 이슈넘버
- close #1622

### 🧐 어떤 것을 변경했어요~?
<!-- 실제로 변경한 사항을 설명해주세요.-->

### 🤔 그렇다면, 어떻게 구현했어요~?
<!-- 실제로 구현한 로직에 대해 설명해주세요.-->
handleSearchSubmit 함수에 blur() 추가 및 debounce 적용

### ❤️‍🔥 당신이 생각하는 PR포인트, 내겐 매력포인트.
<!-- 해당 PR에서 논의가 필요한 사항을 적어주세요. -->
검색 이후 blur되는 부분은 mds의 SearchField 컴포넌트에서 적용되어야 할 부분,,,? 같긴 한데 일단 저희 쪽에서 blur처리 하도록 수정했습니다!
debounce는 검색 이후 마지막 한글이 추가되서 queryString에 들어가서 Enter처리가 추가로 되지 않도록 적용했습니다.

### 📸 스크린샷, 없으면 이것 참,, 섭섭한데요?

[문제 상황]
input에 focus가 되어있을 시, 멤버 프로필 상세 페이지로 리다이렉트가 되지 않았습니다.
https://github.com/user-attachments/assets/e2e5c0a6-be18-4be4-b492-427d1fe59af9

[blur() 추가 및 debounce 미적용시]
https://github.com/user-attachments/assets/b9884957-ed24-4346-b188-14afccc46d10

[blur() 추가 및 debounce 적용 후]
https://github.com/user-attachments/assets/7ebec28a-5bf4-4b39-81bb-7cf4079ed1c6