### PR TITLE
feat: 커피챗 qa

### DIFF
--- a/src/components/coffeechat/detail/SeemoreSelect/index.tsx
+++ b/src/components/coffeechat/detail/SeemoreSelect/index.tsx
@@ -52,7 +52,7 @@ export default function SeemoreSelect({ memberId }: SeemoreSelectProp) {
       cancelButtonText: '취소',
       approveButtonText: '삭제하기',
       buttonFunction: () => handleDelete(),
-    },  
+    },
   };
   const { logSubmitEvent } = useEventLogger();
 
@@ -69,8 +69,8 @@ export default function SeemoreSelect({ memberId }: SeemoreSelectProp) {
     mutate(undefined, {
       onSuccess: async () => {
         logSubmitEvent('coffeechatDelete');
-        queryClient.invalidateQueries({ queryKey: ['getRecentCoffeeChat'] });
-        queryClient.invalidateQueries({ queryKey: ['getMembersCoffeeChat'] });
+        queryClient.refetchQueries({ queryKey: ['getRecentCoffeeChat'] });
+        queryClient.refetchQueries({ queryKey: ['getMembersCoffeeChat'] });
         queryClient.invalidateQueries({ queryKey: ['getMemberOfMe'] });
         await toastOpen({ icon: 'success', content: '커피챗이 삭제되었어요. 다음에 또 만나요!' });
         await router.push(playgroundLink.coffeechat());

--- a/src/components/coffeechat/detail/ShowCoffeechatToggle/index.tsx
+++ b/src/components/coffeechat/detail/ShowCoffeechatToggle/index.tsx
@@ -33,8 +33,8 @@ export default function ShowCoffeechatToggle({ isBlind, memberId }: ShowCoffeech
         } else {
           logClickEvent('coffeechatToggleOff');
         }
-        queryClient.invalidateQueries({ queryKey: ['getRecentCoffeeChat'] });
-        queryClient.invalidateQueries({ queryKey: ['getMembersCoffeeChat'] });
+        queryClient.refetchQueries({ queryKey: ['getRecentCoffeeChat'] });
+        queryClient.refetchQueries({ queryKey: ['getMembersCoffeeChat'] });
         queryClient.invalidateQueries({ queryKey: ['getMemberOfMe'] });
         queryClient.invalidateQueries({ queryKey: getCoffeechatDetail.cacheKey(memberId) });
 

--- a/src/components/coffeechat/detail/index.tsx
+++ b/src/components/coffeechat/detail/index.tsx
@@ -136,8 +136,8 @@ const DetailPage = styled.div`
   max-width: 790px;
 
   @media ${MOBILE_MEDIA_QUERY} {
-    margin: 20px 24px;
-    width: 100%;
+    margin: 20px 0;
+    width: calc(100% - 48px);
   }
 `;
 

--- a/src/components/coffeechat/upload/CoffeechatForm/MyInfoForm/index.tsx
+++ b/src/components/coffeechat/upload/CoffeechatForm/MyInfoForm/index.tsx
@@ -48,7 +48,7 @@ export default function MyInfoForm() {
                   maxLength={200}
                   fixedHeight={126}
                   lineBreakPlaceholder={[
-                    'ex. 안녕하세요, 서버 파트 수료 후 지금은 게임 업계 PM으로 일하고 있습니다. 개발자에서 PM으로 직무를 전환하는 과정이 쉽지 않았던 만큼, 제가 느낀 인사이트를 나누고 함께 고민하고 싶어요!',
+                    '안녕하세요, 서버 파트 수료 후 지금은 게임 업계 PM으로 일하고 있습니다. 개발자에서 PM으로 직무를 전환하는 과정이 쉽지 않았던 만큼, 제가 느낀 인사이트를 나누고 함께 고민하고 싶어요!',
                   ]}
                   isError={!!errors.memberInfo?.introduction}
                   errorMessage={errors.memberInfo?.introduction?.message}
@@ -62,7 +62,7 @@ export default function MyInfoForm() {
                   maxLength={200}
                   fixedHeight={150}
                   lineBreakPlaceholder={[
-                    'ex. 안녕하세요, 서버 파트 수료 후 지금은 게임 업계 PM으로 일하고 있습니다. 개발자에서 PM으로 직무를 전환하는 과정이 쉽지 않았던 만큼, 제가 느낀 인사이트를 나누고 함께 고민하고 싶어요!',
+                    '안녕하세요, 서버 파트 수료 후 지금은 게임 업계 PM으로 일하고 있습니다. 개발자에서 PM으로 직무를 전환하는 과정이 쉽지 않았던 만큼, 제가 느낀 인사이트를 나누고 함께 고민하고 싶어요!',
                   ]}
                   isError={!!errors.memberInfo?.introduction}
                   errorMessage={errors.memberInfo?.introduction?.message}

--- a/src/pages/coffeechat/edit/[id].tsx
+++ b/src/pages/coffeechat/edit/[id].tsx
@@ -48,12 +48,12 @@ const CoffeechatEdit = () => {
       },
       {
         onSuccess: async () => {
-          queryClient.invalidateQueries({ queryKey: ['getRecentCoffeeChat'] });
-          queryClient.invalidateQueries({ queryKey: ['getMembersCoffeeChat'] });
+          logSubmitEvent('editCoffeechat');
           queryClient.invalidateQueries({ queryKey: ['getMemberOfMe'] });
           queryClient.invalidateQueries({ queryKey: getCoffeechatDetail.cacheKey(memberId) });
-          toastOpen({ icon: 'success', content: '커피챗이 수정됐어요! 경험을 나눠주셔서 감사해요.' });
-          logSubmitEvent('editCoffeechat');
+          queryClient.refetchQueries({ queryKey: ['getRecentCoffeeChat'] });
+          queryClient.refetchQueries({ queryKey: ['getMembersCoffeeChat'] });
+          await toastOpen({ icon: 'success', content: '커피챗이 수정됐어요! 경험을 나눠주셔서 감사해요.' });
           await router.push(playgroundLink.coffeechatDetail(me?.id ?? ''));
         },
         onError: (error) => {

--- a/src/pages/coffeechat/upload.tsx
+++ b/src/pages/coffeechat/upload.tsx
@@ -60,8 +60,8 @@ const CoffeechatUpload = () => {
       },
       {
         onSuccess: async () => {
-          queryClient.invalidateQueries({ queryKey: ['getRecentCoffeeChat'] });
-          queryClient.invalidateQueries({ queryKey: ['getMembersCoffeeChat'] });
+          queryClient.refetchQueries({ queryKey: ['getRecentCoffeeChat'] });
+          queryClient.refetchQueries({ queryKey: ['getMembersCoffeeChat'] });
           queryClient.invalidateQueries({ queryKey: ['getMemberOfMe'] });
           queryClient.invalidateQueries({ queryKey: getCoffeechatDetail.cacheKey(String(me?.id)) });
 


### PR DESCRIPTION
### 🤫 쉿, 나한테만 말해줘요. 이슈넘버
- close #1673 

### 🧐 어떤 것을 변경했어요~?
<!-- 실제로 변경한 사항을 설명해주세요.-->
- 커피챗 홈에 데이터가 즉시 반영되지 않는 문제 해결
- 상세 페이지 margin 값 수정

### 🤔 그렇다면, 어떻게 구현했어요~?
<!-- 실제로 구현한 로직에 대해 설명해주세요.-->
- invalidateQueries로 무효화했던 로직을, refetchQueries로 바로 리패치해주었어요.
- width 100%에 양옆 마진을 주었던 css에서 calc를 사용하는 방식으로 변경했어요.

### ❤️‍🔥 당신이 생각하는 PR포인트, 내겐 매력포인트.
<!-- 해당 PR에서 논의가 필요한 사항을 적어주세요. -->

### 📸 스크린샷, 없으면 이것 참,, 섭섭한데요?
