### PR TITLE
fix: ios환경에서 타임캡솝 메세지 작성할때 textArea가 가상 키보드에 가려지는 문제 해결 

### DIFF
--- a/src/components/resolution/submit/TimecapsopSubmitModalContent.tsx
+++ b/src/components/resolution/submit/TimecapsopSubmitModalContent.tsx
@@ -94,7 +94,7 @@ const TimecapsopSubmitModalContent: FC<TimecapsopSubmitModalProps> = ({ userName
       form?.style.setProperty('padding-bottom', '18px');
 
       form?.scrollTo({
-        top: 0,
+        top: form.scrollHeight,
       });
     };
 


### PR DESCRIPTION
### 🤫 쉿, 나한테만 말해줘요. 이슈넘버
- close #1803

### 🧐 어떤 것을 변경했어요~?
<!-- 실제로 변경한 사항을 설명해주세요.-->
- iOS 모바일 환경에서 textarea에 포커스 시 키보드에 입력창이 가려지는 문제를 해결했어요.


### 🤔 그렇다면, 어떻게 구현했어요~?
<!-- 실제로 구현한 로직에 대해 설명해주세요.-->
- navigator.userAgent를 통해 iOS 기기인지 확인하고, 해당하는 경우에만 로직 실행
- textarea에 focus 이벤트가 발생하면 form의 padding-bottom을 280px로 늘려 공간 확보
- 이후 scrollIntoView로 자연스럽게 textarea를 화면 상단으로 스크롤
- blur 시에는 다시 padding-bottom을 기존 18px로 초기화하고, form 자체를 맨 위로 스크롤

### ❤️‍🔥 당신이 생각하는 PR포인트, 내겐 매력포인트.
<!-- 해당 PR에서 논의가 필요한 사항을 적어주세요. -->
- 키보드에 가려지는 문제는 디바이스마다 미묘하게 달라서, padding 값이나 scroll 처리 방식에 대해 더 좋은 방식이 있다면 논의해보고 싶어요

### 📸 스크린샷, 없으면 이것 참,, 섭섭한데요?
- Before: textarea 클릭 시 키보드가 올라오면서 입력창이 하단에 가려짐
  <img src="https://github.com/user-attachments/assets/64a83aa1-cf83-40fe-9c17-1eba1abb64cc" width="300" />


- After: textarea 클릭 시 입력창이 키보드 위로 올라옴
  <img src="https://github.com/user-attachments/assets/cf58b8b5-be46-4fea-af30-7378a6cf1361" width="300" />

