### PR TITLE
feat: 커피챗 예외처리

### DIFF
--- a/src/pages/coffeechat/edit/[id].tsx
+++ b/src/pages/coffeechat/edit/[id].tsx
@@ -60,7 +60,7 @@ const CoffeechatEdit = () => {
             type: 'single',
             typeOptions: {
               approveButtonText: '확인',
-              buttonFunction: async () => await router.push(playgroundLink.coffeechat()),
+              buttonFunction: async () => router.push(playgroundLink.coffeechat()),
             },
           };
           open(option);
@@ -69,37 +69,21 @@ const CoffeechatEdit = () => {
     );
   };
 
-  // FIXME: url에서 직접 id 변경하여 접속하는 경우, 다른 사람의 커피챗 수정 불가능하도록 막기
-  // useEffect(() => {
-  //   if (memberId !== String(me?.id)) {
-  //     open({
-  //       title: '다른 사람의 커피챗은 수정할 수 없어요',
-  //       description: ``,
-  //       type: 'single',
-  //       typeOptions: {
-  //         approveButtonText: '확인',
-  //         buttonFunction: async () => await router.push(playgroundLink.coffeechat()),
-  //       },
-  //     });
-  //   }
-  // }, [me?.id, memberId, open, router]);
+  if (status === 'loading' || status === 'error') return null;
 
-  // FIXME: 존재하지 않는 커피챗 id 접속
-  // useEffect(() => {
-  //   if (isError) {
-  //     const axiosError = error as AxiosError;
+  // MEMO: url에서 직접 id 변경하여 접속하는 경우, 다른 사람의 커피챗 수정 불가능하도록 막기
+  if (status === 'success' && memberId && me?.id && memberId !== String(me?.id)) {
+    router.push(playgroundLink.coffeechat());
 
-  //     open({
-  //       title: `${axiosError?.response?.data}`,
-  //       description: ``,
-  //       type: 'single',
-  //       typeOptions: {
-  //         approveButtonText: '확인',
-  //         buttonFunction: async () => await router.push(playgroundLink.coffeechat()),
-  //       },
-  //     });
-  //   }
-  // }, [error, isError, open, router]);
+    return null;
+  }
+
+  // MEMO: 존재하지 않는 커피챗 id 접속
+  if (status === 'success' && isError) {
+    router.push(playgroundLink.coffeechat());
+
+    return null;
+  }
 
   const defaultForm = {
     memberInfo: {
@@ -122,7 +106,6 @@ const CoffeechatEdit = () => {
 
   return (
     <AuthRequired>
-      {(status === 'loading' || status === 'error') && null}
       {status === 'success' && openerProfile && memberId === String(me?.id) && !isError ? (
         <CoffeechatUploadPage uploadType='수정' form={defaultForm} onSubmit={onSubmit} />
       ) : null}


### PR DESCRIPTION
### 🤫 쉿, 나한테만 말해줘요. 이슈넘버
- close #1650

### 🧐 어떤 것을 변경했어요~?
<!-- 실제로 변경한 사항을 설명해주세요.-->
- 커피챗 예외처리를 해주었어요.

### 🤔 그렇다면, 어떻게 구현했어요~?
<!-- 실제로 구현한 로직에 대해 설명해주세요.-->
- url에서 직접 id 변경하여 접속하는 경우, 다른 사람의 커피챗 수정을 하려고 시도하거나, 존재하지 않는 커피챗 id로 접속을 시도할 때, 커피챗 홈으로 다시 돌아올 수 있도록 했어요.

### ❤️‍🔥 당신이 생각하는 PR포인트, 내겐 매력포인트.
<!-- 해당 PR에서 논의가 필요한 사항을 적어주세요. -->
- 원래는 아래와 같이 친절하게 구현하려고 했었는데요, 확인 버튼을 눌렀을 때 Uncaught 에러가 무한으로 발생하더라구요... 시간관계상 바로 커피챗 홈으로 fallback하게만 연결했습니다.

  ```
open({
    title: '다른 사람의 커피챗은 수정할 수 없어요',
    description: '',
    type: 'single',
    typeOptions: {
      approveButtonText: '확인',
      buttonFunction: () => {
        return () => router.push(playgroundLink.coffeechat());
      },
    },
  });

```
### 📸 스크린샷, 없으면 이것 참,, 섭섭한데요?
