### PR TITLE
fix: 모바일 gnb 하단 여백 수정

### DIFF
--- a/src/components/feed/page/layout/MobileCommunityLayout.tsx
+++ b/src/components/feed/page/layout/MobileCommunityLayout.tsx
@@ -44,7 +44,7 @@ const Container = styled.div`
 `;
 
 const StyledMenuEntryIcons = styled(MenuEntryIcons)`
-  margin: 24px 0 10px;
+  margin: 24px 0 12px;
 `;
 
 const ListSlotBox = styled.div`


### PR DESCRIPTION
### 🤫 쉿, 나한테만 말해줘요. 이슈넘버
- close #1663

### 🧐 어떤 것을 변경했어요~?
<!-- 실제로 변경한 사항을 설명해주세요.-->
디자인측 요청에 따라 모바일 gnb 영역과 끝말잇기 사이 여백을  10px -> 12px로 변경했습니다.

### 🤔 그렇다면, 어떻게 구현했어요~?
<!-- 실제로 구현한 로직에 대해 설명해주세요.-->

### ❤️‍🔥 당신이 생각하는 PR포인트, 내겐 매력포인트.
<!-- 해당 PR에서 논의가 필요한 사항을 적어주세요. -->

### 📸 스크린샷, 없으면 이것 참,, 섭섭한데요?
