### PR TITLE
fix: 타임캡솝 QA 반영

### DIFF
--- a/src/api/endpoint/resolution/deleteTimecapsop.ts
+++ b/src/api/endpoint/resolution/deleteTimecapsop.ts
@@ -1,0 +1,27 @@
+import { useMutation } from '@tanstack/react-query';
+import { useQueryClient } from '@tanstack/react-query';
+import z from 'zod';
+
+import { createEndpoint } from '@/api/typedAxios';
+
+export const deleteResolution = createEndpoint({
+  request: () => ({
+    method: 'delete',
+    url: `api/v1/resolution`,
+  }),
+  serverResponseScheme: z.unknown(),
+});
+
+export const useDeleteResolutionMutation = () => {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationKey: ['deleteResolution'],
+    mutationFn: async () => {
+      const response = await deleteResolution.request();
+      return response;
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['getResolutionValidation'] });
+    },
+  });
+};

--- a/src/api/endpoint/resolution/postResolution.ts
+++ b/src/api/endpoint/resolution/postResolution.ts
@@ -7,7 +7,7 @@ import { TimecapsopTag } from '@/components/resolution/constants';
 
 export interface ResolutionRequestBody {
   content: string;
-  tags: TimecapsopTag[];
+  tags: (keyof typeof TimecapsopTag)[];
 }
 
 export const postResolution = createEndpoint({

--- a/src/components/common/Banner/WelcomeBanner/index.tsx
+++ b/src/components/common/Banner/WelcomeBanner/index.tsx
@@ -77,16 +77,15 @@ const WelcomeBanner = ({ isLastGeneration }: WelcomeBannerProp) => {
                       </Text>
                     </ResolutionButton>
                   </LoggingClick>
-                  {isOpenResolutionModal && (
-                    <TimecapsopSubmitModal
-                      onClose={onCloseResolutionModal}
-                      userName={name ?? '나'}
-                      onSuccess={() => {
-                        onNewRegistration();
-                        onOpenPlaygroundGuideModal();
-                      }}
-                    />
-                  )}
+                  <TimecapsopSubmitModal
+                    onClose={onCloseResolutionModal}
+                    userName={name ?? '나'}
+                    onSuccess={() => {
+                      onNewRegistration();
+                      onOpenPlaygroundGuideModal();
+                    }}
+                    isOpen={isOpenResolutionModal}
+                  />
                   {isOpenPlaygroundGuideModal && (
                     <PlaygroundGuideModal
                       isAlreadyRegistration={isAlreadyRegistration}

--- a/src/components/common/BottomSheet/ModalBottomSheet.tsx
+++ b/src/components/common/BottomSheet/ModalBottomSheet.tsx
@@ -1,0 +1,73 @@
+import styled from '@emotion/styled';
+import { colors } from '@sopt-makers/colors';
+import { ComponentProps, FC, PropsWithChildren } from 'react';
+import Sheet from 'react-modal-sheet';
+
+import IconModalClose from '@/public/icons/icon-modal-close.svg';
+
+export interface BottomSheetProps extends PropsWithChildren<ComponentProps<typeof Sheet>> {
+  onClose: () => void;
+}
+
+export const ModalBottomSheet: FC<BottomSheetProps> = (props) => {
+  const { children, isOpen, onClose, ...restProps } = props;
+
+  return (
+    <CustomSheet isOpen={isOpen} onClose={onClose} detent='content-height' {...restProps}>
+      <Sheet.Container>
+        <Sheet.Header>
+          <StyledCloseButton onClick={onClose}>
+            <StyledIconClose />
+          </StyledCloseButton>
+        </Sheet.Header>
+        <Sheet.Content>{children}</Sheet.Content>
+      </Sheet.Container>
+      <Sheet.Backdrop onTap={onClose} />
+    </CustomSheet>
+  );
+};
+
+const CustomSheet = styled(Sheet)`
+  .react-modal-sheet-backdrop {
+    display: flex;
+    position: fixed;
+    top: 0;
+    left: 0;
+    justify-content: center;
+    background-color: ${colors.grayAlpha800}!important;
+    width: 100%;
+    height: 100%;
+  }
+
+  .react-modal-sheet-container {
+    border-radius: 14px !important;
+    background-color: ${colors.gray900}!important;
+    width: 100%;
+    overflow-x: hidden !important;
+    overflow-y: scroll !important;
+  }
+
+  .react-modal-sheet-header {
+    display: flex;
+  }
+
+  .react-modal-sheet-content {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+  }
+`;
+
+const StyledCloseButton = styled.button`
+  display: flex;
+  position: absolute;
+  top: 22px;
+  right: 22px;
+  align-items: center;
+  justify-content: center;
+  z-index: 3;
+  cursor: pointer;
+  padding: 4px;
+`;
+
+const StyledIconClose = styled(IconModalClose)``;

--- a/src/components/common/HomePopup/index.tsx
+++ b/src/components/common/HomePopup/index.tsx
@@ -109,16 +109,15 @@ export const HomePopup = () => {
         </StBackground>
       )}
 
-      {isOpenResolutionModal && (
-        <TimecapsopSubmitModal
-          onClose={onCloseResolutionModal}
-          userName={name ?? '나'}
-          onSuccess={() => {
-            onNewRegistration();
-            onOpenPlaygroundGuideModal();
-          }}
-        />
-      )}
+      <TimecapsopSubmitModal
+        onClose={onCloseResolutionModal}
+        userName={name ?? '나'}
+        onSuccess={() => {
+          onNewRegistration();
+          onOpenPlaygroundGuideModal();
+        }}
+        isOpen={isOpenResolutionModal}
+      />
       {isOpenPlaygroundGuideModal && (
         <PlaygroundGuideModal isAlreadyRegistration={isAlreadyRegistration} onClose={onClosePlaygroundGuideModal} />
       )}

--- a/src/components/resolution/constants.ts
+++ b/src/components/resolution/constants.ts
@@ -7,6 +7,7 @@ export enum TimecapsopTag {
 }
 
 export interface Tag {
+  key: keyof typeof TimecapsopTag;
   value: TimecapsopTag;
   image: {
     default: string;
@@ -17,6 +18,7 @@ export interface Tag {
 
 export const TAG: Tag[] = [
   {
+    key: 'PRODUCT_RELEASE',
     value: TimecapsopTag.PRODUCT_RELEASE,
     image: {
       default: '/icons/icon-release-default.svg',
@@ -25,6 +27,7 @@ export const TAG: Tag[] = [
     },
   },
   {
+    key: 'NETWORKING',
     value: TimecapsopTag.NETWORKING,
     image: {
       default: '/icons/icon-networking-default.svg',
@@ -33,6 +36,7 @@ export const TAG: Tag[] = [
     },
   },
   {
+    key: 'COLLABORATION_EXPERIENCE',
     value: TimecapsopTag.COLLABORATION_EXPERIENCE,
     image: {
       default: '/icons/icon-cooperation-default.svg',
@@ -41,6 +45,7 @@ export const TAG: Tag[] = [
     },
   },
   {
+    key: 'STARTUP',
     value: TimecapsopTag.STARTUP,
     image: {
       default: '/icons/icon-startup-default.svg',
@@ -49,6 +54,7 @@ export const TAG: Tag[] = [
     },
   },
   {
+    key: 'SKILL_UP',
     value: TimecapsopTag.SKILL_UP,
     image: {
       default: '/icons/icon-skill-default.svg',

--- a/src/components/resolution/delete/index.tsx
+++ b/src/components/resolution/delete/index.tsx
@@ -1,0 +1,28 @@
+import styled from '@emotion/styled';
+import { Button } from '@sopt-makers/ui';
+
+import { useDeleteResolutionMutation } from '@/api/endpoint/resolution/deleteTimecapsop';
+
+const TimecapsopDelteButton = () => {
+  const { mutate } = useDeleteResolutionMutation();
+
+  const handleClick = () => {
+    if (confirm('정말로 삭제하시겠습니까?')) {
+      mutate();
+    }
+  };
+
+  return (
+    <DelteBtn size='sm' onClick={handleClick}>
+      타임캡솝 삭제하기
+    </DelteBtn>
+  );
+};
+
+const DelteBtn = styled(Button)`
+  position: absolute;
+  right: 10px;
+  bottom: 10px;
+`;
+
+export default TimecapsopDelteButton;

--- a/src/components/resolution/submit/PlaygroundGuideModal.tsx
+++ b/src/components/resolution/submit/PlaygroundGuideModal.tsx
@@ -1,6 +1,7 @@
 import styled from '@emotion/styled';
 import { colors } from '@sopt-makers/colors';
 import { fonts } from '@sopt-makers/fonts';
+import { useRouter } from 'next/router';
 import { playgroundLink } from 'playground-common/export';
 import { ReactNode } from 'react';
 
@@ -66,11 +67,13 @@ const PlaygroundGuideModal = ({ isAlreadyRegistration, ...props }: PlaygroundGui
 export default PlaygroundGuideModal;
 
 const Card = ({ name, description, color, hover, icon, button, href, onClose }: CardProps) => {
-  const handleClick = (e: React.MouseEvent) => {
+  const router = useRouter();
+
+  const handleClick = async (e: React.MouseEvent) => {
     e.preventDefault();
     onClose();
-    window.history.replaceState(null, '', playgroundLink.feedList());
-    window.location.href = href;
+    await router.replace('/');
+    router.push(href);
   };
 
   return (

--- a/src/components/resolution/submit/PlaygroundGuideModal.tsx
+++ b/src/components/resolution/submit/PlaygroundGuideModal.tsx
@@ -7,7 +7,9 @@ import { ReactNode } from 'react';
 import Modal from '@/components/common/Modal';
 import Text from '@/components/common/Text';
 import { ModalProps } from '@/components/members/detail/MessageSection/Modal';
+import TimecapsopDelteButton from '@/components/resolution/delete';
 import { cards } from '@/components/resolution/submit/constants/cards';
+import { DEBUG } from '@/constants/env';
 import { MB_BIG_MEDIA_QUERY, MOBILE_MEDIA_QUERY } from '@/styles/mediaQuery';
 import { zIndex } from '@/styles/zIndex';
 
@@ -54,6 +56,7 @@ const PlaygroundGuideModal = ({ isAlreadyRegistration, ...props }: PlaygroundGui
           />
         ))}
       </CardWrapper>
+      {DEBUG && <TimecapsopDelteButton />}
     </StyledModal>
   );
 };

--- a/src/components/resolution/submit/PlaygroundGuideModal.tsx
+++ b/src/components/resolution/submit/PlaygroundGuideModal.tsx
@@ -2,7 +2,6 @@ import styled from '@emotion/styled';
 import { colors } from '@sopt-makers/colors';
 import { fonts } from '@sopt-makers/fonts';
 import { useRouter } from 'next/router';
-import { playgroundLink } from 'playground-common/export';
 import { ReactNode } from 'react';
 
 import Modal from '@/components/common/Modal';
@@ -71,9 +70,9 @@ const Card = ({ name, description, color, hover, icon, button, href, onClose }: 
 
   const handleClick = async (e: React.MouseEvent) => {
     e.preventDefault();
-    onClose();
-    await router.replace('/');
+    await router.replace('/', undefined, { shallow: true });
     router.push(href);
+    onClose();
   };
 
   return (

--- a/src/components/resolution/submit/PlaygroundGuideModal.tsx
+++ b/src/components/resolution/submit/PlaygroundGuideModal.tsx
@@ -1,7 +1,7 @@
 import styled from '@emotion/styled';
 import { colors } from '@sopt-makers/colors';
 import { fonts } from '@sopt-makers/fonts';
-import Link from 'next/link';
+import { playgroundLink } from 'playground-common/export';
 import { ReactNode } from 'react';
 
 import Modal from '@/components/common/Modal';
@@ -64,8 +64,14 @@ const PlaygroundGuideModal = ({ isAlreadyRegistration, ...props }: PlaygroundGui
 export default PlaygroundGuideModal;
 
 const Card = ({ name, description, color, hover, icon, button, href }: CardProps) => {
+  const handleClick = (e: React.MouseEvent) => {
+    e.preventDefault();
+    window.history.replaceState(null, '', playgroundLink.feedList());
+    window.location.href = href;
+  };
+
   return (
-    <StyledCard color={color} hover={hover} href={href}>
+    <StyledCard color={color} hover={hover} href={href} onClick={handleClick}>
       <Description typography='SUIT_14_SB' color={colors.black} lineHeight={20}>
         {description}
       </Description>
@@ -144,7 +150,7 @@ const CardWrapper = styled.section`
   margin-top: 20px;
 `;
 
-const StyledCard = styled(Link)<{ color: string; hover: string }>`
+const StyledCard = styled.a<{ color: string; hover: string }>`
   display: flex;
   flex-direction: column;
   gap: 16px;

--- a/src/components/resolution/submit/PlaygroundGuideModal.tsx
+++ b/src/components/resolution/submit/PlaygroundGuideModal.tsx
@@ -25,6 +25,7 @@ interface CardProps {
   icon: ReactNode;
   button: string;
   href: string;
+  onClose: () => void;
 }
 
 const PlaygroundGuideModal = ({ isAlreadyRegistration, ...props }: PlaygroundGuideModalProps) => {
@@ -53,6 +54,7 @@ const PlaygroundGuideModal = ({ isAlreadyRegistration, ...props }: PlaygroundGui
             icon={card.icon}
             button={card.button}
             href={card.href}
+            onClose={props.onClose}
           />
         ))}
       </CardWrapper>
@@ -63,9 +65,10 @@ const PlaygroundGuideModal = ({ isAlreadyRegistration, ...props }: PlaygroundGui
 
 export default PlaygroundGuideModal;
 
-const Card = ({ name, description, color, hover, icon, button, href }: CardProps) => {
+const Card = ({ name, description, color, hover, icon, button, href, onClose }: CardProps) => {
   const handleClick = (e: React.MouseEvent) => {
     e.preventDefault();
+    onClose();
     window.history.replaceState(null, '', playgroundLink.feedList());
     window.location.href = href;
   };

--- a/src/components/resolution/submit/TimecapsopSubmitModal.tsx
+++ b/src/components/resolution/submit/TimecapsopSubmitModal.tsx
@@ -26,7 +26,7 @@ const schema = yup.object().shape({
 });
 
 interface TimecapsopForm {
-  tags: TimecapsopTag[];
+  tags: (keyof typeof TimecapsopTag)[];
   content: string;
 }
 
@@ -37,7 +37,7 @@ interface TimecapsopSubmitModalProps extends ModalProps {
 
 const TimecapsopSubmitModal: FC<TimecapsopSubmitModalProps> = ({ userName, ...props }) => {
   const { handleConfirmResolution, isPending } = useConfirmResolution();
-  const [selectedTag, setSelectedTag] = useState<TimecapsopTag[]>([]);
+  const [selectedTag, setSelectedTag] = useState<(keyof typeof TimecapsopTag)[]>([]);
   const { handleSubmit, control, formState } = useForm<TimecapsopForm>({
     resolver: yupResolver(schema),
     mode: 'onChange',
@@ -45,7 +45,7 @@ const TimecapsopSubmitModal: FC<TimecapsopSubmitModalProps> = ({ userName, ...pr
 
   const isValid = formState.isValid;
 
-  const onClickTag = (tag: TimecapsopTag) => {
+  const onClickTag = (tag: keyof typeof TimecapsopTag) => {
     if (selectedTag.includes(tag)) {
       setSelectedTag(selectedTag.filter((t) => t !== tag));
     } else {
@@ -104,15 +104,15 @@ const TimecapsopSubmitModal: FC<TimecapsopSubmitModalProps> = ({ userName, ...pr
                   <StyledTagItem
                     key={'tagItem' + index}
                     htmlFor={`tags.${index}`}
-                    onClick={() => onClickTag(tag.value)}
-                    isSelected={selectedTag.includes(tag.value)}
+                    onClick={() => onClickTag(tag.key)}
+                    isSelected={selectedTag.includes(tag.key)}
                     defaultImg={tag.image.default}
                     selectedImg={tag.image.select}
                     hoverImg={tag.image.hover}
                   >
                     <StyledTagText
                       typography='SUIT_14_SB'
-                      color={selectedTag.includes(tag.value) ? colors.white : colors.gray300}
+                      color={selectedTag.includes(tag.key) ? colors.white : colors.gray300}
                     >
                       {tag.value}
                     </StyledTagText>

--- a/src/components/resolution/submit/TimecapsopSubmitModal.tsx
+++ b/src/components/resolution/submit/TimecapsopSubmitModal.tsx
@@ -1,179 +1,50 @@
 import styled from '@emotion/styled';
-import { yupResolver } from '@hookform/resolvers/yup';
 import { colors } from '@sopt-makers/colors';
-import { IconAlertCircle } from '@sopt-makers/icons';
-import { TextArea } from '@sopt-makers/ui';
-import { FC, useState } from 'react';
-import { Controller, useForm } from 'react-hook-form';
-import * as yup from 'yup';
+import { useRouter } from 'next/router';
+import { playgroundLink } from 'playground-common/export';
+import { FC } from 'react';
 
-import RHFControllerFormItem from '@/components/common/form/RHFControllerFormItem';
-import Loading from '@/components/common/Loading';
+import { ModalBottomSheet } from '@/components/common/BottomSheet/ModalBottomSheet';
 import Modal from '@/components/common/Modal';
-import Text from '@/components/common/Text';
-import { ModalProps } from '@/components/members/detail/MessageSection/Modal';
-import { TAG, TimecapsopTag } from '@/components/resolution/constants';
-import { useConfirmResolution } from '@/components/resolution/submit/useConfirmResolution';
-import { MOBILE_MAX_WIDTH, MOBILE_MEDIA_QUERY } from '@/styles/mediaQuery';
+import Responsive from '@/components/common/Responsive';
+import TimecapsopSubmitModalContent from '@/components/resolution/submit/TimecapsopSubmitModalContent';
 import { zIndex } from '@/styles/zIndex';
 
-const schema = yup.object().shape({
-  tags: yup
-    .array()
-    .of(yup.boolean())
-    .test('tags', '목표를 선택해 주세요', (value) => value?.some((v) => v === true) ?? false),
-  content: yup.string().required('내용을 입력해 주세요').max(300, '300자 이내로 입력해 주세요'),
-});
-
-interface TimecapsopForm {
-  tags: (keyof typeof TimecapsopTag)[];
-  content: string;
-}
-
-interface TimecapsopSubmitModalProps extends ModalProps {
-  userName: string;
+interface TimecapsopSubmitModalProps {
+  onClose: () => void;
   onSuccess: () => void;
+  userName: string;
+  isOpen: boolean;
 }
 
-const TimecapsopSubmitModal: FC<TimecapsopSubmitModalProps> = ({ userName, ...props }) => {
-  const { handleConfirmResolution, isPending } = useConfirmResolution();
-  const [selectedTag, setSelectedTag] = useState<(keyof typeof TimecapsopTag)[]>([]);
-  const { handleSubmit, control, formState } = useForm<TimecapsopForm>({
-    resolver: yupResolver(schema),
-    mode: 'onChange',
-  });
-
-  const isValid = formState.isValid;
-
-  const onClickTag = (tag: keyof typeof TimecapsopTag) => {
-    if (selectedTag.includes(tag)) {
-      setSelectedTag(selectedTag.filter((t) => t !== tag));
-    } else {
-      setSelectedTag([...selectedTag, tag]);
-    }
-  };
-
-  const submit = async ({ content }: TimecapsopForm) => {
-    try {
-      if (!isValid) return;
-      handleConfirmResolution({
-        content,
-        tags: selectedTag,
-        onSuccess: () => {
-          props.onClose();
-          props.onSuccess();
-        },
-      });
-    } catch (error) {
-      throw error;
-    }
+const TimecapsopSubmitModal: FC<TimecapsopSubmitModalProps> = ({ onClose, onSuccess, userName, isOpen }) => {
+  const router = useRouter();
+  const handleClose = () => {
+    onClose();
+    router.push(playgroundLink.feedList());
   };
 
   return (
-    <StyledModal isOpen {...props} zIndex={zIndex.헤더 + 100} onOpenAutoFocus={(e) => e.preventDefault()}>
-      <StyledForm onSubmit={handleSubmit(submit)}>
-        <ModalBody>
-          <TitleTextWrapper>
-            <Description typography='SUIT_14_M' color={colors.gray200}>
-              SOPT 36기를 시작하는 나를 응원하며
-            </Description>
-            <Text typography='SUIT_20_SB'>타임캡솝을 만들어볼까요?</Text>
-          </TitleTextWrapper>
+    <>
+      <Responsive only='desktop'>
+        <StyledModal isOpen={isOpen} onClose={handleClose} zIndex={zIndex.헤더 + 100}>
+          <TimecapsopSubmitModalContent userName={userName} onClose={onClose} onSuccess={onSuccess} />
+        </StyledModal>
+      </Responsive>
 
-          <TagsWrapper>
-            <TagTextWrapper>
-              <Text typography='SUIT_14_M' color={colors.gray30}>
-                나만의 목표를 담아보세요
-              </Text>
-              <Text typography='SUIT_14_M' color={colors.gray400}>
-                (다중 선택 가능)
-              </Text>
-            </TagTextWrapper>
-            <StyledTags>
-              {TAG.map((tag, index) => (
-                <div key={'wrapper' + index}>
-                  <RHFControllerFormItem
-                    key={'controller' + index}
-                    name={`tags.${index}`}
-                    id={`tags.${index}`}
-                    component={StyledInput}
-                    control={control}
-                    type='checkbox'
-                    style={{ display: 'none' }}
-                  />
-                  <StyledTagItem
-                    key={'tagItem' + index}
-                    htmlFor={`tags.${index}`}
-                    onClick={() => onClickTag(tag.key)}
-                    isSelected={selectedTag.includes(tag.key)}
-                    defaultImg={tag.image.default}
-                    selectedImg={tag.image.select}
-                    hoverImg={tag.image.hover}
-                  >
-                    <StyledTagText
-                      typography='SUIT_14_SB'
-                      color={selectedTag.includes(tag.key) ? colors.white : colors.gray300}
-                    >
-                      {tag.value}
-                    </StyledTagText>
-                  </StyledTagItem>
-                </div>
-              ))}
-            </StyledTags>
-          </TagsWrapper>
-
-          {formState.errors?.tags && (
-            <TagErrorWrapper>
-              <StyledIconAlertCircle color={colors.error} />
-              <TagErrorMessage typography='SUIT_12_SB'>{formState.errors?.tags.message}</TagErrorMessage>
-            </TagErrorWrapper>
-          )}
-          <TextAreaWrapper>
-            <ReceiverText typography='SUIT_16_SB' color={colors.gray50}>
-              {`To. 7월의 ${userName}`}
-            </ReceiverText>
-            <Controller
-              name='content'
-              control={control}
-              render={({ field, fieldState }) => (
-                <StyledTextArea
-                  {...field}
-                  fixedHeight={156}
-                  maxLength={300}
-                  placeholder={
-                    '(예시) 드디어 솝트 36기 시작! 이걸 보고 있다면 36기 종무식을 하고 있겠지?\n세미나 과제랑 스터디 진짜진짜 열심히 해서 많이 배우고, 앱잼 팀원과 좋은 프로덕트 꼭 만들어보자. 팟팅!'
-                  }
-                  errorMessage={fieldState.error?.message}
-                  isError={!!fieldState.error}
-                  value={field.value ?? ''}
-                />
-              )}
-            />
-            <SenderText typography='SUIT_16_SB' color={colors.gray50}>
-              {`From. 3월의 ${userName}`}
-            </SenderText>
-          </TextAreaWrapper>
-        </ModalBody>
-        <StyledButton isDisabled={!isValid} isError={!formState.errors.content}>
-          {isPending ? (
-            <Loading color='white' />
-          ) : (
-            <Text
-              typography={window.innerWidth <= MOBILE_MAX_WIDTH ? 'SUIT_16_SB' : 'SUIT_18_SB'}
-              color={isValid ? colors.black : colors.gray500}
-            >
-              타임캡솝 보관하기
-            </Text>
-          )}
-        </StyledButton>
-      </StyledForm>
-    </StyledModal>
+      <Responsive only='mobile'>
+        <ModalBottomSheet isOpen={isOpen} onClose={handleClose}>
+          <TimecapsopSubmitModalContent userName={userName} onClose={onClose} onSuccess={onSuccess} />
+        </ModalBottomSheet>
+      </Responsive>
+    </>
   );
 };
 
 export default TimecapsopSubmitModal;
 
 const StyledModal = styled(Modal)`
+  border-radius: 14px;
   background-color: ${colors.gray900};
   max-height: 100vh;
   overflow-y: auto;
@@ -182,175 +53,7 @@ const StyledModal = styled(Modal)`
     display: none;
   }
 
-  @media ${MOBILE_MEDIA_QUERY} {
-    max-width: 100%;
-  }
-
   @supports (height: 100dvh) {
     max-height: 100dvh;
   }
-`;
-
-const Description = styled(Text)`
-  text-align: center;
-  line-height: 22px;
-  white-space: pre-wrap;
-`;
-
-const StyledForm = styled.form`
-  display: flex;
-  flex-direction: column;
-  gap: 28px;
-  align-items: center;
-  padding: 18px;
-  width: 430px;
-  min-width: 320px;
-
-  @media ${MOBILE_MEDIA_QUERY} {
-    @supports (height: 100dvw) {
-      max-width: 100dvw;
-    }
-
-    gap: 24px;
-  }
-`;
-
-const StyledTags = styled.section`
-  display: flex;
-  flex-wrap: wrap;
-  gap: 12px;
-  justify-content: center;
-  width: 294px;
-`;
-
-const StyledTagText = styled(Text)`
-  position: absolute;
-  top: 58px;
-`;
-
-const StyledTagItem = styled.label<{ isSelected: boolean; defaultImg: string; selectedImg: string; hoverImg: string }>`
-  display: flex;
-  position: relative;
-  align-items: center;
-  justify-content: center;
-  transition: all 0.2s;
-  border-radius: 50%;
-  background-image: ${({ isSelected, defaultImg, selectedImg }) => `url(${isSelected ? selectedImg : defaultImg}) `};
-  cursor: pointer;
-  width: 90px;
-  height: 90px;
-
-  &:hover {
-    ${({ isSelected, hoverImg }) => !isSelected && `background-image: url(${hoverImg});`}
-  }
-`;
-
-const StyledTextArea = styled(TextArea)`
-  width: 100%;
-
-  @media ${MOBILE_MEDIA_QUERY} {
-    @supports (height: 100dvw) {
-      max-width: calc(100vw - 40px);
-    }
-  }
-`;
-
-const StyledInput = styled.input``;
-
-const StyledButton = styled.button<{ isDisabled: boolean; isError: boolean }>`
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  transition: background-color 0.2s;
-  border-radius: 12px;
-  background: ${({ isDisabled }) => (isDisabled ? colors.gray800 : 'linear-gradient(90deg, #d5d6e3 0%, #939aab 100%)')};
-  cursor: pointer;
-  padding: 12px 20px;
-  width: 100%;
-  height: 56px;
-
-  &:hover {
-    background-color: ${colors.gray50};
-    color: ${colors.black};
-  }
-
-  @media ${MOBILE_MEDIA_QUERY} {
-    height: 44px;
-  }
-`;
-
-const TagTextWrapper = styled.div`
-  display: flex;
-  gap: 3px;
-  align-items: center;
-  height: 22px;
-`;
-
-const TagErrorWrapper = styled.div`
-  display: flex;
-  align-items: center;
-  margin-top: -24px;
-  width: 100%;
-  height: 16px;
-
-  & > svg {
-    margin-right: 6px;
-  }
-`;
-
-const TagErrorMessage = styled(Text)`
-  color: ${colors.error};
-`;
-
-const StyledIconAlertCircle = styled(IconAlertCircle)`
-  width: 14px;
-  height: 14px;
-`;
-
-const TitleTextWrapper = styled.div`
-  display: flex;
-  flex-direction: column;
-  gap: 4px;
-  align-items: center;
-  width: 100%;
-`;
-
-const ModalBody = styled.div`
-  display: flex;
-  flex-direction: column;
-  gap: 24px;
-  align-items: center;
-  margin-top: 56px;
-  width: 100%;
-
-  @media ${MOBILE_MEDIA_QUERY} {
-    gap: 20px;
-    margin-top: 52px;
-  }
-`;
-
-const TagsWrapper = styled.div`
-  display: flex;
-  flex-direction: column;
-  gap: 12px;
-  align-items: center;
-  width: 100%;
-`;
-
-const TextAreaWrapper = styled.div`
-  display: flex;
-  flex-direction: column;
-  gap: 8px;
-  width: 100%;
-`;
-
-const SenderText = styled(Text)`
-  display: flex;
-  justify-content: flex-end;
-  width: 100%;
-  line-height: 24px;
-`;
-
-const ReceiverText = styled(Text)`
-  line-height: 24px;
 `;

--- a/src/components/resolution/submit/TimecapsopSubmitModalContent.tsx
+++ b/src/components/resolution/submit/TimecapsopSubmitModalContent.tsx
@@ -1,0 +1,334 @@
+import styled from '@emotion/styled';
+import { yupResolver } from '@hookform/resolvers/yup';
+import { colors } from '@sopt-makers/colors';
+import { IconAlertCircle } from '@sopt-makers/icons';
+import { TextArea } from '@sopt-makers/ui';
+import { FC, useState } from 'react';
+import { Controller, useForm } from 'react-hook-form';
+import * as yup from 'yup';
+
+import RHFControllerFormItem from '@/components/common/form/RHFControllerFormItem';
+import Loading from '@/components/common/Loading';
+import Text from '@/components/common/Text';
+import { ModalProps } from '@/components/members/detail/MessageSection/Modal';
+import { TAG, TimecapsopTag } from '@/components/resolution/constants';
+import { useConfirmResolution } from '@/components/resolution/submit/useConfirmResolution';
+import { MOBILE_MAX_WIDTH, MOBILE_MEDIA_QUERY } from '@/styles/mediaQuery';
+
+const schema = yup.object().shape({
+  tags: yup
+    .array()
+    .of(yup.boolean())
+    .test('tags', '목표를 선택해 주세요', (value) => value?.some((v) => v === true) ?? false),
+  content: yup.string().required('내용을 입력해 주세요').max(300, '300자 이내로 입력해 주세요'),
+});
+
+interface TimecapsopForm {
+  tags: (keyof typeof TimecapsopTag)[];
+  content: string;
+}
+
+interface TimecapsopSubmitModalProps extends ModalProps {
+  userName: string;
+  onSuccess: () => void;
+}
+
+const TimecapsopSubmitModalContent: FC<TimecapsopSubmitModalProps> = ({ userName, ...props }) => {
+  const { handleConfirmResolution, isPending } = useConfirmResolution();
+  const [selectedTag, setSelectedTag] = useState<(keyof typeof TimecapsopTag)[]>([]);
+  const { handleSubmit, control, formState } = useForm<TimecapsopForm>({
+    resolver: yupResolver(schema),
+    mode: 'onChange',
+  });
+
+  const isValid = formState.isValid;
+
+  const onClickTag = (tag: keyof typeof TimecapsopTag) => {
+    if (selectedTag.includes(tag)) {
+      setSelectedTag(selectedTag.filter((t) => t !== tag));
+    } else {
+      setSelectedTag([...selectedTag, tag]);
+    }
+  };
+
+  const submit = async ({ content }: TimecapsopForm) => {
+    try {
+      if (!isValid) return;
+      handleConfirmResolution({
+        content,
+        tags: selectedTag,
+        onSuccess: () => {
+          props.onClose();
+          props.onSuccess();
+        },
+      });
+    } catch (error) {
+      throw error;
+    }
+  };
+
+  return (
+    <StyledForm onSubmit={handleSubmit(submit)}>
+      <ModalBody>
+        <TitleTextWrapper>
+          <Description typography='SUIT_14_M' color={colors.gray200}>
+            SOPT 36기를 시작하는 나를 응원하며
+          </Description>
+          <Text typography='SUIT_20_SB'>타임캡솝을 만들어볼까요?</Text>
+        </TitleTextWrapper>
+
+        <TagsWrapper>
+          <TagTextWrapper>
+            <Text typography='SUIT_14_M' color={colors.gray30}>
+              나만의 목표를 담아보세요
+            </Text>
+            <Text typography='SUIT_14_M' color={colors.gray400}>
+              (다중 선택 가능)
+            </Text>
+          </TagTextWrapper>
+          <StyledTags>
+            {TAG.map((tag, index) => (
+              <div key={'wrapper' + index}>
+                <RHFControllerFormItem
+                  key={'controller' + index}
+                  name={`tags.${index}`}
+                  id={`tags.${index}`}
+                  component={StyledInput}
+                  control={control}
+                  type='checkbox'
+                  style={{ display: 'none' }}
+                />
+                <StyledTagItem
+                  key={'tagItem' + index}
+                  htmlFor={`tags.${index}`}
+                  onClick={() => onClickTag(tag.key)}
+                  isSelected={selectedTag.includes(tag.key)}
+                  defaultImg={tag.image.default}
+                  selectedImg={tag.image.select}
+                  hoverImg={tag.image.hover}
+                >
+                  <StyledTagText
+                    typography='SUIT_14_SB'
+                    color={selectedTag.includes(tag.key) ? colors.white : colors.gray300}
+                  >
+                    {tag.value}
+                  </StyledTagText>
+                </StyledTagItem>
+              </div>
+            ))}
+          </StyledTags>
+        </TagsWrapper>
+
+        {formState.errors?.tags && (
+          <TagErrorWrapper>
+            <StyledIconAlertCircle color={colors.error} />
+            <TagErrorMessage typography='SUIT_12_SB'>{formState.errors?.tags.message}</TagErrorMessage>
+          </TagErrorWrapper>
+        )}
+        <TextAreaWrapper>
+          <ReceiverText typography='SUIT_16_SB' color={colors.gray50}>
+            {`To. 7월의 ${userName}`}
+          </ReceiverText>
+          <Controller
+            name='content'
+            control={control}
+            render={({ field, fieldState }) => (
+              <StyledTextArea
+                {...field}
+                fixedHeight={156}
+                maxLength={300}
+                placeholder={
+                  '(예시) 드디어 솝트 36기 시작! 이걸 보고 있다면 36기 종무식을 하고 있겠지?\n세미나 과제랑 스터디 진짜진짜 열심히 해서 많이 배우고, 앱잼 팀원과 좋은 프로덕트 꼭 만들어보자. 팟팅!'
+                }
+                errorMessage={fieldState.error?.message}
+                isError={!!fieldState.error}
+                value={field.value ?? ''}
+              />
+            )}
+          />
+          <SenderText typography='SUIT_16_SB' color={colors.gray50}>
+            {`From. 3월의 ${userName}`}
+          </SenderText>
+        </TextAreaWrapper>
+      </ModalBody>
+      <StyledButton isDisabled={!isValid} isError={!formState.errors.content}>
+        {isPending ? (
+          <Loading color='white' />
+        ) : (
+          <Text
+            typography={window.innerWidth <= MOBILE_MAX_WIDTH ? 'SUIT_16_SB' : 'SUIT_18_SB'}
+            color={isValid ? colors.black : colors.gray500}
+          >
+            타임캡솝 보관하기
+          </Text>
+        )}
+      </StyledButton>
+    </StyledForm>
+  );
+};
+
+export default TimecapsopSubmitModalContent;
+
+const Description = styled(Text)`
+  text-align: center;
+  line-height: 22px;
+  white-space: pre-wrap;
+`;
+
+const StyledForm = styled.form`
+  display: flex;
+  flex-direction: column;
+  gap: 28px;
+  align-items: center;
+  padding: 18px;
+  width: 430px;
+  min-width: 320px;
+
+  @media ${MOBILE_MEDIA_QUERY} {
+    @supports (height: 100dvw) {
+      max-width: 100dvw;
+    }
+
+    gap: 24px;
+  }
+`;
+
+const StyledTags = styled.section`
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  justify-content: center;
+  width: 294px;
+`;
+
+const StyledTagText = styled(Text)`
+  position: absolute;
+  top: 58px;
+`;
+
+const StyledTagItem = styled.label<{ isSelected: boolean; defaultImg: string; selectedImg: string; hoverImg: string }>`
+  display: flex;
+  position: relative;
+  align-items: center;
+  justify-content: center;
+  transition: all 0.2s;
+  border-radius: 50%;
+  background-image: ${({ isSelected, defaultImg, selectedImg }) => `url(${isSelected ? selectedImg : defaultImg}) `};
+  cursor: pointer;
+  width: 90px;
+  height: 90px;
+
+  &:hover {
+    ${({ isSelected, hoverImg }) => !isSelected && `background-image: url(${hoverImg});`}
+  }
+`;
+
+const StyledTextArea = styled(TextArea)`
+  width: 100%;
+
+  @media ${MOBILE_MEDIA_QUERY} {
+    @supports (height: 100dvw) {
+      max-width: calc(100vw - 40px);
+    }
+  }
+`;
+
+const StyledInput = styled.input``;
+
+const StyledButton = styled.button<{ isDisabled: boolean; isError: boolean }>`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: background-color 0.2s;
+  border-radius: 12px;
+  background: ${({ isDisabled }) => (isDisabled ? colors.gray800 : 'linear-gradient(90deg, #d5d6e3 0%, #939aab 100%)')};
+  cursor: pointer;
+  padding: 12px 20px;
+  width: 100%;
+  height: 56px;
+
+  &:hover {
+    background-color: ${colors.gray50};
+    color: ${colors.black};
+  }
+
+  @media ${MOBILE_MEDIA_QUERY} {
+    height: 44px;
+  }
+`;
+
+const TagTextWrapper = styled.div`
+  display: flex;
+  gap: 3px;
+  align-items: center;
+  height: 22px;
+`;
+
+const TagErrorWrapper = styled.div`
+  display: flex;
+  align-items: center;
+  margin-top: -24px;
+  width: 100%;
+  height: 16px;
+
+  & > svg {
+    margin-right: 6px;
+  }
+`;
+
+const TagErrorMessage = styled(Text)`
+  color: ${colors.error};
+`;
+
+const StyledIconAlertCircle = styled(IconAlertCircle)`
+  width: 14px;
+  height: 14px;
+`;
+
+const TitleTextWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  align-items: center;
+  width: 100%;
+`;
+
+const ModalBody = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+  align-items: center;
+  margin-top: 56px;
+  width: 100%;
+
+  @media ${MOBILE_MEDIA_QUERY} {
+    gap: 20px;
+    margin-top: 52px;
+  }
+`;
+
+const TagsWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  align-items: center;
+  width: 100%;
+`;
+
+const TextAreaWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  width: 100%;
+`;
+
+const SenderText = styled(Text)`
+  display: flex;
+  justify-content: flex-end;
+  width: 100%;
+  line-height: 24px;
+`;
+
+const ReceiverText = styled(Text)`
+  line-height: 24px;
+`;

--- a/src/components/resolution/submit/useConfirmResolution.ts
+++ b/src/components/resolution/submit/useConfirmResolution.ts
@@ -4,7 +4,7 @@ import { ResolutionRequestBody, usePostResolutionMutation } from '@/api/endpoint
 import useEventLogger from '@/components/eventLogger/hooks/useEventLogger';
 
 interface Options extends ResolutionRequestBody {
-  onSuccess?: (isAlreadyRegistration: boolean) => void;
+  onSuccess?: () => void;
 }
 
 export const useConfirmResolution = () => {
@@ -16,7 +16,7 @@ export const useConfirmResolution = () => {
       mutateAsync(options, {
         onSuccess: async () => {
           logSubmitEvent('postResolution');
-          options.onSuccess?.(false);
+          options.onSuccess?.();
         },
       });
     },

--- a/src/components/resolution/submit/useConfirmResolution.ts
+++ b/src/components/resolution/submit/useConfirmResolution.ts
@@ -1,50 +1,26 @@
-import { colors } from '@sopt-makers/colors';
-import { useToast } from '@sopt-makers/ui';
-import { useRouter } from 'next/router';
-import { playgroundLink } from 'playground-common/export';
 import { useCallback } from 'react';
 
 import { ResolutionRequestBody, usePostResolutionMutation } from '@/api/endpoint/resolution/postResolution';
-import useConfirm from '@/components/common/Modal/useConfirm';
 import useEventLogger from '@/components/eventLogger/hooks/useEventLogger';
-import { zIndex } from '@/styles/zIndex';
 
 interface Options extends ResolutionRequestBody {
-  onSuccess?: () => void;
+  onSuccess?: (isAlreadyRegistration: boolean) => void;
 }
 
 export const useConfirmResolution = () => {
-  const { confirm } = useConfirm();
   const { mutateAsync, isPending } = usePostResolutionMutation();
-  const { open: toastOpen } = useToast();
   const { logSubmitEvent } = useEventLogger();
-  const router = useRouter();
 
   const handleConfirmResolution = useCallback(
     async (options: Options) => {
-      const result = await confirm({
-        title: '다짐을 보내시겠습니까?',
-        description: '한번 보낸 다짐은 수정할 수 없고, 종무식 때 다시 열어볼 수 있어요. 신중히 다짐해 주세요!',
-        okButtonText: '보내기',
-        cancelButtonText: '취소',
-        maxWidth: 400,
-        zIndex: zIndex.헤더 + 101,
-        okButtonColor: 'linear-gradient(90deg, #8FC0FF 0%, #5BA3FF 100%)',
-        okButtonTextColor: colors.black,
+      mutateAsync(options, {
+        onSuccess: async () => {
+          logSubmitEvent('postResolution');
+          options.onSuccess?.(false);
+        },
       });
-
-      if (result) {
-        mutateAsync(options, {
-          onSuccess: async () => {
-            logSubmitEvent('postResolution');
-            toastOpen({ content: '💌 다짐을 들려주셔서 감사해요.' });
-            options.onSuccess?.();
-            await router.push(playgroundLink.feedList());
-          },
-        });
-      }
     },
-    [confirm, mutateAsync, toastOpen, logSubmitEvent, router],
+    [mutateAsync, logSubmitEvent],
   );
 
   return { handleConfirmResolution, isPending };

--- a/src/pages/members/complete.tsx
+++ b/src/pages/members/complete.tsx
@@ -123,13 +123,12 @@ const CompletePage: FC = () => {
           </Responsive>
         </StyledCompletePage>
       )}
-      {isOpenResolutionModal && (
-        <TimecapsopSubmitModal
-          userName={name ?? '나'}
-          onClose={onCloseResolutionModal}
-          onSuccess={onOpenPlaygroundGuideModal}
-        />
-      )}
+      <TimecapsopSubmitModal
+        userName={name ?? '나'}
+        onClose={onCloseResolutionModal}
+        onSuccess={onOpenPlaygroundGuideModal}
+        isOpen={isOpenResolutionModal}
+      />
       {isOpenPlaygroundGuideModal && (
         <PlaygroundGuideModal
           onClose={() => {

--- a/src/pages/members/complete.tsx
+++ b/src/pages/members/complete.tsx
@@ -134,7 +134,7 @@ const CompletePage: FC = () => {
         <PlaygroundGuideModal
           onClose={() => {
             onClosePlaygroundGuideModal();
-            router.push(playgroundLink.intro());
+            router.push(playgroundLink.feedList());
           }}
         />
       )}


### PR DESCRIPTION
### 🤫 쉿, 나한테만 말해줘요. 이슈넘버
- close #1787

### 🧐 어떤 것을 변경했어요~?
<!-- 실제로 변경한 사항을 설명해주세요.-->
- [x] TimecapsopTag enum을 기반으로 하는 태그 키를 사용하도록 구조 변경
  - 서버와 논의 후 기존의 value(한글)이 아닌 key(영어)에 해당 하는 값으로 요청을 보내는 것으로 수정하기로 결정해서 해당 부분을 수정했어요
- [x] 타임캡솝 제출 로직 수정
- [x] complete의 PlaygroundGuideModal에서 onClose실행 시` / `로 이동하도록 변경
- [x] DEBUG 환경에서만 타임캡솝 삭제하기 버튼 추가
- [x] TimecapsopSubmitModal bottomSheet모달로 수정
- [x]  Playground 카드 클릭 시 히스토리 상태 갱신 및 페이지 이동 로직 추가

### 🤔 그렇다면, 어떻게 구현했어요~?
<!-- 실제로 구현한 로직에 대해 설명해주세요.-->
- Tag 인터페이스에 key 필드 추가하여 TAG 상수 리스트 수정했어요.
- TimecapsopSubmitModal에서 selectedTag 상태와 onClickTag 함수 로직을 enum key 기준으로 처리하도록 변경했어요.
- 타임캡솝 메세지를 제출할 때 기존에는 메세지 확인 모달이 떴지만 해당 모달이 안뜨고 바로 api 요청이 실행되도록 수정했어요.

### ❤️‍🔥 당신이 생각하는 PR포인트, 내겐 매력포인트.
<!-- 해당 PR에서 논의가 필요한 사항을 적어주세요. -->

### 📸 스크린샷, 없으면 이것 참,, 섭섭한데요?

https://github.com/user-attachments/assets/ae825a8e-fb58-4c61-af79-c569ad02a367

