### PR TITLE
feat: sp1관련 앰플리튜드 로깅 추가

### DIFF
--- a/src/api/endpoint/members/getMemberProperty.ts
+++ b/src/api/endpoint/members/getMemberProperty.ts
@@ -10,14 +10,16 @@ export const getMemberproperty = createEndpoint({
   },
   serverResponseScheme: z.object({
     id: z.number(),
-    major: z.string(),
-    job: z.string(),
-    organization: z.string(),
+    major: z.string().nullable(),
+    job: z.string().nullable(),
+    organization: z.string().nullable(),
     part: z.array(z.string()),
     generation: z.array(z.number()),
     coffeeChatStatus: z.string(),
     receivedCoffeeChatCount: z.number(),
     sentCoffeeChatCount: z.number(),
+    uploadSopticleCount: z.number(),
+    uploadReviewCount: z.number(),
   }),
 });
 
@@ -29,7 +31,6 @@ export const useGetMemberProperty = () => {
     queryKey: ['getMemberProperty'],
     queryFn: async () => {
       const data = await getMemberproperty.request();
-      console.log(data);
       return data;
     },
   });

--- a/src/components/eventLogger/controllers/amplitude.ts
+++ b/src/components/eventLogger/controllers/amplitude.ts
@@ -16,7 +16,9 @@ export function createAmplitudeController(apiKey: string, userId: string | undef
   const setUserProperties = (properties: UserProperties) => {
     const identify = new Identify();
     for (const [key, value] of Object.entries(properties)) {
-      identify.set(key, value);
+      if (value !== null) {
+        identify.set(key, value);
+      }
     }
     instance.identify(identify);
   };

--- a/src/components/eventLogger/events.ts
+++ b/src/components/eventLogger/events.ts
@@ -122,6 +122,7 @@ export interface ClickEvents {
   feedUploadButton: undefined;
   feedLike: {
     feedId: string;
+    category: string;
   };
   feedUnlike: {
     feedId: string;

--- a/src/components/eventLogger/events.ts
+++ b/src/components/eventLogger/events.ts
@@ -14,14 +14,16 @@ type CommunityFeedData = {
 
 export type UserProperties = {
   id: number;
-  major: string;
-  organization: string;
-  job: string;
+  major: string | null;
+  organization: string | null;
+  job: string | null;
   part: string[];
   generation: number[];
   coffeeChatStatus: string;
   receivedCoffeeChatCount: number;
   sentCoffeeChatCount: number;
+  uploadSopticleCount: number;
+  uploadReviewCount: number;
 };
 
 type GotoCoffeechat = {

--- a/src/components/eventLogger/events.ts
+++ b/src/components/eventLogger/events.ts
@@ -106,6 +106,7 @@ export interface ClickEvents {
   };
   feedCard: {
     feedId: string;
+    category: string;
   };
   feedShareButton: {
     feedId: string;

--- a/src/components/eventLogger/events.ts
+++ b/src/components/eventLogger/events.ts
@@ -126,6 +126,7 @@ export interface ClickEvents {
   };
   feedUnlike: {
     feedId: string;
+    category: string;
   };
 
   //환영배너 타임캡솝 cta 버튼 클릭

--- a/src/components/eventLogger/events.ts
+++ b/src/components/eventLogger/events.ts
@@ -261,6 +261,7 @@ export interface PageViewEvents {
 export interface ImpressionEvents {
   feedCard: {
     feedId: string;
+    category: string;
   };
   ads: { bannerId: number; pageUrl: string; timeStamp: string };
   adPopup: undefined;

--- a/src/components/eventLogger/events.ts
+++ b/src/components/eventLogger/events.ts
@@ -222,7 +222,9 @@ export interface SubmitEvents {
     word: string;
   };
   wordchainNewGame: undefined;
-  submitCommunity: undefined;
+  submitCommunity: {
+    category: string | undefined;
+  };
   editCommunity: undefined;
   // 커뮤니티(피드)
   postComment: {

--- a/src/components/eventLogger/providers/AmplitudeProvider.tsx
+++ b/src/components/eventLogger/providers/AmplitudeProvider.tsx
@@ -37,6 +37,8 @@ const AmplitudeProvider: FC<EventLoggerProviderProps> = ({ children, apiKey }) =
             coffeeChatStatus: property.coffeeChatStatus,
             receivedCoffeeChatCount: property.receivedCoffeeChatCount,
             sentCoffeeChatCount: property.sentCoffeeChatCount,
+            uploadSopticleCount: property.uploadSopticleCount,
+            uploadReviewCount: property.uploadReviewCount,
           });
         }
 

--- a/src/components/feed/common/utils.ts
+++ b/src/components/feed/common/utils.ts
@@ -41,6 +41,7 @@ export const CategoryList = {
   SOPT활동: 'SOPT활동',
   홍보: '홍보',
   취업_진로: '취업/진로',
+  솝티클: '솝티클',
 };
 
 const 특수임원List = [
@@ -80,3 +81,12 @@ export function getMemberInfo(post: Post) {
 
   return defaultInfo;
 }
+
+export const categoryIdNameMap: Record<number, string> = {
+  1: '자유',
+  2: '파트',
+  3: 'SOPT 활동',
+  4: '홍보',
+  5: '취업/진로',
+  21: '솝티클',
+};

--- a/src/components/feed/detail/FeedDetailContent.tsx
+++ b/src/components/feed/detail/FeedDetailContent.tsx
@@ -3,6 +3,7 @@ import { FC } from 'react';
 import { useGetCommentQuery } from '@/api/endpoint/feed/getComment';
 import { getPost, useGetPostQuery } from '@/api/endpoint/feed/getPost';
 import { useGetPostsInfiniteQuery } from '@/api/endpoint/feed/getPosts';
+import { LoggingClick } from '@/components/eventLogger/components/LoggingClick';
 import FeedLike from '@/components/feed/common/FeedLike';
 import { useToggleLike } from '@/components/feed/common/hooks/useToggleLike';
 import { getMemberInfo } from '@/components/feed/common/utils';
@@ -58,22 +59,27 @@ const FeedDetailContent: FC<FeedDetailContentProps> = ({ postId }) => {
         sopticleUrl={postData.posts.sopticleUrl ?? ''}
         thumbnailUrl={postData.posts.images[0]}
         like={
-          <FeedLike
-            isLiked={postData.isLiked}
-            likes={postData.likes}
-            onClick={(e) => {
-              e.stopPropagation();
-              e.preventDefault();
-              handleToggleLike({
-                postId: Number(postId),
-                isLiked: postData.isLiked,
-                likes: postData.likes,
-                allPostsQueryKey: useGetPostsInfiniteQuery.getKey(''),
-                postsQueryKey: useGetPostsInfiniteQuery.getKey(postData.posts.categoryId.toString()),
-                postQueryKey: getPost.cacheKey(postId),
-              });
-            }}
-          />
+          <LoggingClick
+            eventKey={postData.isLiked ? 'feedUnlike' : 'feedLike'}
+            param={{ feedId: postId, category: postData.category.name }}
+          >
+            <FeedLike
+              isLiked={postData.isLiked}
+              likes={postData.likes}
+              onClick={(e) => {
+                e.stopPropagation();
+                e.preventDefault();
+                handleToggleLike({
+                  postId: Number(postId),
+                  isLiked: postData.isLiked,
+                  likes: postData.likes,
+                  allPostsQueryKey: useGetPostsInfiniteQuery.getKey(''),
+                  postsQueryKey: useGetPostsInfiniteQuery.getKey(postData.posts.categoryId.toString()),
+                  postQueryKey: getPost.cacheKey(postId),
+                });
+              }}
+            />
+          </LoggingClick>
         }
       />
     </DetailFeedCard.Main>

--- a/src/components/feed/list/FeedList.tsx
+++ b/src/components/feed/list/FeedList.tsx
@@ -18,7 +18,7 @@ import { playgroundLink } from '@/constants/links';
 import { MOBILE_MEDIA_QUERY } from '@/styles/mediaQuery';
 
 interface FeedListProps {
-  renderFeedDetailLink: (props: { children: ReactNode; feedId: string }) => ReactNode;
+  renderFeedDetailLink: (props: { children: ReactNode; feedId: string; category: string }) => ReactNode;
   onScrollChange?: (scrolling: boolean) => void;
 }
 

--- a/src/components/feed/list/FeedListItems.tsx
+++ b/src/components/feed/list/FeedListItems.tsx
@@ -29,7 +29,7 @@ import { useNavigateBack } from '@/components/navigation/useNavigateBack';
 import { textStyles } from '@/styles/typography';
 interface FeedListItemsProps {
   categoryId: string | undefined;
-  renderFeedDetailLink: (props: { children: ReactNode; feedId: string }) => ReactNode;
+  renderFeedDetailLink: (props: { children: ReactNode; feedId: string; category: string }) => ReactNode;
   onScrollChange?: (scrolling: boolean) => void;
 }
 
@@ -116,6 +116,7 @@ const FeedListItems: FC<FeedListItemsProps> = ({ categoryId, renderFeedDetailLin
 
           return renderFeedDetailLink({
             feedId: `${post.id}`,
+            category: `${post.categoryName}`,
             children: (
               <FeedCard
                 onClick={() => setMap((map) => ({ ...map, [categoryId ?? '']: idx }))}

--- a/src/components/feed/list/FeedListItems.tsx
+++ b/src/components/feed/list/FeedListItems.tsx
@@ -228,7 +228,10 @@ const FeedListItems: FC<FeedListItemsProps> = ({ categoryId, renderFeedDetailLin
                   </FeedDropdown>
                 }
                 like={
-                  <LoggingClick eventKey={post.isLiked ? 'feedUnlike' : 'feedLike'} param={{ feedId: String(post.id) }}>
+                  <LoggingClick
+                    eventKey={post.isLiked ? 'feedUnlike' : 'feedLike'}
+                    param={{ feedId: String(post.id), category: post.categoryName }}
+                  >
                     <FeedLike
                       isLiked={post.isLiked}
                       likes={post.likes}

--- a/src/components/feed/page/FeedHomePage.tsx
+++ b/src/components/feed/page/FeedHomePage.tsx
@@ -29,10 +29,10 @@ const CommunityPage: FC = () => {
           isDetailOpen={isDetailOpen}
           listSlot={
             <FeedList
-              renderFeedDetailLink={({ children, feedId }) => (
+              renderFeedDetailLink={({ children, feedId, category }) => (
                 <ImpressionArea onImpressionStart={() => queueHit(feedId)}>
                   <LoggingImpression areaThreshold={0.5} eventKey='feedCard' param={{ feedId }}>
-                    <LoggingClick eventKey='feedCard' param={{ feedId }}>
+                    <LoggingClick eventKey='feedCard' param={{ feedId, category }}>
                       <FeedDetailLink feedId={feedId}>{children}</FeedDetailLink>
                     </LoggingClick>
                   </LoggingImpression>
@@ -70,10 +70,10 @@ const CommunityPage: FC = () => {
           isDetailOpen={isDetailOpen}
           listSlot={
             <FeedList
-              renderFeedDetailLink={({ children, feedId }) => (
+              renderFeedDetailLink={({ children, feedId, category }) => (
                 <ImpressionArea onImpressionStart={() => queueHit(feedId)}>
                   <LoggingImpression areaThreshold={0.5} eventKey='feedCard' param={{ feedId }}>
-                    <LoggingClick eventKey='feedCard' param={{ feedId }}>
+                    <LoggingClick eventKey='feedCard' param={{ feedId, category }}>
                       <Link
                         href={{
                           pathname: playgroundLink.feedDetail(feedId),

--- a/src/components/feed/page/FeedHomePage.tsx
+++ b/src/components/feed/page/FeedHomePage.tsx
@@ -31,7 +31,7 @@ const CommunityPage: FC = () => {
             <FeedList
               renderFeedDetailLink={({ children, feedId, category }) => (
                 <ImpressionArea onImpressionStart={() => queueHit(feedId)}>
-                  <LoggingImpression areaThreshold={0.5} eventKey='feedCard' param={{ feedId }}>
+                  <LoggingImpression areaThreshold={0.5} eventKey='feedCard' param={{ feedId, category }}>
                     <LoggingClick eventKey='feedCard' param={{ feedId, category }}>
                       <FeedDetailLink feedId={feedId}>{children}</FeedDetailLink>
                     </LoggingClick>
@@ -72,7 +72,7 @@ const CommunityPage: FC = () => {
             <FeedList
               renderFeedDetailLink={({ children, feedId, category }) => (
                 <ImpressionArea onImpressionStart={() => queueHit(feedId)}>
-                  <LoggingImpression areaThreshold={0.5} eventKey='feedCard' param={{ feedId }}>
+                  <LoggingImpression areaThreshold={0.5} eventKey='feedCard' param={{ feedId, category }}>
                     <LoggingClick eventKey='feedCard' param={{ feedId, category }}>
                       <Link
                         href={{

--- a/src/pages/feed/upload.tsx
+++ b/src/pages/feed/upload.tsx
@@ -8,6 +8,7 @@ import { uploadFeed } from '@/api/endpoint/feed/uploadFeed';
 import AuthRequired from '@/components/auth/AuthRequired';
 import Loading from '@/components/common/Loading';
 import useEventLogger from '@/components/eventLogger/hooks/useEventLogger';
+import { categoryIdNameMap } from '@/components/feed/common/utils';
 import FeedUploadPage, { LoadingWrapper } from '@/components/feed/page/FeedUploadPage';
 import { FeedDataType } from '@/components/feed/upload/types';
 import { setLayout } from '@/utils/layout';
@@ -26,7 +27,8 @@ const FeedUpload: FC = () => {
       { data: data, id: id },
       {
         onSuccess: async () => {
-          logSubmitEvent('submitCommunity');
+          const categoryName = data.categoryId !== null ? categoryIdNameMap[data.categoryId] : undefined;
+          logSubmitEvent('submitCommunity', { category: categoryName });
           queryClient.invalidateQueries({ queryKey: useGetPostsInfiniteQuery.getKey('') });
           await router.push(playgroundLink.feedList());
         },


### PR DESCRIPTION
### 🤫 쉿, 나한테만 말해줘요. 이슈넘버
- close #1827

### 🧐 어떤 것을 변경했어요~?
<!-- 실제로 변경한 사항을 설명해주세요.-->
- click-feedCard 이벤트에 category 이벤트 프로퍼티를 추가했어요
- impression-feedCard 이벤트에 category 이벤트 프로퍼티를 추가했어요
- click-feedLike, feedUnlike 이벤트에 category 이벤트 프로퍼티를 추가했어요
- feedDetail에서는 feedLike이벤트 로깅이 붙어있지 않았어서 디테일 페이지에서도 feedLike이벤트 로깅을 추가했어요
- submitCommunity 이벤트에 category 이벤트 프로퍼티를 추가했어요
- user property에 uploadSopticleCount, uploadReviewCount 를 추가했어요.
- major, organization, job에 한해서 타입에  `nullable`을 추가했어요! 아래 에러가 property받아올 때 해당 항목들에 nullable이 안되어 있어서 나는 에러였다,, 그래서 아마 이때까지 major, organization, job에 null이 포함된 유저는 user property가 안들어갔을 거 같아요,,
  <img width="300" alt="Screenshot 2025-04-30 at 11 44 39 PM" src="https://github.com/user-attachments/assets/00a8738d-0a37-46af-978c-fca043d88e8a" />


### 🤔 그렇다면, 어떻게 구현했어요~?
<!-- 실제로 구현한 로직에 대해 설명해주세요.-->
- ubmitCommunity 이벤트에 category 이벤트 프로퍼티를 추가하는 과정에서 categoryId로 categoryName을 가져와야 했어서 
categoryIdNameMap 객체를 추가해서 빠르게 조회하여 카테고리 이름을 가져오도록 했어요!

### ❤️‍🔥 당신이 생각하는 PR포인트, 내겐 매력포인트.
<!-- 해당 PR에서 논의가 필요한 사항을 적어주세요. -->
- 36th SP1 new Event Properties에 해당 하는 내용은 모두 해놓은 상태이고(해당 pr) 36th SP1 new User Properties와 관련해서는 슬랙에 pm님께 문의를 넣어둔 상황입니다! 채현님께서는 36th SP1 new Event에 해당하는 활동후기와 관련한 앰플리튜드 작업을 해주시면 될 것 같습니다!!
### 📸 스크린샷, 없으면 이것 참,, 섭섭한데요?
<img width="480" alt="image" src="https://github.com/user-attachments/assets/83259e8d-5c68-475c-b47f-7f7cef093a4e" />
