### PR TITLE
feat: 커뮤니티에 솝티클 컴포넌트 구현

### DIFF
--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -45,10 +45,10 @@ const config: StorybookConfig = {
   }),
   staticDirs: ['../public'],
   docs: {
-    autodocs: false,
+    autodocs: true,
   },
   typescript: {
-    reactDocgen: false,
+    reactDocgen: 'react-docgen',
   },
 };
 

--- a/src/components/feed/list/FeedUrlCard.stories.tsx
+++ b/src/components/feed/list/FeedUrlCard.stories.tsx
@@ -1,0 +1,54 @@
+import { Decorator, Meta } from '@storybook/react';
+import { ComponentProps } from 'react';
+
+import FeedUrlCard from '@/components/feed/list/FeedUrlCard';
+
+type FeedUrlCardProps = ComponentProps<typeof FeedUrlCard>;
+
+const meta: Meta<typeof FeedUrlCard> = {
+  component: FeedUrlCard,
+  parameters: {
+    layout: 'centered',
+  },
+};
+export default meta;
+
+const withMaxWidth =
+  (width: string): Decorator =>
+  (Story, { args }) =>
+    <div style={{ maxWidth: width }}>{Story(args)}</div>;
+
+const baseArgs: FeedUrlCardProps = {
+  title: '내가 26살에 메이커스 플레이그라운드 프론트엔드 개발자가 될 수 있었던 이유',
+  description: '지우, 현정, 서영, 정교, 주민, 채현, 성희 화이팅 ~~!!',
+  thumbnailUrl: '/icons/img/og_playground.jpeg',
+  url: 'https://playground.sopt.org/',
+};
+
+export const 기본 = {
+  args: baseArgs,
+  decorators: [withMaxWidth('464px')],
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'FeedUrlCard의 기본 형태예요. 썸네일, 제목, 설명, 링크가 포함되어 있고, 화면 너비가 768px 이하일 때는 세로 정렬로 보여져요.',
+      },
+    },
+  },
+};
+
+export const 디테일 = {
+  args: {
+    ...baseArgs,
+    isDetailFeedCard: true,
+  },
+  decorators: [withMaxWidth('512px')],
+  parameters: {
+    docs: {
+      description: {
+        story: '상세 페이지에서 사용하는 FeedUrlCard예요. 반응형 여부와 관계없이 항상 세로 정렬로 보여져요.',
+      },
+    },
+  },
+};

