### PR TITLE
refactor: 커피챗 커리어 타입 수정

### DIFF
--- a/src/components/coffeechat/upload/CoffeechatForm/types.ts
+++ b/src/components/coffeechat/upload/CoffeechatForm/types.ts
@@ -1,6 +1,6 @@
 export interface CoffeechatFormContent {
   memberInfo: {
-    career: string[] | string | null | undefined;
+    career: string | null | undefined;
     introduction: string | null | undefined;
   };
   coffeeChatInfo: {

--- a/src/pages/coffeechat/edit/[id].tsx
+++ b/src/pages/coffeechat/edit/[id].tsx
@@ -38,11 +38,6 @@ const CoffeechatEdit = () => {
       {
         memberInfo: {
           ...memberInfo,
-          career: memberInfo.career
-            ? Array.isArray(memberInfo.career)
-              ? memberInfo.career[0]
-              : memberInfo.career
-            : null,
         },
         coffeeChatInfo: { ...coffeeChatInfo },
       },


### PR DESCRIPTION
### 🤫 쉿, 나한테만 말해줘요. 이슈넘버
- close #1710

### 🧐 어떤 것을 변경했어요~?
<!-- 실제로 변경한 사항을 설명해주세요.-->
- 커피챗 커리어의 타입을 수정했어요.

### 🤔 그렇다면, 어떻게 구현했어요~?
<!-- 실제로 구현한 로직에 대해 설명해주세요.-->
- string[] 타입을 삭제했어요
- 업로드 시, 배열 타입인지에 따라 string으로 가공하는 로직을 삭제했어요

### ❤️‍🔥 당신이 생각하는 PR포인트, 내겐 매력포인트.
<!-- 해당 PR에서 논의가 필요한 사항을 적어주세요. -->
- 기존 커리어의 경우, 배열을 받는 칩 섹션 공통 컴포넌트를 사용했는데, 디자인 개편으로 칩 섹션이 아닌 드롭다운/바텀시트를 사용하게 되면서, 배열 타입 정의가 불필요해졌어요!

### 📸 스크린샷, 없으면 이것 참,, 섭섭한데요?
