### PR TITLE
feat: 프로필 등록 완료 페이지 내 멤버카드를 mds 디자인으로 변경

### DIFF
--- a/src/components/members/main/MemberCard/index.tsx
+++ b/src/components/members/main/MemberCard/index.tsx
@@ -1,6 +1,7 @@
 import styled from '@emotion/styled';
 import * as AspectRatio from '@radix-ui/react-aspect-ratio';
 import { colors } from '@sopt-makers/colors';
+import { IconUser } from '@sopt-makers/icons';
 import { m } from 'framer-motion';
 import { useRouter } from 'next/router';
 import { playgroundLink } from 'playground-common/export';
@@ -75,7 +76,7 @@ const MemberCard: FC<MemberCardProps> = ({
               {imageUrl ? (
                 <Image className='image' src={imageUrl} width={196} alt='member_image' />
               ) : (
-                <DefaultImage className='image' src='/icons/icon-member-default.svg' alt='default_member_image' />
+                <IconUser style={{ width: 115, height: 115, color: `${colors.gray400}`, paddingTop: '10px' }} />
               )}
             </ImageHolder>
           </StyledAspectRatio>

--- a/src/components/members/upload/complete/MemberCardOfMe.tsx
+++ b/src/components/members/upload/complete/MemberCardOfMe.tsx
@@ -4,6 +4,7 @@ import { IconUser } from '@sopt-makers/icons';
 import { FC } from 'react';
 
 import ResizedImage from '@/components/common/ResizedImage';
+import Text from '@/components/common/Text';
 import { MOBILE_MEDIA_QUERY } from '@/styles/mediaQuery';
 import { textStyles } from '@/styles/typography';
 
@@ -38,9 +39,11 @@ const MemberCardOfMe: FC<MemberCardOfMeProps> = ({ name, belongs, badges, intro,
         <BadgesBox>
           <Badges>
             {badges.map((badge, idx) => (
-              <Badge key={idx}>
+              <Badge isActive={badge.isActive} key={idx}>
                 {badge.isActive && <BadgeActiveDot />}
-                {badge.content}
+                <Text typography='SUIT_11_SB' color={badge.isActive ? colors.secondary : colors.gray200}>
+                  {badge.content}
+                </Text>
               </Badge>
             ))}
           </Badges>
@@ -132,34 +135,6 @@ const Badges = styled.div`
   gap: 4px;
 `;
 
-const Badge = styled.div`
-  display: flex;
-  flex-direction: row;
-  flex-shrink: 0;
-  gap: 6px;
-  align-items: center;
-  border-radius: 6px;
-  background-color: ${colors.gray700};
-  padding: 6px 8px;
-  color: ${colors.gray100};
-
-  ${textStyles.SUIT_11_M};
-
-  @media ${MOBILE_MEDIA_QUERY} {
-    padding: 4px 6px;
-    color: ${colors.gray100};
-
-    ${textStyles.SUIT_11_M};
-  }
-`;
-
-const BadgeActiveDot = styled.span`
-  border-radius: 50%;
-  background-color: #cdf47c;
-  width: 6px;
-  height: 6px;
-`;
-
 const Intro = styled.p`
   display: ${'-webkit-box'};
   margin-top: 16px;
@@ -176,4 +151,29 @@ const Intro = styled.p`
     color: ${colors.gray600};
     -webkit-line-clamp: 1;
   }
+`;
+
+const Badge = styled.div<{ isActive: boolean }>`
+  display: flex;
+  flex-direction: row;
+  flex-shrink: 0;
+  gap: 6px;
+  align-items: center;
+  border-radius: 6px;
+  background-color: ${({ isActive }) => (isActive ? 'rgb(247 114 52 / 20%)' : colors.gray700)};
+  padding: 6px;
+  height: 22px;
+  line-height: 0;
+
+  @media ${MOBILE_MEDIA_QUERY} {
+    padding: 4px 6px;
+    color: ${colors.gray100};
+  }
+`;
+
+const BadgeActiveDot = styled.span`
+  border-radius: 50%;
+  background-color: ${colors.secondary};
+  width: 6px;
+  height: 6px;
 `;

--- a/src/components/members/upload/complete/MemberCardOfMe.tsx
+++ b/src/components/members/upload/complete/MemberCardOfMe.tsx
@@ -1,5 +1,6 @@
 import styled from '@emotion/styled';
 import { colors } from '@sopt-makers/colors';
+import { IconUser } from '@sopt-makers/icons';
 import { FC } from 'react';
 
 import ResizedImage from '@/components/common/ResizedImage';
@@ -25,7 +26,7 @@ const MemberCardOfMe: FC<MemberCardOfMeProps> = ({ name, belongs, badges, intro,
           {imageUrl ? (
             <Image className='image' src={imageUrl} width={180} alt='member_image' />
           ) : (
-            <DefaultImage className='image' src='/icons/icon-member-default.svg' alt='default_member_image' />
+            <IconUser style={{ width: 115, height: 115, color: `${colors.gray400}`, paddingTop: '10px' }} />
           )}
         </ImageHolder>
       </StyledImageArea>


### PR DESCRIPTION
### 🤫 쉿, 나한테만 말해줘요. 이슈넘버
- close #1684

### 🧐 어떤 것을 변경했어요~?
<!-- 실제로 변경한 사항을 설명해주세요.-->
프로필 등록 완료 페이지 (/members/complete)에서 mds 이전 디자인을 사용하고있어서,
현재 변경된 멤버 탭과 일치하도록 mds 디자인을 입혀주었습니다

### 🤔 그렇다면, 어떻게 구현했어요~?
<!-- 실제로 구현한 로직에 대해 설명해주세요.-->

### ❤️‍🔥 당신이 생각하는 PR포인트, 내겐 매력포인트.
<!-- 해당 PR에서 논의가 필요한 사항을 적어주세요. -->

### 📸 스크린샷, 없으면 이것 참,, 섭섭한데요?
<img width="408" alt="image" src="https://github.com/user-attachments/assets/87954116-b025-4911-94fe-4270e6ffa8c5">