--- a/src/components/feed/list/FeedUrlCard.tsx
+++ b/src/components/feed/list/FeedUrlCard.tsx
@@ -11,6 +11,7 @@ interface FeedUrlCardProps {
   description?: string;
   thumbnailUrl?: string;
   url?: string;
+  isDetailFeedCard?: boolean;
 }
 
 const FeedUrlCard = ({
@@ -18,11 +19,12 @@ const FeedUrlCard = ({
   description = '초기에 고도화된 두 디자인 시스템을 겪으며 느낀점초기에 고도화된 두 디자인 시스템을 겪으며 느낀점초기에 고도화된 두 디자인 시스템을 겪으며 느낀점',
   thumbnailUrl = '/icons/img/og_playground.jpeg',
   url = 'https://www.naver.com/asdfasfasfhasjfhakjshdkf',
+  isDetailFeedCard = false,
 }: FeedUrlCardProps) => {
   return (
-    <FeedUrlCardBox>
-      <ThumbnailImg src={thumbnailUrl} loading='lazy' decoding='async' alt='' />
-      <PreviewTextBox>
+    <FeedUrlCardBox isDetailFeedCard={isDetailFeedCard}>
+      <ThumbnailImg src={thumbnailUrl} loading='lazy' decoding='async' alt='' isDetailFeedCard={isDetailFeedCard} />
+      <PreviewTextBox isDetailFeedCard={isDetailFeedCard}>
         <EllipsisText typography='SUIT_16_SB' lineHeight={24}>
           {title}
         </EllipsisText>
@@ -39,7 +41,7 @@ const FeedUrlCard = ({
 
 export default FeedUrlCard;
 
-const FeedUrlCardBox = styled.div`
+const FeedUrlCardBox = styled.div<{ isDetailFeedCard?: boolean }>`
   display: flex;
   gap: 12px;
   transition: background-color 0.2s ease;
@@ -47,7 +49,6 @@ const FeedUrlCardBox = styled.div`
   background-color: ${colors.gray800};
   padding: 8px;
   width: calc(100% - 20px);
-  min-width: 264px;
   height: 136px;
 
   @media (hover: hover) and (pointer: fine) {
@@ -60,20 +61,39 @@ const FeedUrlCardBox = styled.div`
     flex-direction: column;
     height: auto;
   }
+
+  ${({ isDetailFeedCard }) =>
+    isDetailFeedCard &&
+    `
+    width: 100%;
+    height: auto;
+    flex-direction: column;
+  `}
 `;
 
-const ThumbnailImg = styled.img`
+const ThumbnailImg = styled.img<{ isDetailFeedCard?: boolean }>`
   border-radius: 8px;
-  width: 192px;
+  max-width: 192px;
   height: 120px;
   object-fit: cover;
 
   @media ${MOBILE_MEDIA_QUERY} {
-    width: 100%;
+    max-width: 100%;
   }
+
+  ${({ isDetailFeedCard }) =>
+    isDetailFeedCard &&
+    `
+    max-width: 100%;
+    height: 240px;
+    
+    @media ${MOBILE_MEDIA_QUERY} {
+      height: 172px;
+    }
+  `}
 `;
 
-const PreviewTextBox = styled.div`
+const PreviewTextBox = styled.div<{ isDetailFeedCard?: boolean }>`
   display: flex;
   flex: 1;
   flex-direction: column;
@@ -83,6 +103,8 @@ const PreviewTextBox = styled.div`
   @media ${MOBILE_MEDIA_QUERY} {
     gap: 8px;
   }
+
+  ${({ isDetailFeedCard }) => isDetailFeedCard && `width: 100%;`}
 `;
 
 const EllipsisText = styled(Text)`
@@ -92,8 +114,7 @@ const EllipsisText = styled(Text)`
   -webkit-box-orient: vertical;
   overflow: hidden;
   text-overflow: ellipsis;
-
-  /* word-break: break-word; */
+  word-break: break-word;
 `;
 
 const LinkStyle = styled.a`

--- a/src/components/feed/list/FeedUrlCard.tsx
+++ b/src/components/feed/list/FeedUrlCard.tsx
@@ -1,0 +1,93 @@
+import styled from '@emotion/styled';
+import { colors } from '@sopt-makers/colors';
+import { fonts } from '@sopt-makers/fonts';
+
+import Text from '@/components/common/Text';
+const defalutThumbnailImgUrl = '/icons/img/og_playground.jpeg';
+
+interface FeedUrlCardProps {
+  title?: string;
+  description?: string;
+  thumbnailUrl?: string;
+  url?: string;
+}
+
+const FeedUrlCard = ({
+  title = '초기의, 고도화된 두 디자인 시스템을 겪으며 느낀점초기에 고도화된 두 디자인 시스템을 겪으며 느낀점초기에 고도화된 두 디자인 시스템을 겪으며 느낀점',
+  description = '초기에 고도화된 두 디자인 시스템을 겪으며 느낀점초기에 고도화된 두 디자인 시스템을 겪으며 느낀점초기에 고도화된 두 디자인 시스템을 겪으며 느낀점',
+  thumbnailUrl = '/icons/img/og_playground.jpeg',
+  url = 'https://www.naver.com/asdfasfasfhasjfhakjshdkf',
+}: FeedUrlCardProps) => {
+  return (
+    <FeedUrlCardBox>
+      <ThumbnailImg src={thumbnailUrl} loading='lazy' decoding='async' alt='' />
+      <PreviewTextBox>
+        <EllipsisText typography='SUIT_16_SB' lineHeight={24}>
+          {title}
+        </EllipsisText>
+        <EllipsisText typography='SUIT_14_L' lineHeight={22}>
+          {description}
+        </EllipsisText>
+        <LinkStyle href={url} target='_blank'>
+          {url}
+        </LinkStyle>
+      </PreviewTextBox>
+    </FeedUrlCardBox>
+  );
+};
+
+export default FeedUrlCard;
+
+const FeedUrlCardBox = styled.div`
+  display: flex;
+  gap: 12px;
+  transition: background-color 0.2s ease;
+  border-radius: 12px;
+  background-color: ${colors.gray800};
+  padding: 8px;
+  width: calc(100% - 20px);
+  height: 136px;
+
+  &:hover {
+    background-color: ${colors.gray700};
+  }
+`;
+
+const ThumbnailImg = styled.img`
+  border-radius: 8px;
+  width: 192px;
+  height: 120px;
+  object-fit: cover;
+`;
+
+const PreviewTextBox = styled.div`
+  display: flex;
+  flex: 1;
+  flex-direction: column;
+  gap: 4px;
+  overflow: hidden;
+`;
+
+const EllipsisText = styled(Text)`
+  /* stylelint-disable-next-line value-no-vendor-prefix */
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+  text-overflow: ellipsis;
+
+  /* word-break: break-word; */
+`;
+
+const LinkStyle = styled.a`
+  overflow: hidden;
+  text-decoration: underline;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  color: ${colors.success};
+  ${fonts.BODY_14_L};
+
+  &:hover {
+    text-decoration: underline;
+  }
+`;

--- a/src/components/feed/list/FeedUrlCard.tsx
+++ b/src/components/feed/list/FeedUrlCard.tsx
@@ -3,6 +3,7 @@ import { colors } from '@sopt-makers/colors';
 import { fonts } from '@sopt-makers/fonts';
 
 import Text from '@/components/common/Text';
+import { MOBILE_MEDIA_QUERY } from '@/styles/mediaQuery';
 const defalutThumbnailImgUrl = '/icons/img/og_playground.jpeg';
 
 interface FeedUrlCardProps {
@@ -46,10 +47,18 @@ const FeedUrlCardBox = styled.div`
   background-color: ${colors.gray800};
   padding: 8px;
   width: calc(100% - 20px);
+  min-width: 264px;
   height: 136px;
 
-  &:hover {
-    background-color: ${colors.gray700};
+  @media (hover: hover) and (pointer: fine) {
+    &:hover {
+      background-color: ${colors.gray700};
+    }
+  }
+
+  @media ${MOBILE_MEDIA_QUERY} {
+    flex-direction: column;
+    height: auto;
   }
 `;
 
@@ -58,6 +67,10 @@ const ThumbnailImg = styled.img`
   width: 192px;
   height: 120px;
   object-fit: cover;
+
+  @media ${MOBILE_MEDIA_QUERY} {
+    width: 100%;
+  }
 `;
 
 const PreviewTextBox = styled.div`
@@ -66,6 +79,10 @@ const PreviewTextBox = styled.div`
   flex-direction: column;
   gap: 4px;
   overflow: hidden;
+
+  @media ${MOBILE_MEDIA_QUERY} {
+    gap: 8px;
+  }
 `;
 
 const EllipsisText = styled(Text)`


### PR DESCRIPTION
### 🤫 쉿, 나한테만 말해줘요. 이슈넘버
- close #1812

### 🧐 어떤 것을 변경했어요~?
<!-- 실제로 변경한 사항을 설명해주세요.-->
- FeedUrlCard 컴포넌트를 구현했어요
- 기존 스토리북 설정에서는 autodocs 옵션을 true로 수정했어요
### 🤔 그렇다면, 어떻게 구현했어요~?
<!-- 실제로 구현한 로직에 대해 설명해주세요.-->
- 기본형식의 경우 반응형일때(768px 이하 )`flex-direction: column;`이 적용되어야 하지만 상세보기에서의 FeedUrlCard는
반응형과 관계없이 `flex-direction: column;`이 기본값이라서 `isDetailFeedCard`라는 boolean값을 props에 추가해서 판별 할 수 있도록 하였어요.


### ❤️‍🔥 당신이 생각하는 PR포인트, 내겐 매력포인트.
<!-- 해당 PR에서 논의가 필요한 사항을 적어주세요. -->
- 아직 api구현이 완료되지 않아서 해당 컴포넌트를 뷰자체에는 넣어두지 않았어요 ui는 스토리북으로 확인 부탁드려요!
- 기존 스토리북 설정에서는 autodocs: false로 되어 있어서, docs를 추가해도 문서 탭이 보이지 않았어요. 그래서 해당 옵션을 true로 수정해 문서 탭이 표시되도록 설정했어요. 스토리북은 하나의 컴포넌트를 독립적인 문서처럼 보여줄 수 있기 때문에 각 스토리에 간단한 설명을 덧붙여주는 것이 컴포넌트를 이해하는 데 큰 도움이 된다고 생각해요. 스토리를 추가할 때 설명을 간단히 적어주면 팀원들이 컴포넌트를 빠르게 파악하는 데 도움이 될 것 같은데 이에 대해서는 어떻게 생각하시나요?

- 아직은 솝티클 데이터가 없어서 컴포넌트의 props를 다 옵셔널로 해두었는데 이는 추후에 수정하도록 하겠습니다!

### 📸 스크린샷, 없으면 이것 참,, 섭섭한데요?
<img width="1022" alt="image" src="https://github.com/user-attachments/assets/8467866b-431f-4537-acd2-c7d4cb9ac1cc" />
<img width="1023" alt="image" src="https://github.com/user-attachments/assets/04a7cec1-93d5-45cf-bf2b-2b2fb038a750" />
<img width="1011" alt="image" src="https://github.com/user-attachments/assets/b1d03d9d-ef41-47de-a71d-e21f2e20b010" />

