### PR TITLE
fix: fix: 쪽지 보내기 모달 내 글자수 validation 서버와 불일치 문제 해결

### DIFF
--- a/src/components/members/detail/MessageSection/MessageModal.tsx
+++ b/src/components/members/detail/MessageSection/MessageModal.tsx
@@ -50,7 +50,7 @@ const CATEGORY: Category[] = [
 
 const schema = yup.object().shape({
   email: yup.string().email('올바른 이메일 형태를 입력해주세요.').required('이메일을 입력해주세요.'),
-  content: yup.string().required('내용을 입력해주세요.').max(750, '750자 이내로 입력해주세요.'),
+  content: yup.string().required('내용을 입력해주세요.').max(500, '500자 이내로 입력해주세요.'),
 });
 
 const COFFEECHAT_PLACEHOLDER =

--- a/src/components/members/main/MemberList/index.tsx
+++ b/src/components/members/main/MemberList/index.tsx
@@ -189,7 +189,6 @@ const MemberList: FC<MemberListProps> = ({ banner }) => {
   }, 0);
 
   const handleClickCard = (profile: Profile) => {
-    debugger;
     logClickEvent('memberCard', { id: profile.id, name: profile.name });
   };
 


### PR DESCRIPTION
### 🤫 쉿, 나한테만 말해줘요. 이슈넘버
- close #1644

### 🧐 어떤 것을 변경했어요~?
<!-- 실제로 변경한 사항을 설명해주세요.-->
쪽지 보내기 내용 글자수 제한이 750자로 되어있었는데, 서버측에서는 40자로 되어있어서
둘다 500자로 통일하는 작업을 거쳤습니다.
### 🤔 그렇다면, 어떻게 구현했어요~?
<!-- 실제로 구현한 로직에 대해 설명해주세요.-->

### ❤️‍🔥 당신이 생각하는 PR포인트, 내겐 매력포인트.
<!-- 해당 PR에서 논의가 필요한 사항을 적어주세요. -->

### 📸 스크린샷, 없으면 이것 참,, 섭섭한데요?
