### PR TITLE
feat: 솝티클 툴팁 구현

### DIFF
--- a/src/components/common/HomePopup/index.tsx
+++ b/src/components/common/HomePopup/index.tsx
@@ -60,13 +60,15 @@ export const HomePopup = () => {
     };
   }, [isPopupVisible]);
 
-  const handleCloseForToday = () => {
+  const handleCloseForToday = (e: React.MouseEvent<HTMLButtonElement>) => {
+    e.stopPropagation();
     const today = getKoreanDate();
     localStorage.setItem('popupClosedDate', today);
     setPopupVisible(false);
   };
 
-  const handleClosePopup = async () => {
+  const handleClosePopup = async (e?: React.MouseEvent<HTMLButtonElement>) => {
+    e?.stopPropagation();
     setPopupVisible(false);
     await Promise.resolve();
   };

--- a/src/components/feed/list/CategorySelect.tsx
+++ b/src/components/feed/list/CategorySelect.tsx
@@ -33,7 +33,10 @@ const CategorySelect: FC<CategorySelectProps> = ({ categories, onCategoryChange 
   const sopticleCategoryRef = useRef<HTMLAnchorElement>(null);
 
   const TOOLTIP_NAME = '솝티클';
-  const { tooltipPosition, isOpen } = useTooltip(sopticleCategoryRef);
+  const { tooltipPosition, isOpen, closeTooltipForToday } = useTooltip(
+    sopticleCategoryRef,
+    'categoryTooltipClosedDate',
+  );
 
   return (
     <Container>
@@ -52,7 +55,12 @@ const CategorySelect: FC<CategorySelectProps> = ({ categories, onCategoryChange 
           {categories.map((category) => (
             <LoggingClick key={category.id} eventKey='feedListCategoryFilter' param={{ category: category.name }}>
               <Category
-                onClick={() => onCategoryChange(category.id)}
+                onClick={() => {
+                  if (category.name === TOOLTIP_NAME) {
+                    closeTooltipForToday();
+                  }
+                  onCategoryChange(category.id);
+                }}
                 categoryId={category.hasAllCategory ? category.id : category.tags.at(0)?.id ?? category.id} // 하위에 "전체" 카테고리가 없으면 태그의 첫 카테고리로 보내기
                 active={parentCategory?.id === category.id}
                 ref={category.name === TOOLTIP_NAME ? sopticleCategoryRef : null} // 툴팁이 필요한 카테고리에만 Ref 설정
@@ -68,7 +76,7 @@ const CategorySelect: FC<CategorySelectProps> = ({ categories, onCategoryChange 
           <Tooltip.Content>
             <Tooltip.Header>
               <Tooltip.Title>NEW!</Tooltip.Title>
-              <Tooltip.Close />
+              <Tooltip.Close onClick={closeTooltipForToday} />
             </Tooltip.Header>
             SOPT 회원들이 직접 작성한 아티클,{`\n`}이제 플레이그라운드에서도 볼 수 있어요!
           </Tooltip.Content>

--- a/src/components/feed/list/CategorySelect.tsx
+++ b/src/components/feed/list/CategorySelect.tsx
@@ -32,6 +32,7 @@ const CategorySelect: FC<CategorySelectProps> = ({ categories, onCategoryChange 
 
   const sopticleCategoryRef = useRef<HTMLAnchorElement>(null);
 
+  const TOOLTIP_NAME = '솝티클';
   const { tooltipPosition, isOpen } = useTooltip(sopticleCategoryRef);
 
   return (
@@ -54,7 +55,7 @@ const CategorySelect: FC<CategorySelectProps> = ({ categories, onCategoryChange 
                 onClick={() => onCategoryChange(category.id)}
                 categoryId={category.hasAllCategory ? category.id : category.tags.at(0)?.id ?? category.id} // 하위에 "전체" 카테고리가 없으면 태그의 첫 카테고리로 보내기
                 active={parentCategory?.id === category.id}
-                ref={category.name === '솝티클' ? sopticleCategoryRef : null} // "솝티클" 카테고리에만 Ref 설정
+                ref={category.name === TOOLTIP_NAME ? sopticleCategoryRef : null} // 툴팁이 필요한 카테고리에만 Ref 설정
               >
                 {category.name}
               </Category>

--- a/src/components/feed/list/CategorySelect.tsx
+++ b/src/components/feed/list/CategorySelect.tsx
@@ -1,14 +1,14 @@
 import styled from '@emotion/styled';
 import { colors } from '@sopt-makers/colors';
-import { FC, useEffect, useRef, useState } from 'react';
+import { FC, useRef } from 'react';
 
 import { useGetPostsInfiniteQuery } from '@/api/endpoint/feed/getPosts';
 import HorizontalScroller from '@/components/common/HorizontalScroller';
 import { LoggingClick } from '@/components/eventLogger/components/LoggingClick';
 import { CategoryLink, useCategoryParam } from '@/components/feed/common/queryParam';
-import { MOBILE_MEDIA_QUERY } from '@/styles/mediaQuery';
+import Tooltip from '@/components/feed/list/FeedCategoryTooltip/index';
+import { useTooltip } from '@/components/feed/list/FeedCategoryTooltip/useTooltip';
 import { textStyles } from '@/styles/typography';
-import { zIndex } from '@/styles/zIndex';
 
 interface CategorySelectProps {
   categories: {
@@ -31,44 +31,8 @@ const CategorySelect: FC<CategorySelectProps> = ({ categories, onCategoryChange 
     ) ?? null;
 
   const sopticleCategoryRef = useRef<HTMLAnchorElement>(null);
-  const [isOpen, setIsOpen] = useState(false);
 
-  const [tooltipPosition, setTooltipPosition] = useState({ top: 0, left: 0 });
-
-  const updateTooltipPosition = () => {
-    if (sopticleCategoryRef.current) {
-      const rect = sopticleCategoryRef.current.getBoundingClientRect();
-      const parentRect = sopticleCategoryRef.current.offsetParent?.getBoundingClientRect() || { top: 0, left: 0 };
-
-      setTooltipPosition({
-        top: rect.bottom - parentRect.top,
-        left: rect.left - parentRect.left + 8,
-      });
-    }
-  };
-
-  useEffect(() => {
-    if (sopticleCategoryRef.current === null) return;
-    setIsOpen(true);
-    updateTooltipPosition();
-
-    window.addEventListener('resize', updateTooltipPosition);
-
-    const handleUserInteraction = () => {
-      setIsOpen(false);
-    };
-
-    window.addEventListener('scroll', handleUserInteraction, { once: true });
-    window.addEventListener('click', handleUserInteraction, { once: true });
-    window.addEventListener('keydown', handleUserInteraction, { once: true });
-
-    return () => {
-      window.removeEventListener('scroll', handleUserInteraction);
-      window.removeEventListener('click', handleUserInteraction);
-      window.removeEventListener('keydown', handleUserInteraction);
-      window.removeEventListener('resize', updateTooltipPosition);
-    };
-  }, []);
+  const { tooltipPosition, isOpen } = useTooltip(sopticleCategoryRef);
 
   return (
     <Container>
@@ -98,14 +62,7 @@ const CategorySelect: FC<CategorySelectProps> = ({ categories, onCategoryChange 
           ))}
         </CategoryBox>
       </HorizontalScroller>
-      {isOpen && (
-        <Tooltip top={tooltipPosition.top} left={tooltipPosition.left}>
-          <TooltipArrow />
-          <TooltipContent>
-            SOPT 회원들이 직접 작성한 아티클,{`\n`}이제 플레이그라운드에서도 볼 수 있어요!
-          </TooltipContent>
-        </Tooltip>
-      )}
+      {isOpen && <Tooltip tooltipPosition={tooltipPosition} />}
       {parentCategory && parentCategory.tags.length > 0 && (
         <HorizontalScroller css={{ marginBottom: '12px' }}>
           <TagBox>
@@ -182,48 +139,5 @@ const Chip = styled(CategoryLink)<{ active: boolean }>`
   &:hover {
     transition: 0.2s;
     background-color: ${(props) => !props.active && colors.gray700};
-  }
-`;
-
-const Tooltip = styled.div<{ top: number; left: number }>`
-  position: absolute;
-  top: ${({ top }) => `${top}px`};
-  left: ${({ left }) => `${left}px`};
-  z-index: ${zIndex.헤더};
-`;
-
-const TooltipArrow = styled.div`
-  position: absolute;
-  left: 16px;
-  border-right: 5px solid transparent;
-  border-bottom: 9px solid ${colors.gray600};
-  border-left: 5px solid transparent;
-  width: 0;
-  height: 0;
-
-  @media ${MOBILE_MEDIA_QUERY} {
-    left: 20px;
-  }
-`;
-
-const TooltipContent = styled.div`
-  display: inline-flex;
-  position: absolute;
-  top: 9px;
-  flex-direction: column;
-  gap: 24px;
-  align-items: flex-start;
-  margin: 0;
-  border-radius: 12px;
-  background: ${colors.gray600};
-  padding: 12px 14px;
-  min-width: 160px;
-  ${textStyles.SUIT_13_M}
-
-  line-height: 20px;
-  white-space: pre;
-
-  @media ${MOBILE_MEDIA_QUERY} {
-    padding: 16px 18px;
   }
 `;

--- a/src/components/feed/list/CategorySelect.tsx
+++ b/src/components/feed/list/CategorySelect.tsx
@@ -1,12 +1,14 @@
 import styled from '@emotion/styled';
 import { colors } from '@sopt-makers/colors';
-import { FC } from 'react';
+import { FC, useEffect, useState } from 'react';
 
 import { useGetPostsInfiniteQuery } from '@/api/endpoint/feed/getPosts';
 import HorizontalScroller from '@/components/common/HorizontalScroller';
 import { LoggingClick } from '@/components/eventLogger/components/LoggingClick';
 import { CategoryLink, useCategoryParam } from '@/components/feed/common/queryParam';
+import { MOBILE_MEDIA_QUERY } from '@/styles/mediaQuery';
 import { textStyles } from '@/styles/typography';
+import { zIndex } from '@/styles/zIndex';
 
 interface CategorySelectProps {
   categories: {
@@ -28,59 +30,89 @@ const CategorySelect: FC<CategorySelectProps> = ({ categories, onCategoryChange 
       (category) => category.id === currentCategoryId || category.tags.some((tag) => tag.id === currentCategoryId),
     ) ?? null;
 
+  const [isOpen, setIsOpen] = useState(false);
+
+  useEffect(() => {
+    setIsOpen(true);
+
+    const handleUserInteraction = () => {
+      setIsOpen(false);
+    };
+
+    window.addEventListener('scroll', handleUserInteraction, { once: true });
+    window.addEventListener('click', handleUserInteraction, { once: true });
+    window.addEventListener('keydown', handleUserInteraction, { once: true });
+
+    return () => {
+      window.removeEventListener('scroll', handleUserInteraction);
+      window.removeEventListener('click', handleUserInteraction);
+      window.removeEventListener('keydown', handleUserInteraction);
+    };
+  }, []);
+
   return (
-    <Container>
-      <HorizontalScroller>
-        <CategoryBox>
-          <LoggingClick
-            eventKey='feedListCategoryFilter'
-            param={{
-              category: '전체',
-            }}
-          >
-            <Category categoryId={undefined} active={currentCategoryId === ''} onClick={() => onCategoryChange('')}>
-              전체
-            </Category>
-          </LoggingClick>
-          {categories.map((category) => (
-            <LoggingClick key={category.id} eventKey='feedListCategoryFilter' param={{ category: category.name }}>
-              <Category
-                onClick={() => onCategoryChange(category.id)}
-                categoryId={category.hasAllCategory ? category.id : category.tags.at(0)?.id ?? category.id} // 하위에 "전체" 카테고리가 없으면 태그의 첫 카테고리로 보내기
-                active={parentCategory?.id === category.id}
-              >
-                {category.name}
+    <>
+      <Container>
+        <HorizontalScroller>
+          <CategoryBox>
+            <LoggingClick
+              eventKey='feedListCategoryFilter'
+              param={{
+                category: '전체',
+              }}
+            >
+              <Category categoryId={undefined} active={currentCategoryId === ''} onClick={() => onCategoryChange('')}>
+                전체
               </Category>
             </LoggingClick>
-          ))}
-        </CategoryBox>
-      </HorizontalScroller>
-      {parentCategory && parentCategory.tags.length > 0 && (
-        <HorizontalScroller css={{ marginBottom: '12px' }}>
-          <TagBox>
-            {parentCategory.hasAllCategory && (
-              <LoggingClick eventKey='feedListCategoryFilter' param={{ category: '전체' }}>
-                <Chip categoryId={parentCategory.id} active={parentCategory.id === currentCategoryId}>
-                  전체
-                </Chip>
-              </LoggingClick>
-            )}
-            {parentCategory.tags.map((tag) => (
-              <LoggingClick key={tag.id} eventKey='feedListCategoryFilter' param={{ category: tag.name }}>
-                <Chip
-                  key={tag.id}
-                  categoryId={tag.id}
-                  active={tag.id === currentCategoryId}
-                  onClick={() => onCategoryChange(tag.id)}
+            {categories.map((category) => (
+              <LoggingClick key={category.id} eventKey='feedListCategoryFilter' param={{ category: category.name }}>
+                <Category
+                  onClick={() => onCategoryChange(category.id)}
+                  categoryId={category.hasAllCategory ? category.id : category.tags.at(0)?.id ?? category.id} // 하위에 "전체" 카테고리가 없으면 태그의 첫 카테고리로 보내기
+                  active={parentCategory?.id === category.id}
                 >
-                  {tag.name}
-                </Chip>
+                  {category.name}
+                </Category>
               </LoggingClick>
             ))}
-          </TagBox>
+          </CategoryBox>
         </HorizontalScroller>
-      )}
-    </Container>
+        {isOpen && (
+          <Tooltip>
+            <TooltipArrow />
+            <TooltipContent>
+              SOPT 회원들이 직접 작성한 아티클,{`\n`}이제 플레이그라운드에서도 볼 수 있어요!
+            </TooltipContent>
+          </Tooltip>
+        )}
+        {parentCategory && parentCategory.tags.length > 0 && (
+          <HorizontalScroller css={{ marginBottom: '12px' }}>
+            <TagBox>
+              {parentCategory.hasAllCategory && (
+                <LoggingClick eventKey='feedListCategoryFilter' param={{ category: '전체' }}>
+                  <Chip categoryId={parentCategory.id} active={parentCategory.id === currentCategoryId}>
+                    전체
+                  </Chip>
+                </LoggingClick>
+              )}
+              {parentCategory.tags.map((tag) => (
+                <LoggingClick key={tag.id} eventKey='feedListCategoryFilter' param={{ category: tag.name }}>
+                  <Chip
+                    key={tag.id}
+                    categoryId={tag.id}
+                    active={tag.id === currentCategoryId}
+                    onClick={() => onCategoryChange(tag.id)}
+                  >
+                    {tag.name}
+                  </Chip>
+                </LoggingClick>
+              ))}
+            </TagBox>
+          </HorizontalScroller>
+        )}
+      </Container>
+    </>
   );
 };
 
@@ -131,5 +163,54 @@ const Chip = styled(CategoryLink)<{ active: boolean }>`
   &:hover {
     transition: 0.2s;
     background-color: ${(props) => !props.active && colors.gray700};
+  }
+`;
+
+const Tooltip = styled.div`
+  position: absolute;
+  top: 44px;
+  left: 59px;
+  z-index: ${zIndex.헤더};
+`;
+
+const TooltipArrow = styled.div`
+  position: absolute;
+  left: 16px;
+  border-right: 5px solid transparent;
+  border-bottom: 9px solid #3f3f47;
+  border-left: 5px solid transparent;
+  width: 0;
+  height: 0;
+
+  @media ${MOBILE_MEDIA_QUERY} {
+    left: 20px;
+  }
+`;
+
+const TooltipContent = styled.div`
+  display: inline-flex;
+  position: absolute;
+  top: 9px;
+  flex-direction: column;
+  gap: 24px;
+  align-items: flex-start;
+  margin: 0;
+  border-radius: 12px;
+
+  /* Drop Shadow/200 */
+  box-shadow: var(--sds-size-depth-0) var(--sds-size-depth-025) var(--sds-size-depth-100) var(--sds-size-depth-0)
+      var(--sds-color-black-200),
+    var(--sds-size-depth-0) var(--sds-size-depth-025) var(--sds-size-depth-100) var(--sds-size-depth-0)
+      var(--sds-color-black-100);
+  background: #3f3f47;
+  padding: 12px 14px;
+  min-width: 160px;
+  ${textStyles.SUIT_13_M}
+
+  line-height: 20px;
+  white-space: pre;
+
+  @media ${MOBILE_MEDIA_QUERY} {
+    padding: 16px 18px;
   }
 `;

--- a/src/components/feed/list/CategorySelect.tsx
+++ b/src/components/feed/list/CategorySelect.tsx
@@ -63,7 +63,17 @@ const CategorySelect: FC<CategorySelectProps> = ({ categories, onCategoryChange 
           ))}
         </CategoryBox>
       </HorizontalScroller>
-      {isOpen && <Tooltip tooltipPosition={tooltipPosition} />}
+      {isOpen && (
+        <Tooltip tooltipPosition={tooltipPosition}>
+          <Tooltip.Content>
+            <Tooltip.Header>
+              <Tooltip.Title>NEW!</Tooltip.Title>
+              <Tooltip.Close />
+            </Tooltip.Header>
+            SOPT 회원들이 직접 작성한 아티클,{`\n`}이제 플레이그라운드에서도 볼 수 있어요!
+          </Tooltip.Content>
+        </Tooltip>
+      )}
       {parentCategory && parentCategory.tags.length > 0 && (
         <HorizontalScroller css={{ marginBottom: '12px' }}>
           <TagBox>

--- a/src/components/feed/list/CategorySelect.tsx
+++ b/src/components/feed/list/CategorySelect.tsx
@@ -71,69 +71,67 @@ const CategorySelect: FC<CategorySelectProps> = ({ categories, onCategoryChange 
   }, []);
 
   return (
-    <>
-      <Container>
-        <HorizontalScroller>
-          <CategoryBox>
-            <LoggingClick
-              eventKey='feedListCategoryFilter'
-              param={{
-                category: '전체',
-              }}
-            >
-              <Category categoryId={undefined} active={currentCategoryId === ''} onClick={() => onCategoryChange('')}>
-                전체
+    <Container>
+      <HorizontalScroller>
+        <CategoryBox>
+          <LoggingClick
+            eventKey='feedListCategoryFilter'
+            param={{
+              category: '전체',
+            }}
+          >
+            <Category categoryId={undefined} active={currentCategoryId === ''} onClick={() => onCategoryChange('')}>
+              전체
+            </Category>
+          </LoggingClick>
+          {categories.map((category) => (
+            <LoggingClick key={category.id} eventKey='feedListCategoryFilter' param={{ category: category.name }}>
+              <Category
+                onClick={() => onCategoryChange(category.id)}
+                categoryId={category.hasAllCategory ? category.id : category.tags.at(0)?.id ?? category.id} // 하위에 "전체" 카테고리가 없으면 태그의 첫 카테고리로 보내기
+                active={parentCategory?.id === category.id}
+                ref={category.name === '솝티클' ? sopticleCategoryRef : null} // "솝티클" 카테고리에만 Ref 설정
+              >
+                {category.name}
               </Category>
             </LoggingClick>
-            {categories.map((category) => (
-              <LoggingClick key={category.id} eventKey='feedListCategoryFilter' param={{ category: category.name }}>
-                <Category
-                  onClick={() => onCategoryChange(category.id)}
-                  categoryId={category.hasAllCategory ? category.id : category.tags.at(0)?.id ?? category.id} // 하위에 "전체" 카테고리가 없으면 태그의 첫 카테고리로 보내기
-                  active={parentCategory?.id === category.id}
-                  ref={category.name === '솝티클' ? sopticleCategoryRef : null} // "솝티클" 카테고리에만 Ref 설정
+          ))}
+        </CategoryBox>
+      </HorizontalScroller>
+      {isOpen && (
+        <Tooltip top={tooltipPosition.top} left={tooltipPosition.left}>
+          <TooltipArrow />
+          <TooltipContent>
+            SOPT 회원들이 직접 작성한 아티클,{`\n`}이제 플레이그라운드에서도 볼 수 있어요!
+          </TooltipContent>
+        </Tooltip>
+      )}
+      {parentCategory && parentCategory.tags.length > 0 && (
+        <HorizontalScroller css={{ marginBottom: '12px' }}>
+          <TagBox>
+            {parentCategory.hasAllCategory && (
+              <LoggingClick eventKey='feedListCategoryFilter' param={{ category: '전체' }}>
+                <Chip categoryId={parentCategory.id} active={parentCategory.id === currentCategoryId}>
+                  전체
+                </Chip>
+              </LoggingClick>
+            )}
+            {parentCategory.tags.map((tag) => (
+              <LoggingClick key={tag.id} eventKey='feedListCategoryFilter' param={{ category: tag.name }}>
+                <Chip
+                  key={tag.id}
+                  categoryId={tag.id}
+                  active={tag.id === currentCategoryId}
+                  onClick={() => onCategoryChange(tag.id)}
                 >
-                  {category.name}
-                </Category>
+                  {tag.name}
+                </Chip>
               </LoggingClick>
             ))}
-          </CategoryBox>
+          </TagBox>
         </HorizontalScroller>
-        {isOpen && (
-          <Tooltip top={tooltipPosition.top} left={tooltipPosition.left}>
-            <TooltipArrow />
-            <TooltipContent>
-              SOPT 회원들이 직접 작성한 아티클,{`\n`}이제 플레이그라운드에서도 볼 수 있어요!
-            </TooltipContent>
-          </Tooltip>
-        )}
-        {parentCategory && parentCategory.tags.length > 0 && (
-          <HorizontalScroller css={{ marginBottom: '12px' }}>
-            <TagBox>
-              {parentCategory.hasAllCategory && (
-                <LoggingClick eventKey='feedListCategoryFilter' param={{ category: '전체' }}>
-                  <Chip categoryId={parentCategory.id} active={parentCategory.id === currentCategoryId}>
-                    전체
-                  </Chip>
-                </LoggingClick>
-              )}
-              {parentCategory.tags.map((tag) => (
-                <LoggingClick key={tag.id} eventKey='feedListCategoryFilter' param={{ category: tag.name }}>
-                  <Chip
-                    key={tag.id}
-                    categoryId={tag.id}
-                    active={tag.id === currentCategoryId}
-                    onClick={() => onCategoryChange(tag.id)}
-                  >
-                    {tag.name}
-                  </Chip>
-                </LoggingClick>
-              ))}
-            </TagBox>
-          </HorizontalScroller>
-        )}
-      </Container>
-    </>
+      )}
+    </Container>
   );
 };
 

--- a/src/components/feed/list/FeedCategoryTooltip/index.tsx
+++ b/src/components/feed/list/FeedCategoryTooltip/index.tsx
@@ -1,19 +1,56 @@
 import styled from '@emotion/styled';
 import { colors } from '@sopt-makers/colors';
-import React from 'react';
+import { IconXClose } from '@sopt-makers/icons';
+import React, { createContext, ReactNode, useContext } from 'react';
 
+import Text from '@/components/common/Text';
 import { MOBILE_MEDIA_QUERY } from '@/styles/mediaQuery';
 import { textStyles } from '@/styles/typography';
 import { zIndex } from '@/styles/zIndex';
 
-const Tooltip = ({ tooltipPosition }: { tooltipPosition: { top: number; left: number } }) => {
+const TooltipContext = createContext<{ top: number; left: number } | null>(null);
+interface TooltipProps {
+  tooltipPosition: { top: number; left: number };
+  children: ReactNode;
+}
+
+const Tooltip = ({ tooltipPosition, children }: TooltipProps) => {
   return (
-    <TooltipWrapper top={tooltipPosition.top} left={tooltipPosition.left}>
-      <TooltipArrow />
-      <TooltipContent>SOPT 회원들이 직접 작성한 아티클,{`\n`}이제 플레이그라운드에서도 볼 수 있어요!</TooltipContent>
-    </TooltipWrapper>
+    <TooltipContext.Provider value={tooltipPosition}>
+      <TooltipWrapper top={tooltipPosition.top} left={tooltipPosition.left}>
+        <TooltipArrow />
+        {children}
+      </TooltipWrapper>
+    </TooltipContext.Provider>
   );
 };
+
+const Header = ({ children }: { children: React.ReactNode }) => {
+  return <TooltipHeader>{children}</TooltipHeader>;
+};
+const Title = ({ children }: { children: ReactNode }) => {
+  return <Text typography='SUIT_14_SB'>{children}</Text>;
+};
+
+const Content = ({ children }: { children: ReactNode }) => {
+  return <TooltipContent>{children}</TooltipContent>;
+};
+
+const Close = () => {
+  return (
+    <IconXClose
+      style={{
+        width: 18,
+        height: 18,
+      }}
+    />
+  );
+};
+
+Tooltip.Header = Header;
+Tooltip.Title = Title;
+Tooltip.Content = Content;
+Tooltip.Close = Close;
 
 export default Tooltip;
 
@@ -38,18 +75,25 @@ const TooltipArrow = styled.div`
   }
 `;
 
+const TooltipHeader = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  width: 100%;
+`;
+
 const TooltipContent = styled.div`
   display: inline-flex;
   position: absolute;
   top: 9px;
   flex-direction: column;
-  gap: 24px;
+  gap: 8px;
   align-items: flex-start;
   margin: 0;
   border-radius: 12px;
   background: ${colors.gray600};
   padding: 12px 14px;
-  min-width: 160px;
+  width: 272px;
   ${textStyles.SUIT_13_M}
 
   line-height: 20px;

--- a/src/components/feed/list/FeedCategoryTooltip/index.tsx
+++ b/src/components/feed/list/FeedCategoryTooltip/index.tsx
@@ -36,14 +36,16 @@ const Content = ({ children }: { children: ReactNode }) => {
   return <TooltipContent>{children}</TooltipContent>;
 };
 
-const Close = () => {
+const Close = ({ onClick }: { onClick: () => void }) => {
   return (
-    <IconXClose
-      style={{
-        width: 18,
-        height: 18,
-      }}
-    />
+    <button onClick={onClick} aria-label='툴팁 오늘 하루동안 보지 않기'>
+      <IconXClose
+        style={{
+          width: 18,
+          height: 18,
+        }}
+      />
+    </button>
   );
 };
 

--- a/src/components/feed/list/FeedCategoryTooltip/index.tsx
+++ b/src/components/feed/list/FeedCategoryTooltip/index.tsx
@@ -1,0 +1,61 @@
+import styled from '@emotion/styled';
+import { colors } from '@sopt-makers/colors';
+import React from 'react';
+
+import { MOBILE_MEDIA_QUERY } from '@/styles/mediaQuery';
+import { textStyles } from '@/styles/typography';
+import { zIndex } from '@/styles/zIndex';
+
+const Tooltip = ({ tooltipPosition }: { tooltipPosition: { top: number; left: number } }) => {
+  return (
+    <TooltipWrapper top={tooltipPosition.top} left={tooltipPosition.left}>
+      <TooltipArrow />
+      <TooltipContent>SOPT 회원들이 직접 작성한 아티클,{`\n`}이제 플레이그라운드에서도 볼 수 있어요!</TooltipContent>
+    </TooltipWrapper>
+  );
+};
+
+export default Tooltip;
+
+const TooltipWrapper = styled.div<{ top: number; left: number }>`
+  position: absolute;
+  top: ${({ top }) => `${top}px`};
+  left: ${({ left }) => `${left}px`};
+  z-index: ${zIndex.헤더};
+`;
+
+const TooltipArrow = styled.div`
+  position: absolute;
+  left: 16px;
+  border-right: 5px solid transparent;
+  border-bottom: 9px solid ${colors.gray600};
+  border-left: 5px solid transparent;
+  width: 0;
+  height: 0;
+
+  @media ${MOBILE_MEDIA_QUERY} {
+    left: 20px;
+  }
+`;
+
+const TooltipContent = styled.div`
+  display: inline-flex;
+  position: absolute;
+  top: 9px;
+  flex-direction: column;
+  gap: 24px;
+  align-items: flex-start;
+  margin: 0;
+  border-radius: 12px;
+  background: ${colors.gray600};
+  padding: 12px 14px;
+  min-width: 160px;
+  ${textStyles.SUIT_13_M}
+
+  line-height: 20px;
+  white-space: pre;
+
+  @media ${MOBILE_MEDIA_QUERY} {
+    padding: 16px 18px;
+  }
+`;

--- a/src/components/feed/list/FeedCategoryTooltip/useTooltip.ts
+++ b/src/components/feed/list/FeedCategoryTooltip/useTooltip.ts
@@ -1,0 +1,43 @@
+import { RefObject, useCallback, useEffect, useState } from 'react';
+
+export const useTooltip = (positionRef: RefObject<HTMLAnchorElement>) => {
+  const [isOpen, setIsOpen] = useState(false);
+  const [tooltipPosition, setTooltipPosition] = useState({ top: 0, left: 0 });
+
+  const updateTooltipPosition = useCallback(() => {
+    if (positionRef.current) {
+      const rect = positionRef.current.getBoundingClientRect();
+      const parentRect = positionRef.current.offsetParent?.getBoundingClientRect() || { top: 0, left: 0 };
+
+      setTooltipPosition({
+        top: rect.bottom - parentRect.top,
+        left: rect.left - parentRect.left + 8,
+      });
+    }
+  }, [positionRef]);
+
+  useEffect(() => {
+    if (positionRef.current === null) return;
+    setIsOpen(true);
+    updateTooltipPosition();
+
+    window.addEventListener('resize', updateTooltipPosition);
+
+    const handleUserInteraction = () => {
+      setIsOpen(false);
+    };
+
+    window.addEventListener('scroll', handleUserInteraction, { once: true });
+    window.addEventListener('click', handleUserInteraction, { once: true });
+    window.addEventListener('keydown', handleUserInteraction, { once: true });
+
+    return () => {
+      window.removeEventListener('scroll', handleUserInteraction);
+      window.removeEventListener('click', handleUserInteraction);
+      window.removeEventListener('keydown', handleUserInteraction);
+      window.removeEventListener('resize', updateTooltipPosition);
+    };
+  }, [positionRef, updateTooltipPosition]);
+
+  return { tooltipPosition, isOpen };
+};

--- a/src/components/feed/list/FeedCategoryTooltip/useTooltip.ts
+++ b/src/components/feed/list/FeedCategoryTooltip/useTooltip.ts
@@ -1,6 +1,15 @@
 import { RefObject, useCallback, useEffect, useState } from 'react';
 
-export const useTooltip = (positionRef: RefObject<HTMLAnchorElement>) => {
+const getTodayDate = () => {
+  const now = new Date();
+  return `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, '0')}-${String(now.getDate()).padStart(
+    2,
+    '0',
+  )}`;
+};
+
+export const useTooltip = (positionRef: RefObject<HTMLAnchorElement>, storageKey: string) => {
+  const today = getTodayDate();
   const [isOpen, setIsOpen] = useState(false);
   const [tooltipPosition, setTooltipPosition] = useState({ top: 0, left: 0 });
 
@@ -17,27 +26,24 @@ export const useTooltip = (positionRef: RefObject<HTMLAnchorElement>) => {
   }, [positionRef]);
 
   useEffect(() => {
-    if (positionRef.current === null) return;
-    setIsOpen(true);
+    const lastClosedDate = localStorage.getItem(storageKey);
+
+    if (lastClosedDate === today || positionRef.current === null) return;
+
     updateTooltipPosition();
+    setIsOpen(true);
 
     window.addEventListener('resize', updateTooltipPosition);
 
-    const handleUserInteraction = () => {
-      setIsOpen(false);
-    };
-
-    window.addEventListener('scroll', handleUserInteraction, { once: true });
-    window.addEventListener('click', handleUserInteraction, { once: true });
-    window.addEventListener('keydown', handleUserInteraction, { once: true });
-
     return () => {
-      window.removeEventListener('scroll', handleUserInteraction);
-      window.removeEventListener('click', handleUserInteraction);
-      window.removeEventListener('keydown', handleUserInteraction);
       window.removeEventListener('resize', updateTooltipPosition);
     };
-  }, [positionRef, updateTooltipPosition]);
+  }, [positionRef, updateTooltipPosition, storageKey, today]);
 
-  return { tooltipPosition, isOpen };
+  const closeTooltipForToday = () => {
+    localStorage.setItem(storageKey, today);
+    setIsOpen(false);
+  };
+
+  return { tooltipPosition, isOpen, closeTooltipForToday };
 };


### PR DESCRIPTION
### 🤫 쉿, 나한테만 말해줘요. 이슈넘버
- close #1811

### 🧐 어떤 것을 변경했어요~?
<!-- 실제로 변경한 사항을 설명해주세요.-->
메인 페이지에서 솝티클 탭이 있으면 툴팁이 자동노출되도록 컴포넌트 추가했습니다.

### 🤔 그렇다면, 어떻게 구현했어요~?
<!-- 실제로 구현한 로직에 대해 설명해주세요.-->
~~카테고리에서 솝티클이 있으면 ref를 지정해서 해당하는 위치에 툴팁이 자동노출되도록 구현했습니다.
사용자의 이벤트(scroll. click, keydown)이 일어나면 툴팁이 사라지도록 했습니다
이때 홈에 팝업이 뜨는 경우 팝업에서의 클릭은 감지하지 않도록 팝업 버튼에 `e.stopPropagation();`를 추가했습니다.~~

+) 수정된 기능 명세 반영했습니다.
수정된 기능 명세를 반영하여, 툴팁에 제목과 닫기 버튼이 추가되었습니다.
이 요소들을 사용하는 쪽에서 유연하게 조합할 수 있도록 툴팁은 합성 컴포넌트 패턴으로 작성하였습니다.

기존에는 사용자 이벤트(스크롤, 클릭, 키보드 입력 등)를 감지하여 툴팁을 자동으로 닫았으나,
현재는 닫기 버튼 클릭 또는 솝티클 카테고리 선택 시 툴팁이 닫히고, 해당 날짜에 다시 노출되지 않도록 변경되었습니다.
이를 위해 useTooltip 훅에 closeTooltipForToday 함수를 추가하고, 닫기 버튼 및 카테고리 선택 영역에서 이 함수를 onClick으로 연결했습니다.
툴팁의 닫은 날짜는 localStorage에 저장되며, 향후 다양한 위치에서 툴팁을 사용할 가능성을 고려하여, 스토리지 키를 외부에서 인자로 주입받도록 설계하였습니다.

### ❤️‍🔥 당신이 생각하는 PR포인트, 내겐 매력포인트.
<!-- 해당 PR에서 논의가 필요한 사항을 적어주세요. -->
더 좋은 방법이 있다면 편하게 말씀해주세요!

### 📸 스크린샷, 없으면 이것 참,, 섭섭한데요?
일단 api가 아직 수정되지 않아서 쿼리 데브툴에서 솝티클 탭을 추가했을 때 화면입니다!
![image](https://github.com/user-attachments/assets/2661b406-d3fa-4051-bd28-845ce6f7894e)
![image](https://github.com/user-attachments/assets/7a042448-011f-47b4-bbbc-58fb0671fcec)
