### PR TITLE
fix: 이미지 다운로드 테스트용 페이지 모바일에서 안뜨는 현상 해결

### DIFF
--- a/src/components/resolution/read/hooks/useImageDownload.ts
+++ b/src/components/resolution/read/hooks/useImageDownload.ts
@@ -3,42 +3,42 @@ import { useRef } from 'react';
 
 const useImageDownload = (fileName: string) => {
   const ref = useRef<HTMLDivElement>(null);
+  const style = typeof window !== 'undefined' ? document.createElement('style') : null;
 
   const removePaddingCss = `
-  body > div:last-child > span + img {
-    display: inline !important;
-  }
-`;
-
-  const style = document.createElement('style');
+    body > div:last-child > span + img {
+      display: inline !important;
+    }
+  `;
 
   const createStyle = (css: string) => {
+    if (!style) return;
     style.appendChild(document.createTextNode(css));
     document.head.appendChild(style);
   };
 
   const removeStyle = () => {
-    if (style.parentNode) {
+    if (style?.parentNode) {
       style.parentNode.removeChild(style);
     }
   };
 
   const onClick = () => {
+    if (typeof window === 'undefined') return;
+
     createStyle(removePaddingCss);
     html2canvas(ref.current as HTMLDivElement, {
       backgroundColor: null,
       scale: 4,
     })
-      .then((canvas: HTMLCanvasElement) => {
+      .then((canvas) => {
         removeStyle();
         const link = document.createElement('a');
         link.href = canvas.toDataURL('image/png');
         link.download = `${fileName}.png`;
         link.click();
       })
-      .catch((error: Error) => {
-        console.error(error);
-      });
+      .catch(console.error);
   };
 
   return { ref, onClick };

--- a/src/pages/test/image/index.tsx
+++ b/src/pages/test/image/index.tsx
@@ -1,33 +1,24 @@
 import { css } from '@emotion/react';
 import styled from '@emotion/styled';
-import { FC, useEffect, useState } from 'react';
 
 import { ModalButton } from '@/components/common/Modal/parts';
 import useImageDownload from '@/components/resolution/read/hooks/useImageDownload';
 import ResolutionMessage from '@/components/resolution/read/ResolutionMessage';
 
-const Image: FC<{}> = () => {
-  const [isDocumentLoadded, setIsDocumentLoadded] = useState(false);
-
-  useEffect(() => {
-    window.onload = () => {
-      setIsDocumentLoadded(true);
-    };
-  }, []);
-
-  return isDocumentLoadded ? <ImageContent /> : null;
-};
-
 function ImageContent() {
   const { ref: imageRef, onClick: onDownloadButtonClick } = useImageDownload('now-sopt');
 
   return (
-    <Content ref={imageRef}>
-      <ResolutionMessage />
+    <>
+      <Content ref={imageRef}>
+        <ResolutionWrapper>
+          <ResolutionMessage />
+        </ResolutionWrapper>
+      </Content>
       <Footer align='stretch'>
         <ModalButton onClick={onDownloadButtonClick}>이미지로 저장하기</ModalButton>
       </Footer>
-    </Content>
+    </>
   );
 }
 
@@ -36,6 +27,10 @@ const Content = styled.div`
   flex-direction: column;
   align-items: center;
   padding: 20px;
+`;
+
+const ResolutionWrapper = styled.div`
+  width: fit-content;
 `;
 
 const Footer = styled.div<{ align: 'left' | 'right' | 'stretch'; stack?: 'horizontal' | 'vertical' }>`
@@ -54,4 +49,4 @@ const Footer = styled.div<{ align: 'left' | 'right' | 'stretch'; stack?: 'horizo
   }
 `;
 
-export default Image;
+export default ImageContent;


### PR DESCRIPTION
### 🤫 쉿, 나한테만 말해줘요. 이슈넘버
- close #1724

### 🧐 어떤 것을 변경했어요~?
<!-- 실제로 변경한 사항을 설명해주세요.-->
이미지 다운로드 테스트를 위해 현우님이 만들어주신 페이지가
모바일에서 접속시 아무것도 뜨지 않는 문제가 발생했습니다.

이미지 다운로드 훅에서 document객체에 접근하는데,
기존 코드에서 window.onload 이벤트로 브라우저 환경을 확인하는 방식이 제대로 작동하지 않았던 것 같습니다
따라서 이를 제거하고 이미지 다운로드 훅 내에서 window 객체를 확인하는 방식으로 수정하였습니다.

