### PR TITLE
feat: 솝티클 업로드 UI

### DIFF
--- a/src/components/feed/page/FeedUploadPage.tsx
+++ b/src/components/feed/page/FeedUploadPage.tsx
@@ -3,7 +3,7 @@ import styled from '@emotion/styled';
 import { colors } from '@sopt-makers/colors';
 import { Callout } from '@sopt-makers/ui';
 import { useRouter } from 'next/router';
-import { FormEvent, useEffect, useRef, useState } from 'react';
+import { FormEvent, useEffect, useRef } from 'react';
 
 import Checkbox from '@/components/common/Checkbox';
 import Responsive from '@/components/common/Responsive';
@@ -16,6 +16,7 @@ import CheckboxFormItem from '@/components/feed/upload/CheckboxFormItem';
 import BlindWriterWarning from '@/components/feed/upload/CheckboxFormItem/BlindWriterWarning';
 import CodeUploadButton from '@/components/feed/upload/CodeUploadButton';
 import { useCategoryUsingRulesPreview } from '@/components/feed/upload/hooks/useCategorySelect';
+import useLinkValidator from '@/components/feed/upload/hooks/useLinkValidator';
 import useUploadFeedData from '@/components/feed/upload/hooks/useUploadFeedData';
 import ImagePreview from '@/components/feed/upload/ImagePreview';
 import ImageUploadButton from '@/components/feed/upload/ImageUploadButton';
