### PR TITLE
fix: 멤버 프로필 상세 UI 문제 해결

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,7 +41,7 @@ jobs:
       - name: Build
         run: yarn build && yarn next export
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: built-app
           path: out

--- a/.github/workflows/deploy-development.yml
+++ b/.github/workflows/deploy-development.yml
@@ -26,7 +26,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Download Built App
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: built-app
           path: out

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Checkout Branch
         uses: actions/checkout@v3
       - name: Download Built App
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: built-app
           path: out

--- a/src/components/members/detail/DetailinfoSection/index.tsx
+++ b/src/components/members/detail/DetailinfoSection/index.tsx
@@ -2,7 +2,6 @@ import styled from '@emotion/styled';
 import { colors } from '@sopt-makers/colors';
 
 import { ProfileDetail } from '@/api/endpoint_LEGACY/members/type';
-import Text from '@/components/common/Text';
 import MemberDetailSection from '@/components/members/detail/ActivitySection/MemberDetailSection';
 import InfoItem from '@/components/members/detail/InfoItem';
 
@@ -21,9 +20,7 @@ const DetailInfoSection = ({ profile }: DetailInfoSectionProps) => {
         <InfoItem label='활동 지역'>
           <StyledAddressBadgeWrapper>
             {profile.address.split(',').map((address) => (
-              <AddressItem key={address}>
-                <Text typography='SUIT_18_M'>{address}</Text>
-              </AddressItem>
+              <AddressItem key={address}>{address}</AddressItem>
             ))}
           </StyledAddressBadgeWrapper>
         </InfoItem>

--- a/src/components/members/detail/DetailinfoSection/index.tsx
+++ b/src/components/members/detail/DetailinfoSection/index.tsx
@@ -12,7 +12,7 @@ interface DetailInfoSectionProps {
 const DetailInfoSection = ({ profile }: DetailInfoSectionProps) => {
   const hasProfileInfo = profile.university || profile.major || profile.address;
 
-  if (!hasProfileInfo) return;
+  if (!hasProfileInfo) return null;
 
   return (
     <MemberDetailSection style={{ gap: '30px' }}>

--- a/src/components/members/detail/DetailinfoSection/index.tsx
+++ b/src/components/members/detail/DetailinfoSection/index.tsx
@@ -10,9 +10,11 @@ interface DetailInfoSectionProps {
 }
 
 const DetailInfoSection = ({ profile }: DetailInfoSectionProps) => {
-  const hasProfileInfo = profile.birthday || profile.university || profile.major || profile.address;
+  const hasProfileInfo = profile.university || profile.major || profile.address;
 
-  return hasProfileInfo ? (
+  if (!hasProfileInfo) return;
+
+  return (
     <MemberDetailSection style={{ gap: '30px' }}>
       {profile.university && <InfoItem label='학교'>{profile.university}</InfoItem>}
       {profile.major && <InfoItem label='전공'>{profile.major}</InfoItem>}
@@ -26,7 +28,7 @@ const DetailInfoSection = ({ profile }: DetailInfoSectionProps) => {
         </InfoItem>
       )}
     </MemberDetailSection>
-  ) : null;
+  );
 };
 
 export default DetailInfoSection;


### PR DESCRIPTION
### 🤫 쉿, 나한테만 말해줘요. 이슈넘버
- close #1742

### 🧐 어떤 것을 변경했어요~?
<!-- 실제로 변경한 사항을 설명해주세요.-->

아주 간단한 픽스 사항입니다~~

1. 개인 정보 영역 비어있어도 섹션 박스가 표시됨
<img width="354" alt="image" src="https://github.com/user-attachments/assets/6c76377e-8939-46db-aa14-ae4b52ce680a" />

- 조건 분기가 잘못되어있어서 수정

2. 모바일에서 활동지역 폰트 크기가 큼
<img width="354" alt="image" src="https://github.com/user-attachments/assets/eac40461-b716-4d96-8fa8-0cd3482d9dd1" />

### 🤔 그렇다면, 어떻게 구현했어요~?
<!-- 실제로 구현한 로직에 대해 설명해주세요.-->

### ❤️‍🔥 당신이 생각하는 PR포인트, 내겐 매력포인트.
<!-- 해당 PR에서 논의가 필요한 사항을 적어주세요. -->

### 📸 스크린샷, 없으면 이것 참,, 섭섭한데요?
