### PR TITLE
feat: 타임캡솝 amplitude 이벤트 등록 

### DIFF
--- a/src/components/common/Banner/WelcomeBanner/index.tsx
+++ b/src/components/common/Banner/WelcomeBanner/index.tsx
@@ -67,10 +67,7 @@ const WelcomeBanner = ({ isLastGeneration }: WelcomeBannerProp) => {
                   <WelcomText color={colors.white} typography='SUIT_18_B'>
                     {'SOPT가 연결되는 곳,\n Playground에 오신 걸 환영해요!'}
                   </WelcomText>
-                  <LoggingClick
-                    eventKey='welcomeBannerResolution'
-                    param={{ isAlreadySubmitted: isRegistration ?? false }}
-                  >
+                  <LoggingClick eventKey='bannerTimeCapsule' param={{ isAlreadySubmitted: isRegistration ?? false }}>
                     <ResolutionButton type='button' onClick={handleResolutionModalOpen}>
                       <Text color={colors.black} typography='SUIT_14_SB'>
                         {'타임캡솝을 만들어보세요 >'}

--- a/src/components/eventLogger/events.ts
+++ b/src/components/eventLogger/events.ts
@@ -129,11 +129,11 @@ export interface ClickEvents {
     feedId: string;
   };
 
-  //다짐메시지 제출
-  welcomeBannerResolution: {
+  //환영배너 타임캡솝 cta 버튼 클릭
+  bannerTimeCapsule: {
     isAlreadySubmitted: boolean;
   };
-  profileUploadResolution: undefined;
+  profileUploadTimeCapsule: undefined;
 
   // 다짐메시지 노출
   saveResolutionImage: undefined;
@@ -234,8 +234,8 @@ export interface SubmitEvents {
     referral: 'more' | 'detail';
     isBlindWriter: boolean;
   };
-  //다짐메시지
-  postResolution: undefined;
+  //타임캡솝 보관하기
+  makeTimeCapsule: undefined;
   searchCoffeeChat: {
     search_content: string;
   };

--- a/src/components/resolution/submit/TimecapsopSubmitModalContent.tsx
+++ b/src/components/resolution/submit/TimecapsopSubmitModalContent.tsx
@@ -315,17 +315,11 @@ const TitleTextWrapper = styled.div`
 
 const ModalBody = styled.div`
   display: flex;
-
-  /* flex: 1; */
   flex-direction: column;
   gap: 24px;
   align-items: center;
   margin-top: 56px;
   width: 100%;
-
-  /* overflow-y: auto; */
-
-  /* -webkit-overflow-scrolling: touch; */
 
   @media ${MOBILE_MEDIA_QUERY} {
     gap: 20px;

--- a/src/components/resolution/submit/TimecapsopSubmitModalContent.tsx
+++ b/src/components/resolution/submit/TimecapsopSubmitModalContent.tsx
@@ -186,6 +186,8 @@ const StyledForm = styled.form`
   padding: 18px;
   width: 430px;
   min-width: 320px;
+  overflow-y: auto;
+  -webkit-overflow-scrolling: touch;
 
   @media ${MOBILE_MEDIA_QUERY} {
     @supports (height: 100dvw) {
@@ -313,11 +315,17 @@ const TitleTextWrapper = styled.div`
 
 const ModalBody = styled.div`
   display: flex;
+
+  /* flex: 1; */
   flex-direction: column;
   gap: 24px;
   align-items: center;
   margin-top: 56px;
   width: 100%;
+
+  /* overflow-y: auto; */
+
+  /* -webkit-overflow-scrolling: touch; */
 
   @media ${MOBILE_MEDIA_QUERY} {
     gap: 20px;

--- a/src/components/resolution/submit/useConfirmResolution.ts
+++ b/src/components/resolution/submit/useConfirmResolution.ts
@@ -15,7 +15,7 @@ export const useConfirmResolution = () => {
     async (options: Options) => {
       mutateAsync(options, {
         onSuccess: async () => {
-          logSubmitEvent('postResolution');
+          logSubmitEvent('makeTimeCapsule');
           options.onSuccess?.();
         },
       });

--- a/src/pages/members/complete.tsx
+++ b/src/pages/members/complete.tsx
@@ -74,7 +74,7 @@ const CompletePage: FC = () => {
               {isLastGeneration && isResolutionOpen ? (
                 <BottomSection>
                   <p>AT SOPT만을 위한 타임캡솝을 준비했어요</p>
-                  <LoggingClick eventKey='profileUploadResolution'>
+                  <LoggingClick eventKey='profileUploadTimeCapsule'>
                     <ResolutionButton onClick={handleResolutionModalOpen}>타임캡솝 만들기</ResolutionButton>
                   </LoggingClick>
                 </BottomSection>
@@ -100,7 +100,7 @@ const CompletePage: FC = () => {
             {isLastGeneration && isResolutionOpen ? (
               <BottomSection>
                 <p>AT SOPT만을 위한 타임캡솝을 준비했어요</p>
-                <LoggingClick eventKey='profileUploadResolution'>
+                <LoggingClick eventKey='profileUploadTimeCapsule'>
                   <ResolutionButton onClick={handleResolutionModalOpen}>타임캡솝 만들기</ResolutionButton>
                 </LoggingClick>
               </BottomSection>


### PR DESCRIPTION
### 🤫 쉿, 나한테만 말해줘요. 이슈넘버
- close #1795

### 🧐 어떤 것을 변경했어요~?
<!-- 실제로 변경한 사항을 설명해주세요.-->
- 새롭게 정의된 amplitude event로 수정했어요.
  - ![image](https://github.com/user-attachments/assets/46a00a3b-e7d2-4ef4-86d7-6b32c878d1f1)
  - 홈팝업의 경우 기존과 같아서 따로 수정하지 않았어요!
- 타임캡솝 모달에서 모바일 버전에 터치 스크롤이 원활하지 않던 것도 함께 수정했어요.

### 🤔 그렇다면, 어떻게 구현했어요~?
<!-- 실제로 구현한 로직에 대해 설명해주세요.-->
- `overflow-y: auto;` 와 `-webkit-overflow-scrolling: touch;`를 모달의 최상위 스크롤 가능 요소에 적용해서 콘텐츠가 요소의 높이를 초과할 경우 스크롤이 잘 동작하도록 했어요.

### ❤️‍🔥 당신이 생각하는 PR포인트, 내겐 매력포인트.
<!-- 해당 PR에서 논의가 필요한 사항을 적어주세요. -->
- 모바일 환경에서 textArea를 선택했을때 가상 키보드에 의해서 textArea가 가려지는 현상은 별도의 처리가 필요할 것 같습니다!

### 📸 스크린샷, 없으면 이것 참,, 섭섭한데요?
