### PR TITLE
fix: 멤버 리스트 내 커피챗 뱃지 클릭시 멤버 카드 클릭과 함께 작동되는 문제 해결

### DIFF
--- a/src/components/members/main/MemberCard/index.tsx
+++ b/src/components/members/main/MemberCard/index.tsx
@@ -59,7 +59,7 @@ const MemberCard: FC<MemberCardProps> = ({
 
   const router = useRouter();
   const onCoffeeChatButtonClick = (e: React.MouseEvent<Element, MouseEvent>) => {
-    e.stopPropagation();
+    e.preventDefault();
     router.push(playgroundLink.coffeechatDetail(memberId));
   };
 


### PR DESCRIPTION
### 🤫 쉿, 나한테만 말해줘요. 이슈넘버
- close #1642

### 🧐 어떤 것을 변경했어요~?
<!-- 실제로 변경한 사항을 설명해주세요.-->
 커피챗 버튼 클릭시 멤버 카드의 link 동작을 막기 위해 e.preventDefault 추가

### 🤔 그렇다면, 어떻게 구현했어요~?
<!-- 실제로 구현한 로직에 대해 설명해주세요.-->
멤버 카드가 Link태그로 이루어져있어서, 그 내부에 있는 커피챗 버튼을 누를 때도 a태그의 href동작이 발생하게 됩니다.
이 동작을 방지하고 커피챗 상세로만 이동시키기 위해, 커피챗 버튼 onClick에 e.preventDefault()를 추가했습니다.

### ❤️‍🔥 당신이 생각하는 PR포인트, 내겐 매력포인트.
<!-- 해당 PR에서 논의가 필요한 사항을 적어주세요. -->

### 📸 스크린샷, 없으면 이것 참,, 섭섭한데요?
#### AS-IS
https://github.com/user-attachments/assets/9ded0388-ff30-481d-afe3-f8a5060ba0cf

#### TO-BE
https://github.com/user-attachments/assets/ed849053-1925-43c0-90bf-4895ff7cfcaf

