### PR TITLE
Fix: 이미지 저장시 bg url 변경

### DIFF
--- a/src/components/mySoptReport/MyReport/index.tsx
+++ b/src/components/mySoptReport/MyReport/index.tsx
@@ -56,10 +56,13 @@ const index = ({ myPgData }: MyReportProps) => {
   const handleDownLoad = async () => {
     const element = document.getElementById('downloadableContent');
     if (element) {
+      await document.fonts.ready;
+
       const canvas = await html2canvas(element, {
         useCORS: true,
         backgroundColor: null,
         scale: 2,
+        foreignObjectRendering: true,
       });
 
       const dataUrl = canvas.toDataURL('image/png');

--- a/src/components/mySoptReport/MyReport/index.tsx
+++ b/src/components/mySoptReport/MyReport/index.tsx
@@ -23,9 +23,9 @@ import personOn from '@/public/icons/img/mySoptReport/person_on.png';
 
 import { indicatorIcons, Value } from '@/components/mySoptReport/constants';
 import Popup from '@/components/mySoptReport/PopUp';
+import useImageDownload from '@/components/resolution/read/hooks/useImageDownload';
 import { PLAYGROUND_ORIGIN } from '@/constants/links';
 import { fonts } from '@sopt-makers/fonts';
-import html2canvas from 'html2canvas';
 import { playgroundLink } from 'playground-common/export';
 
 interface MyReportProps {
@@ -43,6 +43,8 @@ const index = ({ myPgData }: MyReportProps) => {
   const [cardsArray, setCardsArray] = useState<Card[]>([]);
   const [isPopupOpen, setIsPopupOpen] = useState(false);
 
+  const { ref: imageRef, onClick: onDownloadButtonClick } = useImageDownload('2024년 마이 솝트 리포트');
+
   useEffect(() => {
     if (myPgData) {
       const cards = Object.entries(myPgData).map(([key, value]) => ({
@@ -56,19 +58,7 @@ const index = ({ myPgData }: MyReportProps) => {
   const handleDownLoad = async () => {
     const element = document.getElementById('downloadableContent');
     if (element) {
-      await document.fonts.ready;
-
-      const canvas = await html2canvas(element, {
-        useCORS: true,
-        backgroundColor: null,
-        scale: 2,
-      });
-
-      const dataUrl = canvas.toDataURL('image/png');
-      const link = document.createElement('a');
-      link.href = dataUrl;
-      link.download = `2024년 마이 솝트 리포트`;
-      link.click();
+      onDownloadButtonClick();
     }
 
     open({
@@ -165,7 +155,7 @@ const index = ({ myPgData }: MyReportProps) => {
         </HiddenContent>
       </Popup>
 
-      <HiddenContent id='downloadableContent'>
+      <HiddenContent id='downloadableContent' ref={imageRef}>
         {cardsArray
           ?.filter((card) => card.id !== 'myCrewStats')
           .map((card) => (

--- a/src/components/mySoptReport/MyReport/index.tsx
+++ b/src/components/mySoptReport/MyReport/index.tsx
@@ -275,6 +275,12 @@ const HiddenContent = styled.div<{ $isSmall?: boolean }>`
   padding: 193px 26px 0;
   width: 560px;
   height: 960px;
+
+  @supports (-webkit-touch-callout: none) {
+    background-image: url('/icons/img/mySoptReport/collect_bg.png') !important;
+    /* stylelint-disable */
+    -webkit-background-size: cover !important;
+  }
 `;
 
 const MentionMakers = styled.p`

--- a/src/components/mySoptReport/MyReport/index.tsx
+++ b/src/components/mySoptReport/MyReport/index.tsx
@@ -56,7 +56,7 @@ const index = ({ myPgData }: MyReportProps) => {
   const handleDownLoad = async () => {
     const element = document.getElementById('downloadableContent');
     if (element) {
-      await document.fonts.ready;
+      // await document.fonts.ready;
 
       const canvas = await html2canvas(element, {
         useCORS: true,

--- a/src/components/mySoptReport/MyReport/index.tsx
+++ b/src/components/mySoptReport/MyReport/index.tsx
@@ -25,7 +25,7 @@ import { indicatorIcons, Value } from '@/components/mySoptReport/constants';
 import Popup from '@/components/mySoptReport/PopUp';
 import { PLAYGROUND_ORIGIN } from '@/constants/links';
 import { fonts } from '@sopt-makers/fonts';
-import { toPng } from 'html-to-image';
+import html2canvas from 'html2canvas';
 import { playgroundLink } from 'playground-common/export';
 
 interface MyReportProps {
@@ -56,10 +56,16 @@ const index = ({ myPgData }: MyReportProps) => {
   const handleDownLoad = async () => {
     const element = document.getElementById('downloadableContent');
     if (element) {
-      const dataUrl = await toPng(element);
+      const canvas = await html2canvas(element, {
+        useCORS: true,
+        backgroundColor: null,
+        scale: 2,
+      });
+
+      const dataUrl = canvas.toDataURL('image/png');
       const link = document.createElement('a');
       link.href = dataUrl;
-      link.download = '2024년 마이 솝트 리포트';
+      link.download = `2024년 마이 솝트 리포트`;
       link.click();
     }
 
@@ -275,12 +281,6 @@ const HiddenContent = styled.div<{ $isSmall?: boolean }>`
   padding: 193px 26px 0;
   width: 560px;
   height: 960px;
-
-  @supports (-webkit-touch-callout: none) {
-    background-image: url('/icons/img/mySoptReport/collect_bg.png') !important;
-    /* stylelint-disable */
-    -webkit-background-size: cover !important;
-  }
 `;
 
 const MentionMakers = styled.p`

--- a/src/components/mySoptReport/MyReport/index.tsx
+++ b/src/components/mySoptReport/MyReport/index.tsx
@@ -296,7 +296,7 @@ const ShareSection = styled.section`
   margin-top: -200px;
   background-image: url(${particle_pc.src});
   background-size: cover;
-  width: 100vw;
+  width: 1920px;
   height: 1000px;
 
   p {

--- a/src/components/mySoptReport/MyReport/index.tsx
+++ b/src/components/mySoptReport/MyReport/index.tsx
@@ -56,13 +56,12 @@ const index = ({ myPgData }: MyReportProps) => {
   const handleDownLoad = async () => {
     const element = document.getElementById('downloadableContent');
     if (element) {
-      // await document.fonts.ready;
+      await document.fonts.ready;
 
       const canvas = await html2canvas(element, {
         useCORS: true,
         backgroundColor: null,
         scale: 2,
-        foreignObjectRendering: true,
       });
 
       const dataUrl = canvas.toDataURL('image/png');

--- a/src/components/mySoptReport/MyReport/index.tsx
+++ b/src/components/mySoptReport/MyReport/index.tsx
@@ -270,7 +270,7 @@ const HiddenContent = styled.div<{ $isSmall?: boolean }>`
 
   z-index: -1;
   border-radius: 20px;
-  background-image: url(${`${PLAYGROUND_ORIGIN}/icons/img/mySoptReport/collect_bg.png`});
+  background-image: url('/icons/img/mySoptReport/collect_bg.png') !important;
   background-size: cover;
   padding: 193px 26px 0;
   width: 560px;

--- a/src/components/mySoptReport/MyReport/index.tsx
+++ b/src/components/mySoptReport/MyReport/index.tsx
@@ -262,7 +262,7 @@ const HiddenContent = styled.div<{ $isSmall?: boolean }>`
   top: 0;
   left: 0;
   flex-wrap: wrap;
-  gap: 12px;
+  column-gap: 12px;
   justify-content: center;
   ${({ $isSmall }) => ($isSmall ? 'transform: scale(1.0);' : ' position: absolute;')};
 
@@ -270,7 +270,7 @@ const HiddenContent = styled.div<{ $isSmall?: boolean }>`
   border-radius: 20px;
   background-image: url('/icons/img/mySoptReport/collect_bg.png') !important;
   background-size: cover;
-  padding: 193px 26px 0;
+  padding: 193px 26px 20px;
   width: 560px;
   height: 960px;
 `;

--- a/src/components/mySoptReport/ReportCard/CardHeader/index.tsx
+++ b/src/components/mySoptReport/ReportCard/CardHeader/index.tsx
@@ -29,10 +29,13 @@ const CardHeader = ({ title = 'SOPT Playground', image, type, value }: CardHeade
       const element = document.getElementById(`downloadableContent-${cardConfig.strongColor}`);
       if (element) {
         try {
+          await document.fonts.ready;
+
           const canvas = await html2canvas(element, {
             useCORS: true,
             backgroundColor: null,
             scale: 2,
+            foreignObjectRendering: true,
           });
 
           const dataUrl = canvas.toDataURL('image/png');

--- a/src/components/mySoptReport/ReportCard/CardHeader/index.tsx
+++ b/src/components/mySoptReport/ReportCard/CardHeader/index.tsx
@@ -4,7 +4,7 @@ import styled from '@emotion/styled';
 import { colors } from '@sopt-makers/colors';
 import { fonts } from '@sopt-makers/fonts';
 import { useToast } from '@sopt-makers/ui';
-import { toPng } from 'html-to-image';
+import html2canvas from 'html2canvas';
 import { StaticImageData } from 'next/image';
 
 interface CardHeaderProps {
@@ -28,11 +28,21 @@ const CardHeader = ({ title = 'SOPT Playground', image, type, value }: CardHeade
       // 이미지가 없는 경우 HTML -> PNG 변환 후 다운로드
       const element = document.getElementById(`downloadableContent-${cardConfig.strongColor}`);
       if (element) {
-        const dataUrl = await toPng(element);
-        const link = document.createElement('a');
-        link.href = dataUrl;
-        link.download = `마이 플그 데이터 ${cardConfig.index}`;
-        link.click();
+        try {
+          const canvas = await html2canvas(element, {
+            useCORS: true, // 외부 이미지 사용 가능
+            backgroundColor: null, // 배경색을 투명하게 설정
+            scale: 2, // 고해상도 이미지 저장
+          });
+
+          const dataUrl = canvas.toDataURL('image/png');
+          const link = document.createElement('a');
+          link.href = dataUrl;
+          link.download = `마이 플그 데이터 ${cardConfig.index}.png`;
+          link.click();
+        } catch (error) {
+          console.error('이미지 변환 오류:', error);
+        }
       }
     }
 

--- a/src/components/mySoptReport/ReportCard/CardHeader/index.tsx
+++ b/src/components/mySoptReport/ReportCard/CardHeader/index.tsx
@@ -92,7 +92,6 @@ const CardHeader = ({ title = 'SOPT Playground', image, type, value }: CardHeade
               {}
             </WordChainContainer>
           )}
-          {cardConfig?.subImage}
           {cardConfig?.subImage && <TypeImg src={cardConfig.subImage} />}
         </HiddenContent>
       )}

--- a/src/components/mySoptReport/ReportCard/CardHeader/index.tsx
+++ b/src/components/mySoptReport/ReportCard/CardHeader/index.tsx
@@ -1,10 +1,10 @@
 import { getCardConfig } from '@/components/mySoptReport/constants';
+import useImageDownload from '@/components/resolution/read/hooks/useImageDownload';
 import { MOBILE_MEDIA_QUERY } from '@/styles/mediaQuery';
 import styled from '@emotion/styled';
 import { colors } from '@sopt-makers/colors';
 import { fonts } from '@sopt-makers/fonts';
 import { useToast } from '@sopt-makers/ui';
-import html2canvas from 'html2canvas';
 import { StaticImageData } from 'next/image';
 
 interface CardHeaderProps {
@@ -18,6 +18,8 @@ const CardHeader = ({ title = 'SOPT Playground', image, type, value }: CardHeade
   const cardConfig = type && value && getCardConfig(type, value);
   const { open } = useToast();
 
+  const { ref: imageRef, onClick: onDownloadButtonClick } = useImageDownload(`마이 플그 데이터 ${cardConfig?.index}`);
+
   const handleDownload = async () => {
     if (image) {
       const link = document.createElement('a');
@@ -28,24 +30,7 @@ const CardHeader = ({ title = 'SOPT Playground', image, type, value }: CardHeade
       // 이미지가 없는 경우 HTML -> PNG 변환 후 다운로드
       const element = document.getElementById(`downloadableContent-${cardConfig.strongColor}`);
       if (element) {
-        try {
-          await document.fonts.ready;
-
-          const canvas = await html2canvas(element, {
-            useCORS: true,
-            backgroundColor: null,
-            scale: 2,
-            foreignObjectRendering: true,
-          });
-
-          const dataUrl = canvas.toDataURL('image/png');
-          const link = document.createElement('a');
-          link.href = dataUrl;
-          link.download = `마이 플그 데이터 ${cardConfig.index}`;
-          link.click();
-        } catch (error) {
-          console.error('이미지 변환 오류:', error);
-        }
+        onDownloadButtonClick();
       }
     }
 
@@ -69,7 +54,11 @@ const CardHeader = ({ title = 'SOPT Playground', image, type, value }: CardHeade
 
       {/* 다운로드를 위한 숨겨진 HTML 콘텐츠 */}
       {!image && (
-        <HiddenContent id={`downloadableContent-${cardConfig.strongColor}`} $bgColor={cardConfig.bgColor}>
+        <HiddenContent
+          id={`downloadableContent-${cardConfig.strongColor}`}
+          $bgColor={cardConfig.bgColor}
+          ref={imageRef}
+        >
           <Title>SOPT Playground</Title>
           <MainText
             $titleColor={cardConfig.titleColor}

--- a/src/components/mySoptReport/ReportCard/CardHeader/index.tsx
+++ b/src/components/mySoptReport/ReportCard/CardHeader/index.tsx
@@ -30,15 +30,15 @@ const CardHeader = ({ title = 'SOPT Playground', image, type, value }: CardHeade
       if (element) {
         try {
           const canvas = await html2canvas(element, {
-            useCORS: true, // 외부 이미지 사용 가능
-            backgroundColor: null, // 배경색을 투명하게 설정
-            scale: 2, // 고해상도 이미지 저장
+            useCORS: true,
+            backgroundColor: null,
+            scale: 2,
           });
 
           const dataUrl = canvas.toDataURL('image/png');
           const link = document.createElement('a');
           link.href = dataUrl;
-          link.download = `마이 플그 데이터 ${cardConfig.index}.png`;
+          link.download = `마이 플그 데이터 ${cardConfig.index}`;
           link.click();
         } catch (error) {
           console.error('이미지 변환 오류:', error);

--- a/src/components/mySoptReport/ReportCard/CardHeader/index.tsx
+++ b/src/components/mySoptReport/ReportCard/CardHeader/index.tsx
@@ -15,7 +15,7 @@ interface CardHeaderProps {
 }
 
 const CardHeader = ({ title = 'SOPT Playground', image, type, value }: CardHeaderProps) => {
-  const cardConfig = type && value && getCardConfig(type, value);
+  const cardConfig = (type && getCardConfig(type, value)) || null;
   const { open } = useToast();
 
   const { ref: imageRef, onClick: onDownloadButtonClick } = useImageDownload(`마이 플그 데이터 ${cardConfig?.index}`);
@@ -28,7 +28,7 @@ const CardHeader = ({ title = 'SOPT Playground', image, type, value }: CardHeade
       link.click();
     } else {
       // 이미지가 없는 경우 HTML -> PNG 변환 후 다운로드
-      const element = document.getElementById(`downloadableContent-${cardConfig.strongColor}`);
+      const element = document.getElementById(`downloadableContent-${cardConfig?.strongColor}`);
       if (element) {
         onDownloadButtonClick();
       }
@@ -55,22 +55,22 @@ const CardHeader = ({ title = 'SOPT Playground', image, type, value }: CardHeade
       {/* 다운로드를 위한 숨겨진 HTML 콘텐츠 */}
       {!image && (
         <HiddenContent
-          id={`downloadableContent-${cardConfig.strongColor}`}
-          $bgColor={cardConfig.bgColor}
+          id={`downloadableContent-${cardConfig?.strongColor}`}
+          $bgColor={cardConfig?.bgColor}
           ref={imageRef}
         >
           <Title>SOPT Playground</Title>
           <MainText
-            $titleColor={cardConfig.titleColor}
-            $strongColor={cardConfig.strongColor}
-            dangerouslySetInnerHTML={{ __html: cardConfig.title }}
+            $titleColor={cardConfig?.titleColor}
+            $strongColor={cardConfig?.strongColor}
+            dangerouslySetInnerHTML={{ __html: cardConfig?.title || '' }}
           />
-          {cardConfig.description && (
+          {cardConfig?.description && (
             <Description $strongColor={cardConfig.strongColor}>{cardConfig.description}</Description>
           )}
           {type === 'myCrewStats' && (
             <CrewContainer>
-              {cardConfig.crewList!.length > 0 ? (
+              {cardConfig?.crewList && cardConfig.crewList.length > 0 ? (
                 cardConfig.crewList!.slice(0, 3).map((crew: string, idx: number) => (
                   <CrewItem key={idx} $index={idx}>
                     <CrewText>{crew}</CrewText>
@@ -84,7 +84,7 @@ const CardHeader = ({ title = 'SOPT Playground', image, type, value }: CardHeade
           )}
           {type === 'myWordChainGameStats' && (
             <WordChainContainer>
-              {cardConfig.wordList!.length > 0 ? (
+              {cardConfig?.wordList && cardConfig.wordList.length > 0 ? (
                 cardConfig
                   .wordList!.slice(0, 5)
                   .map((word: string, idx: number) => <WordChainChip key={idx}>{word}</WordChainChip>)
@@ -94,7 +94,7 @@ const CardHeader = ({ title = 'SOPT Playground', image, type, value }: CardHeade
               {}
             </WordChainContainer>
           )}
-          {cardConfig?.subImage && <TypeImg src={cardConfig.subImage} />}
+          {cardConfig?.subImage && <TypeImg src={cardConfig.subImage as string} />}
         </HiddenContent>
       )}
     </Wrapper>

--- a/src/components/mySoptReport/index.tsx
+++ b/src/components/mySoptReport/index.tsx
@@ -50,12 +50,12 @@ export default function MySoptReport() {
         });
       } else if (tab === 'playground') {
         window.scrollTo({
-          top: isMobile ? 2190 : 2220,
+          top: isMobile ? 2150 : 2220,
           behavior: 'smooth',
         });
       } else if (tab === 'my-pg') {
         window.scrollTo({
-          top: isMobile ? 5450 : 5800,
+          top: isMobile ? 5450 : 5840,
           behavior: 'smooth',
         });
       }
@@ -70,9 +70,9 @@ export default function MySoptReport() {
     // MEMO: 버튼 클릭으로 인한 스크롤 변경일 경우, tab 변경을 막기 위함
     if (flag) return;
     if (isMobile) {
-      if (scrollY >= 600 && scrollY < 2190) {
+      if (scrollY >= 600 && scrollY < 2150) {
         setActiveTab('sopt');
-      } else if (scrollY >= 2190 && scrollY < 5450) {
+      } else if (scrollY >= 2150 && scrollY < 5450) {
         setActiveTab('playground');
       } else if (scrollY >= 5450) {
         setActiveTab('my-pg');
@@ -80,9 +80,9 @@ export default function MySoptReport() {
     } else {
       if (scrollY >= 500 && scrollY < 2220) {
         setActiveTab('sopt');
-      } else if (scrollY >= 2220 && scrollY < 5800) {
+      } else if (scrollY >= 2220 && scrollY < 5840) {
         setActiveTab('playground');
-      } else if (scrollY >= 5800) {
+      } else if (scrollY >= 5840) {
         setActiveTab('my-pg');
       }
     }


### PR DESCRIPTION
### 🤫 쉿, 나한테만 말해줘요. 이슈넘버
- close #1729 

### 🧐 어떤 것을 변경했어요~?
<!-- 실제로 변경한 사항을 설명해주세요.-->
dev서버에서 이미지 저장이 정상적으로 동작함에 따라, ${PLAYGROUND_ORIGIN} 에서 제공하던 url을 변경합니다.

또한, Safari에서 toPng()가 background-image 또는 <img>를 올바르게 변환하지 못함에 따라 html2canvas로 변경하여 Safari에서도 안정적으로 이미지를 다운 받을 수 있도록 변경하였습니다.

### 🤔 그렇다면, 어떻게 구현했어요~?
<!-- 실제로 구현한 로직에 대해 설명해주세요.-->

### ❤️‍🔥 당신이 생각하는 PR포인트, 내겐 매력포인트.
<!-- 해당 PR에서 논의가 필요한 사항을 적어주세요. -->

### 📸 스크린샷, 없으면 이것 참,, 섭섭한데요?
