### PR TITLE
feat: 커피챗 상세 default 이미지 mds 적용

### DIFF
--- a/src/components/coffeechat/detail/OpenerProfile/index.tsx
+++ b/src/components/coffeechat/detail/OpenerProfile/index.tsx
@@ -48,7 +48,7 @@ export default function OpenerProfile({ memberId }: OpenerProfileProps) {
                 <ProfileImage src={openerProfile.profileImage} alt='프로필 이미지' />
               ) : (
                 <StIconBox>
-                  <StIconUser style={{}} />
+                  <StIconUser />
                 </StIconBox>
               )}
             </ProfileImageBox>

--- a/src/components/coffeechat/detail/OpenerProfile/index.tsx
+++ b/src/components/coffeechat/detail/OpenerProfile/index.tsx
@@ -2,8 +2,8 @@ import { css } from '@emotion/react';
 import styled from '@emotion/styled';
 import { colors } from '@sopt-makers/colors';
 import { fonts } from '@sopt-makers/fonts';
-import { IconMail } from '@sopt-makers/icons';
-import { useDialog } from '@sopt-makers/ui';
+import { IconMail, IconUser, IconUserX } from '@sopt-makers/icons';
+import { useDialog, UserMention } from '@sopt-makers/ui';
 import Link from 'next/link';
 import ProfileIcon from 'public/icons/icon-profile.svg';
 
@@ -12,6 +12,7 @@ import MessageModal from '@/components/coffeechat/CoffeeChatModal/CoffeeChatModa
 import RegisterCoffeechatButton from '@/components/coffeechat/detail/RegisterCoffeechatButton';
 import ShowCoffeechatToggle from '@/components/coffeechat/detail/ShowCoffeechatToggle';
 import useModalState from '@/components/common/Modal/useModalState';
+import Responsive from '@/components/common/Responsive';
 import { MOBILE_MEDIA_QUERY } from '@/styles/mediaQuery';
 
 interface OpenerProfileProps {
@@ -41,12 +42,14 @@ export default function OpenerProfile({ memberId }: OpenerProfileProps) {
     <>
       {openerProfile && (
         <OpenerProfileSection isMine={!!openerProfile.isMine}>
-          <Link href={"/members/"+memberId}>
+          <Link href={'/members/' + memberId}>
             <ProfileImageBox>
-             {openerProfile.profileImage ? (
+              {openerProfile.profileImage ? (
                 <ProfileImage src={openerProfile.profileImage} alt='프로필 이미지' />
               ) : (
-                <ProfileIcon />
+                <StIconBox>
+                  <StIconUser style={{}} />
+                </StIconBox>
               )}
             </ProfileImageBox>
           </Link>
@@ -181,7 +184,23 @@ const MailIcon = styled(IconMail)`
   width: 20px;
   height: 20px;
 `;
-
+const StIconBox = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background-color: ${colors.gray900};
+  width: 100%;
+  height: 100%;
+`;
+const StIconUser = styled(IconUser)`
+  margin-top: 5px;
+  width: 60px;
+  color: ${colors.gray400};
+  @media ${MOBILE_MEDIA_QUERY} {
+    margin-top: 3.5px;
+    width: 46px;
+  }
+`;
 // TODO: 폰 아이콘 mds에 반영되면 반영 필요
 const PhoneIcon = styled(IconPhone)`
   width: 20px;

--- a/src/components/coffeechat/detail/OpenerProfile/index.tsx
+++ b/src/components/coffeechat/detail/OpenerProfile/index.tsx
@@ -2,17 +2,15 @@ import { css } from '@emotion/react';
 import styled from '@emotion/styled';
 import { colors } from '@sopt-makers/colors';
 import { fonts } from '@sopt-makers/fonts';
-import { IconMail, IconUser, IconUserX } from '@sopt-makers/icons';
-import { useDialog, UserMention } from '@sopt-makers/ui';
+import { IconMail, IconUser } from '@sopt-makers/icons';
+import { useDialog } from '@sopt-makers/ui';
 import Link from 'next/link';
-import ProfileIcon from 'public/icons/icon-profile.svg';
 
 import { useGetCoffeechatDetail } from '@/api/endpoint/coffeechat/getCoffeechatDetail';
 import MessageModal from '@/components/coffeechat/CoffeeChatModal/CoffeeChatModal';
 import RegisterCoffeechatButton from '@/components/coffeechat/detail/RegisterCoffeechatButton';
 import ShowCoffeechatToggle from '@/components/coffeechat/detail/ShowCoffeechatToggle';
 import useModalState from '@/components/common/Modal/useModalState';
-import Responsive from '@/components/common/Responsive';
 import { MOBILE_MEDIA_QUERY } from '@/styles/mediaQuery';
 
 interface OpenerProfileProps {


### PR DESCRIPTION
### 🤫 쉿, 나한테만 말해줘요. 이슈넘버
- close #1718 

저번에 커피챗 mds 적용에서, default icon에 대한 부분이 추가 디자인 수정이 있어서 이슈 파서 진행했습니다

### 🧐 어떤 것을 변경했어요~?
<!-- 실제로 변경한 사항을 설명해주세요.-->

간단하게, 기존 user default icon에 대해서 mds를 적용했어요


### ❤️‍🔥 당신이 생각하는 PR포인트, 내겐 매력포인트.
<!-- 해당 PR에서 논의가 필요한 사항을 적어주세요. -->

MDS에서 svg 비율이 figma랑 약간 다르게 설정되어 있는거같은데.. 크리티컬한 이슈는 아니여서 일단 수동으로 맞춰서 진행했습니다. 나중에 플폼팀분들한테 한번 노티드릴게요!

### 📸 스크린샷
![스크린샷 2025-01-13 오전 12 44 04](https://github.com/user-attachments/assets/8bed2a99-2fbe-4a49-9994-392fe4aa31fb)
![스크린샷 2025-01-13 오전 12 44 15](https://github.com/user-attachments/assets/ea1506c9-84ee-49ab-891a-ec09441a7130)