@@ -82,14 +83,12 @@ export default function FeedUploadPage({ defaultValue, editingId, onSubmit }: Fe
   const { isPreviewOpen, openUsingRules, closeUsingRules } = useCategoryUsingRulesPreview(false);
   const { logClickEvent } = useEventLogger();
 
-  const [urlError, setUrlError] = useState(false);
+  const { islinkError, validateLink, resetLinkError } = useLinkValidator();
 
   const handleSubmit = (e: FormEvent<HTMLFormElement>) => {
     e.preventDefault();
 
-    // isSopticle일 때만 링크 유효성 검사
-    if (isSopticle && !/^https?:\/\//.test(feedData.content)) {
-      setUrlError(true);
+    if (isSopticle && !validateLink(feedData.content)) {
       return;
     }
 
@@ -188,10 +187,10 @@ export default function FeedUploadPage({ defaultValue, editingId, onSubmit }: Fe
                   <LinkInput
                     onChange={(e) => {
                       handleSaveContent(e);
-                      setUrlError(false);
+                      resetLinkError();
                     }}
                     value={feedData.content}
-                    isError={urlError}
+                    isError={islinkError}
                   />
                   <Callout type='information' hasIcon>
                     내가 직접 작성한 아티클을 SOPT회원들에게 공유해 보세요!
@@ -314,10 +313,10 @@ export default function FeedUploadPage({ defaultValue, editingId, onSubmit }: Fe
                     <LinkInput
                       onChange={(e) => {
                         handleSaveContent(e);
-                        setUrlError(false);
+                        resetLinkError();
                       }}
                       value={feedData.content}
-                      isError={urlError}
+                      isError={islinkError}
                     />
                     <Callout type='information' hasIcon>
                       내가 직접 작성한 아티클을 SOPT회원들에게 공유해 보세요!

--- a/src/components/feed/page/FeedUploadPage.tsx
+++ b/src/components/feed/page/FeedUploadPage.tsx
@@ -83,7 +83,7 @@ export default function FeedUploadPage({ defaultValue, editingId, onSubmit }: Fe
   const { isPreviewOpen, openUsingRules, closeUsingRules } = useCategoryUsingRulesPreview(false);
   const { logClickEvent } = useEventLogger();
 
-  const { islinkError, validateLink, resetLinkError } = useLinkValidator();
+  const { isLinkError, validateLink, resetLinkError } = useLinkValidator();
 
   const handleSubmit = (e: FormEvent<HTMLFormElement>) => {
     e.preventDefault();
@@ -190,7 +190,7 @@ export default function FeedUploadPage({ defaultValue, editingId, onSubmit }: Fe
                       resetLinkError();
                     }}
                     value={feedData.content}
-                    isError={islinkError}
+                    isError={isLinkError}
                   />
                   <Callout type='information' hasIcon>
                     내가 직접 작성한 아티클을 SOPT회원들에게 공유해 보세요!
@@ -316,7 +316,7 @@ export default function FeedUploadPage({ defaultValue, editingId, onSubmit }: Fe
                         resetLinkError();
                       }}
                       value={feedData.content}
-                      isError={islinkError}
+                      isError={isLinkError}
                     />
                     <Callout type='information' hasIcon>
                       내가 직접 작성한 아티클을 SOPT회원들에게 공유해 보세요!

--- a/src/components/feed/page/FeedUploadPage.tsx
+++ b/src/components/feed/page/FeedUploadPage.tsx
@@ -275,10 +275,6 @@ export default function FeedUploadPage({ defaultValue, editingId, onSubmit }: Fe
                   올리기
                 </Button>
               </TopHeader>
-            </>
-          }
-          body={
-            <BodyWrapper>
               <Category
                 feedData={feedData}
                 onSaveCategory={handleSaveCategory}
@@ -286,28 +282,36 @@ export default function FeedUploadPage({ defaultValue, editingId, onSubmit }: Fe
                 closeUsingRules={closeUsingRules}
                 isEdit={isEdit}
               />
+            </>
+          }
+          body={
+            <>
               <Body>
                 {feedData.isBlindWriter && <BlindWriterWarning />}
-                <CheckBoxesWrapper>
-                  {parentCategory?.hasQuestion && (
-                    <CheckboxFormItem label='질문글'>
-                      <Checkbox
-                        checked={feedData.isQuestion}
-                        onChange={(e) => handleSaveIsQuestion(e.target.checked)}
-                        size='medium'
-                      />
-                    </CheckboxFormItem>
-                  )}
-                  {parentCategory?.hasBlind && (
-                    <CheckboxFormItem label='익명'>
-                      <Checkbox
-                        checked={feedData.isBlindWriter}
-                        onChange={(e) => handleSaveIsBlindWriter(e.target.checked)}
-                        size='medium'
-                      />
-                    </CheckboxFormItem>
-                  )}
-                </CheckBoxesWrapper>
+
+                {(parentCategory?.hasQuestion || parentCategory?.hasBlind) && (
+                  <CheckBoxesWrapper>
+                    {parentCategory?.hasQuestion && (
+                      <CheckboxFormItem label='질문글'>
+                        <Checkbox
+                          checked={feedData.isQuestion}
+                          onChange={(e) => handleSaveIsQuestion(e.target.checked)}
+                          size='medium'
+                        />
+                      </CheckboxFormItem>
+                    )}
+                    {parentCategory?.hasBlind && (
+                      <CheckboxFormItem label='익명'>
+                        <Checkbox
+                          checked={feedData.isBlindWriter}
+                          onChange={(e) => handleSaveIsBlindWriter(e.target.checked)}
+                          size='medium'
+                        />
+                      </CheckboxFormItem>
+                    )}
+                  </CheckBoxesWrapper>
+                )}
+
                 {isSopticle ? (
                   <InputWrapper>
                     <LinkInput
@@ -318,9 +322,11 @@ export default function FeedUploadPage({ defaultValue, editingId, onSubmit }: Fe
                       value={feedData.content}
                       isError={isLinkError}
                     />
-                    <Callout type='information' hasIcon>
-                      내가 직접 작성한 아티클을 SOPT회원들에게 공유해 보세요!
-                    </Callout>
+                    <CalloutWrapper>
+                      <Callout type='information' hasIcon>
+                        내가 직접 작성한 아티클을 SOPT회원들에게 공유해 보세요!
+                      </Callout>
+                    </CalloutWrapper>
                   </InputWrapper>
                 ) : (
                   <>
@@ -345,7 +351,7 @@ export default function FeedUploadPage({ defaultValue, editingId, onSubmit }: Fe
                   </>
                 )}
               </Body>
-            </BodyWrapper>
+            </>
           }
           footer={
             <Footer>
@@ -357,12 +363,6 @@ export default function FeedUploadPage({ defaultValue, editingId, onSubmit }: Fe
     </form>
   );
 }
-
-const BodyWrapper = styled.section`
-  @media ${MOBILE_MEDIA_QUERY} {
-    margin-top: 44px;
-  }
-`;
 
 const Body = styled.div`
   display: flex;
@@ -413,7 +413,6 @@ const ButtonContainer = styled.div`
 
 const TopHeader = styled.header`
   display: flex;
-  position: fixed;
   justify-content: space-between;
   z-index: 2;
   background-color: ${colors.gray950};
@@ -476,7 +475,7 @@ const CheckBoxesWrapper = styled.div`
   gap: 16px;
 
   @media ${MOBILE_MEDIA_QUERY} {
-    margin: 24px 0;
+    margin-bottom: 24px;
   }
 `;
 
@@ -497,4 +496,8 @@ export const LoadingWrapper = styled.div`
   justify-content: center;
   width: 100%;
   height: 100vh;
+`;
+
+const CalloutWrapper = styled.div`
+  margin-bottom: 12px;
 `;

--- a/src/components/feed/upload/Category/CategoryHeader/index.tsx
+++ b/src/components/feed/upload/Category/CategoryHeader/index.tsx
@@ -71,6 +71,7 @@ const CategoryTitle = styled.button`
   border-radius: 8px;
   cursor: pointer;
   padding: 6px;
+  color: ${colors.gray10};
 
   &:hover {
     background-color: ${colors.gray800};

--- a/src/components/feed/upload/Category/CategoryHeader/index.tsx
+++ b/src/components/feed/upload/Category/CategoryHeader/index.tsx
@@ -55,7 +55,7 @@ const CategoryContainer = styled.div`
   align-items: center;
 
   @media ${MOBILE_MEDIA_QUERY} {
-    padding: 12px 16px;
+    padding: 19px 16px;
   }
 `;
 
@@ -118,7 +118,7 @@ const CategorySelectorStarter = styled.header`
   }
 
   @media ${MOBILE_MEDIA_QUERY} {
-    padding: 14px 16px;
+    padding: 19px 16px;
     width: 100%;
 
     &:hover {

--- a/src/components/feed/upload/Category/CategorySelector/CategorySelectOptions.tsx
+++ b/src/components/feed/upload/Category/CategorySelector/CategorySelectOptions.tsx
@@ -3,7 +3,6 @@ import { colors } from '@sopt-makers/colors';
 import { useQuery } from '@tanstack/react-query';
 
 import { getCategory } from '@/api/endpoint/feed/getCategory';
-import { SOPTICLE_CATEGORY_ID } from '@/components/feed/constants';
 import { BasicCategory } from '@/components/feed/upload/Category/types';
 import { FeedDataType } from '@/components/feed/upload/types';
 import { textStyles } from '@/styles/typography';
@@ -22,11 +21,13 @@ export default function CategorySelectOptions({ onSave, feedData }: CategorySele
     queryFn: getCategory.request,
   });
 
+  const sortedCategories = categories ? [...categories.slice(1), categories[0]] : [];
+
   return (
     <Select>
-      {categories &&
-        categories.length > 0 &&
-        categories.map((category: BasicCategory) => {
+      {sortedCategories &&
+        sortedCategories.length > 0 &&
+        sortedCategories.map((category: BasicCategory) => {
           return (
             <Option
               key={category.id}

--- a/src/components/feed/upload/Category/CategorySelector/CategorySelectOptions.tsx
+++ b/src/components/feed/upload/Category/CategorySelector/CategorySelectOptions.tsx
@@ -22,13 +22,11 @@ export default function CategorySelectOptions({ onSave, feedData }: CategorySele
     queryFn: getCategory.request,
   });
 
-  const filteredCategories = categories?.filter((category) => category.id !== SOPTICLE_CATEGORY_ID);
-
   return (
     <Select>
-      {filteredCategories &&
-        filteredCategories.length > 0 &&
-        filteredCategories.map((category: BasicCategory) => {
+      {categories &&
+        categories.length > 0 &&
+        categories.map((category: BasicCategory) => {
           return (
             <Option
               key={category.id}
@@ -47,6 +45,7 @@ export default function CategorySelectOptions({ onSave, feedData }: CategorySele
 const OptionTitle = styled.h2`
   ${textStyles.SUIT_16_M};
 
+  line-height: 22px;
   color: ${colors.white};
 `;
 
@@ -54,6 +53,7 @@ const OptionContents = styled.p`
   text-align: left;
   ${textStyles.SUIT_12_R};
 
+  line-height: 20px;
   color: ${colors.gray300};
 `;
 
@@ -61,6 +61,7 @@ const Option = styled.button<{ isSelected: boolean }>`
   display: flex;
   flex-direction: column;
   gap: 2px;
+  align-items: flex-start;
   border-radius: 6px;
   background-color: ${({ isSelected }) => isSelected && colors.gray700};
   cursor: pointer;

--- a/src/components/feed/upload/Category/TagSelector/TagSelectOptions.tsx
+++ b/src/components/feed/upload/Category/TagSelector/TagSelectOptions.tsx
@@ -1,4 +1,5 @@
 import styled from '@emotion/styled';
+import { colors } from '@sopt-makers/colors';
 
 import Responsive from '@/components/common/Responsive';
 import SquareLink from '@/components/common/SquareLink';
@@ -98,6 +99,7 @@ const Option = styled.button`
   cursor: pointer;
   padding: 12px;
   width: 100%;
+  color: ${colors.gray10};
 `;
 
 const SubmitButton = styled.button`

--- a/src/components/feed/upload/CheckboxFormItem/BlindWriterWarning/index.tsx
+++ b/src/components/feed/upload/CheckboxFormItem/BlindWriterWarning/index.tsx
@@ -30,7 +30,7 @@ const WarningBox = styled.article`
   color: ${colors.gray30};
 
   @media ${MOBILE_MEDIA_QUERY} {
-    margin-top: 16px;
+    margin-bottom: 24px;
   }
 `;
 

--- a/src/components/feed/upload/CodeUploadButton/index.tsx
+++ b/src/components/feed/upload/CodeUploadButton/index.tsx
@@ -67,6 +67,7 @@ const Button = styled.button`
   border-radius: 21px;
   background-color: ${colors.gray800};
   padding: 6px 12px;
+  color: ${colors.gray10};
 
   ${textStyles.SUIT_13_M}
 `;

--- a/src/components/feed/upload/ImageUploadButton/index.tsx
+++ b/src/components/feed/upload/ImageUploadButton/index.tsx
@@ -34,8 +34,8 @@ const Button = styled.button`
   border-radius: 21px;
   background-color: ${colors.gray800};
   padding: 6px 12px;
-
-  ${textStyles.SUIT_13_M}
+  color: ${colors.gray10};
+  ${textStyles.SUIT_13_M};
 `;
 
 const imageSvg = (

--- a/src/components/feed/upload/Input/LinkInput/index.tsx
+++ b/src/components/feed/upload/Input/LinkInput/index.tsx
@@ -1,15 +1,20 @@
 import styled from '@emotion/styled';
 import { TextField } from '@sopt-makers/ui';
-import { ChangeEvent } from 'react';
+import { ChangeEvent, KeyboardEvent } from 'react';
 
 interface UrlInputProps {
   onChange: (e: ChangeEvent<HTMLInputElement> | ChangeEvent<HTMLTextAreaElement>) => void;
   value: string | null;
   isError: boolean;
-  onKeyDown?: (e: React.KeyboardEvent<HTMLInputElement>) => void;
 }
 
-const UrlInput = ({ onChange, value, isError, onKeyDown }: UrlInputProps) => {
+const LinkInput = ({ onChange, value, isError }: UrlInputProps) => {
+  const handleKeyDown = (e: KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === 'Enter') {
+      e.preventDefault();
+    }
+  };
+
   return (
     <StyledTextField
       errorMessage='올바른 링크를 입력해 주세요'
@@ -19,7 +24,7 @@ const UrlInput = ({ onChange, value, isError, onKeyDown }: UrlInputProps) => {
       onChange={onChange}
       value={value ?? ''}
       isError={isError}
-      onKeyDown={onKeyDown}
+      onKeyDown={handleKeyDown}
     />
   );
 };
@@ -29,4 +34,4 @@ const StyledTextField = styled(TextField)<{ isError: boolean }>`
   width: 100%;
 `;
 
-export default UrlInput;
+export default LinkInput;

--- a/src/components/feed/upload/Input/LinkInput/index.tsx
+++ b/src/components/feed/upload/Input/LinkInput/index.tsx
@@ -1,0 +1,32 @@
+import styled from '@emotion/styled';
+import { TextField } from '@sopt-makers/ui';
+import { ChangeEvent } from 'react';
+
+interface UrlInputProps {
+  onChange: (e: ChangeEvent<HTMLInputElement> | ChangeEvent<HTMLTextAreaElement>) => void;
+  value: string | null;
+  isError: boolean;
+  onKeyDown?: (e: React.KeyboardEvent<HTMLInputElement>) => void;
+}
+
+const UrlInput = ({ onChange, value, isError, onKeyDown }: UrlInputProps) => {
+  return (
+    <StyledTextField
+      errorMessage='올바른 링크를 입력해 주세요'
+      labelText='아티클 링크'
+      placeholder='ex. https://playground.sopt.org'
+      required
+      onChange={onChange}
+      value={value ?? ''}
+      isError={isError}
+      onKeyDown={onKeyDown}
+    />
+  );
+};
+
+const StyledTextField = styled(TextField)<{ isError: boolean }>`
+  margin-bottom: ${({ isError }) => (isError ? 0 : '24px')};
+  width: 100%;
+`;
+
+export default UrlInput;

--- a/src/components/feed/upload/Input/LinkInput/index.tsx
+++ b/src/components/feed/upload/Input/LinkInput/index.tsx
@@ -2,13 +2,13 @@ import styled from '@emotion/styled';
 import { TextField } from '@sopt-makers/ui';
 import { ChangeEvent, KeyboardEvent } from 'react';
 
-interface UrlInputProps {
+interface LinkInputProps {
   onChange: (e: ChangeEvent<HTMLInputElement> | ChangeEvent<HTMLTextAreaElement>) => void;
-  value: string | null;
+  value: string;
   isError: boolean;
 }
 
-const LinkInput = ({ onChange, value, isError }: UrlInputProps) => {
+const LinkInput = ({ onChange, value, isError }: LinkInputProps) => {
   const handleKeyDown = (e: KeyboardEvent<HTMLInputElement>) => {
     if (e.key === 'Enter') {
       e.preventDefault();

--- a/src/components/feed/upload/hooks/useLinkValidator.ts
+++ b/src/components/feed/upload/hooks/useLinkValidator.ts
@@ -1,0 +1,26 @@
+import { useState } from 'react';
+
+export default function useLinkValidator() {
+  const [islinkError, setIsLinkError] = useState(false);
+
+  const isValidLink = (link: string | null) => {
+    return /^https?:\/\//.test(link ?? '');
+  };
+
+  const validateLink = (link: string | null) => {
+    const isValid = isValidLink(link);
+    setIsLinkError(!isValid);
+
+    return isValid;
+  };
+
+  const resetLinkError = () => {
+    setIsLinkError(false);
+  };
+
+  return {
+    islinkError,
+    validateLink,
+    resetLinkError,
+  };
+}

--- a/src/components/feed/upload/hooks/useLinkValidator.ts
+++ b/src/components/feed/upload/hooks/useLinkValidator.ts
@@ -1,7 +1,7 @@
 import { useState } from 'react';
 
 export default function useLinkValidator() {
-  const [islinkError, setIsLinkError] = useState(false);
+  const [isLinkError, setIsLinkError] = useState(false);
 
   const isValidLink = (link: string | null) => {
     return /^https?:\/\//.test(link ?? '');
@@ -19,7 +19,7 @@ export default function useLinkValidator() {
   };
 
   return {
-    islinkError,
+    isLinkError,
     validateLink,
     resetLinkError,
   };

--- a/src/components/feed/upload/layout/MobileFeedUploadLayout.tsx
+++ b/src/components/feed/upload/layout/MobileFeedUploadLayout.tsx
@@ -23,14 +23,12 @@ const HeaderWrapper = styled.header`
 `;
 
 const BodyWrapper = styled.section`
-  margin-top: 10px;
+  padding-top: 24px;
   width: 100%;
 `;
 
 const FooterWrapper = styled.footer`
   display: flex;
-  position: fixed;
-  bottom: 0;
   flex-direction: column;
   gap: 8px;
   margin-bottom: 10px;

--- a/src/components/feed/upload/layout/MobileFeedUploadLayout.tsx
+++ b/src/components/feed/upload/layout/MobileFeedUploadLayout.tsx
@@ -29,6 +29,8 @@ const BodyWrapper = styled.section`
 
 const FooterWrapper = styled.footer`
   display: flex;
+  position: fixed;
+  bottom: 0;
   flex-direction: column;
   gap: 8px;
   margin-bottom: 10px;


### PR DESCRIPTION
### 🤫 쉿, 나한테만 말해줘요. 이슈넘버
- close #1823 

### 🧐 어떤 것을 변경했어요~?
<!-- 실제로 변경한 사항을 설명해주세요.-->
- LinkInput 컴포넌트를 만들었어요
- 링크 유효성을 검사하는 로직을 `useLinkValidator`로 만들었어요.
- LinkInput 컴포넌트를 솝티클 업로드 영역에 분기처리로 추가했어요.

### 🤔 그렇다면, 어떻게 구현했어요~?
<!-- 실제로 구현한 로직에 대해 설명해주세요.-->
- LinkInput에서 앤터키를 눌렀을 때 form 제출이 되는 걸 막고자 onKeyDown 이벤트에 e.preventDefault()를 통해 기본 동작을 막았어요
- 링크의 유효성 검사는 "https://"로 시작하는지를 정규식을 통해 검사했어요
- ` const isSopticle = parentCategory?.id === SOPTICLE_CATEGORY_ID;` 해당 로직으로 솝트클인지 확인하고
`{isSopticle ? <>  ... </> : <> ... </>}` 이와 같이 솝티클인 경우와 아닌 경우를 나눠서 커뮤니티 업로드 구좌를 구현했어요
- 업로드 페이지에 카테고리를 선택하는 토글에서 솝티클 카테고리를 가장 뒤에 두기 위해서 
 ` const sortedCategories = categories ? [...categories.slice(1), categories[0]] : [];` 이와 같이 가장 앞에 있던 카테고리를 가장 뒤로 보냈어요.

### ❤️‍🔥 당신이 생각하는 PR포인트, 내겐 매력포인트.
<!-- 해당 PR에서 논의가 필요한 사항을 적어주세요. -->
-  가장 앞에 있던 카테고리를 가장 뒤로 보내는 연산을 메모이제이션 하는 것이 좋을지 아니면 간단한 연산이니 현재 로직을 그대로 둘지에 대해서 고민중이에요. 이에 대한 의견이 궁금합니다!

### 📸 스크린샷, 없으면 이것 참,, 섭섭한데요?
<img width="400" alt="image" src="https://github.com/user-attachments/assets/3a929c79-0b31-4436-bf43-0fb61f22cdb6" />
<img width="400" alt="image" src="https://github.com/user-attachments/assets/961e0a24-9d8f-41da-b0c0-4d9925c6efdc" />
