### PR TITLE
fix: 멤버 프로필 기본 이미지 수정

### DIFF
--- a/src/components/members/detail/ProfileSection/index.tsx
+++ b/src/components/members/detail/ProfileSection/index.tsx
@@ -1,7 +1,7 @@
 import styled from '@emotion/styled';
 import { colors } from '@sopt-makers/colors';
 import { fonts } from '@sopt-makers/fonts';
-import { IconAlertTriangle, IconUserX } from '@sopt-makers/icons';
+import { IconAlertTriangle, IconUser, IconUserX } from '@sopt-makers/icons';
 import { Flex } from '@toss/emotion-utils';
 import { uniq } from 'lodash-es';
 import Link from 'next/link';
@@ -10,10 +10,10 @@ import { playgroundLink } from 'playground-common/export';
 import CallIcon from 'public/icons/icon-call.svg';
 import EditIcon from 'public/icons/icon-edit.svg';
 import MailIcon from 'public/icons/icon-mail.svg';
-import ProfileIcon from 'public/icons/icon-profile.svg';
 
 import { ProfileDetail } from '@/api/endpoint_LEGACY/members/type';
 import ResizedImage from '@/components/common/ResizedImage';
+import Responsive from '@/components/common/Responsive';
 import useEventLogger from '@/components/eventLogger/hooks/useEventLogger';
 import FeedDropdown from '@/components/feed/common/FeedDropdown';
 import { useBlockMember } from '@/components/members/hooks/useBlockMember';
@@ -42,7 +42,12 @@ const ProfileSection = ({ profile, memberId }: ProfileSectionProps) => {
           <ProfileImage src={profile.profileImage} height={171} />
         ) : (
           <EmptyProfileImage>
-            <ProfileIcon />
+            <Responsive only='desktop'>
+              <IconUser style={{ width: 130, height: 130, color: `${colors.gray400}`, paddingTop: '20px' }} />
+            </Responsive>
+            <Responsive only='mobile'>
+              <IconUser style={{ width: 60, height: 60, color: `${colors.gray400}`, paddingTop: '10px' }} />
+            </Responsive>
           </EmptyProfileImage>
         )}
         {profile.isCoffeeChatActivate && (
@@ -137,7 +142,7 @@ const EmptyProfileImage = styled.div`
   align-items: center;
   justify-content: center;
   border-radius: 36px;
-  background: ${colors.gray700};
+  background: ${colors.gray900};
   width: 171px;
   height: 171px;
   @media ${MOBILE_MEDIA_QUERY} {
@@ -145,11 +150,6 @@ const EmptyProfileImage = styled.div`
     width: 78px;
     min-width: 78px;
     height: 78px;
-
-    & > svg {
-      width: 40px;
-      height: 40px;
-    }
   }
 `;
 
@@ -312,12 +312,12 @@ const IconContainer = styled.div`
 
   @media ${MOBILE_MEDIA_QUERY} {
     padding: 3px;
-    width: 26px;
-    height: 26px;
+    width: 22px;
+    height: 22px;
 
     & > svg {
-      width: 19px;
-      height: 19px;
+      width: 15px;
+      height: 15px;
     }
   }
 `;

--- a/src/components/members/main/MemberCard/index.tsx
+++ b/src/components/members/main/MemberCard/index.tsx
@@ -76,7 +76,14 @@ const MemberCard: FC<MemberCardProps> = ({
               {imageUrl ? (
                 <Image className='image' src={imageUrl} width={196} alt='member_image' />
               ) : (
-                <IconUser style={{ width: 115, height: 115, color: `${colors.gray400}`, paddingTop: '10px' }} />
+                <>
+                  <Responsive only='desktop'>
+                    <IconUser style={{ width: 115, height: 115, color: `${colors.gray400}`, paddingTop: '10px' }} />
+                  </Responsive>
+                  <Responsive only='mobile'>
+                    <IconUser style={{ width: 60, height: 60, color: `${colors.gray400}`, paddingTop: '10px' }} />
+                  </Responsive>
+                </>
               )}
             </ImageHolder>
           </StyledAspectRatio>


### PR DESCRIPTION
### 🤫 쉿, 나한테만 말해줘요. 이슈넘버
- close #1691

### 🧐 어떤 것을 변경했어요~?
<!-- 실제로 변경한 사항을 설명해주세요.-->
- 모바일과 pc에서 같은 사이즈의 아이콘을 쓰고있는 문제가 있어서 모바일용 아이콘을 추가해주었습니다.
- '멤버 상세뷰'에서는 이전 아이콘을 그대로 쓰고있어서 이것또한 mds 아이콘으로 교체해주었습니다.

### 🤔 그렇다면, 어떻게 구현했어요~?
<!-- 실제로 구현한 로직에 대해 설명해주세요.-->
Responsive로 모바일 pc 나누어서 아이콘 삽입해주었습니다.

### ❤️‍🔥 당신이 생각하는 PR포인트, 내겐 매력포인트.
<!-- 해당 PR에서 논의가 필요한 사항을 적어주세요. -->

### 📸 스크린샷, 없으면 이것 참,, 섭섭한데요?
#### 멤버 탭
![image](https://github.com/user-attachments/assets/da900980-7fbe-4822-bd10-9d92275b7014)

#### 상세 뷰
![image](https://github.com/user-attachments/assets/36ac0556-55f8-4836-a42d-e0d8efd9abc7)
![image](https://github.com/user-attachments/assets/4ecc6b17-25ca-4a67-b928-2f8293dc5806)

