### PR TITLE
feat: 활동후기 업로드 로깅 추가

### DIFF
--- a/src/components/blog/Success.tsx
+++ b/src/components/blog/Success.tsx
@@ -5,6 +5,7 @@ import { m } from 'framer-motion';
 import { useRouter } from 'next/router';
 import { FC } from 'react';
 
+import { LoggingClick } from '@/components/eventLogger/components/LoggingClick';
 import { playgroundLink } from '@/constants/links';
 import { MOBILE_MEDIA_QUERY } from '@/styles/mediaQuery';
 import { textStyles } from '@/styles/typography';
@@ -22,9 +23,11 @@ const UploadSuccess: FC<UploadSuccessProps> = ({}) => {
       <SubTitle>등록한 활동후기는 SOPT 공식{'\n'}홈페이지에서 확인할 수 있어요.</SubTitle>
 
       <ButtonGroup>
-        <Button size='lg' onClick={() => window.open('https://www.sopt.org/blog', '_blank')}>
-          업로드한 활동후기 보러가기
-        </Button>
+        <LoggingClick eventKey='reviewGoToHomepage'>
+          <Button size='lg' onClick={() => window.open('https://www.sopt.org/blog', '_blank')}>
+            업로드한 활동후기 보러가기
+          </Button>
+        </LoggingClick>
         {/* TODO: 헤더 바꿀때 url이랑 함께 바꾸기 */}
         <Button size='lg' theme='black' onClick={() => router.push(playgroundLink.blog())}>
           활동후기 더 올리기

--- a/src/components/eventLogger/events.ts
+++ b/src/components/eventLogger/events.ts
@@ -193,6 +193,8 @@ export interface ClickEvents {
   timeCapsuleGotoProject: undefined;
   timeCapsuleGotoMember: undefined;
   timeCapsuleGotoCoffeechat: undefined;
+
+  reviewGoToHomepage: undefined; // 업로드한 활동후기 보러가기
 }
 
 export interface SubmitEvents {
@@ -241,8 +243,8 @@ export interface SubmitEvents {
   coffeechatDelete: undefined;
   editCoffeechat: undefined;
   coffeechatReview: undefined;
-  // 활동후기 업로드하기
-  reviewUpload: undefined;
+
+  reviewUpload: undefined; // 활동후기 업로드하기
 }
 
 export interface PageViewEvents {

--- a/src/components/eventLogger/events.ts
+++ b/src/components/eventLogger/events.ts
@@ -241,6 +241,8 @@ export interface SubmitEvents {
   coffeechatDelete: undefined;
   editCoffeechat: undefined;
   coffeechatReview: undefined;
+  // 활동후기 업로드하기
+  reviewUpload: undefined;
 }
 
 export interface PageViewEvents {

--- a/src/pages/blog/index.tsx
+++ b/src/pages/blog/index.tsx
@@ -9,6 +9,7 @@ import { useGetMemberOfMe } from '@/api/endpoint/members/getMemberOfMe';
 import { postReview, RequestBody } from '@/api/endpoint/review/postReview';
 import AuthRequired from '@/components/auth/AuthRequired';
 import UploadBlog from '@/components/blog/UploadBlog';
+import useEventLogger from '@/components/eventLogger/hooks/useEventLogger';
 import { playgroundLink } from '@/constants/links';
 import { MOBILE_MEDIA_QUERY } from '@/styles/mediaQuery';
 import { setLayout } from '@/utils/layout';
@@ -16,6 +17,7 @@ import { setLayout } from '@/utils/layout';
 const BlogPage: FC = () => {
   const router = useRouter();
   const { data } = useGetMemberOfMe();
+  const { logSubmitEvent } = useEventLogger();
   const { mutate, status, error } = useMutation({
     mutationFn: async (requestBody: RequestBody) => {
       if (!data) {
@@ -27,6 +29,7 @@ const BlogPage: FC = () => {
       return postReview.request(requestBody);
     },
     onSuccess() {
+      logSubmitEvent('reviewUpload');
       router.push(playgroundLink.blogSuccess());
     },
   });


### PR DESCRIPTION
### 🤫 쉿, 나한테만 말해줘요. 이슈넘버
- close #1831

### 🧐 어떤 것을 변경했어요~?
<!-- 실제로 변경한 사항을 설명해주세요.-->
활동후기 업로드를 할 때, submit에 `reviewUpload`로 로깅 추가했습니다.
활동후기 보러가기를 클릭할 때, `reviewGoToHomepage`로 로깅 추가했습니다. 
### 🤔 그렇다면, 어떻게 구현했어요~?
<!-- 실제로 구현한 로직에 대해 설명해주세요.-->

### ❤️‍🔥 당신이 생각하는 PR포인트, 내겐 매력포인트.
<!-- 해당 PR에서 논의가 필요한 사항을 적어주세요. -->
활동후기 업로드 페이지로 이동할 때 로깅을 추가해야 하는데,
헤더에 로깅이 들어가서 헤더 PR에 함께 추가하든,
헤더를 배포하고 다시 추가하는 방법을 선택해야 할 것 같습니다.
헤더를 기다리고 여기서 다시 작업하면 작업이 밀릴 것 같은데
헤더 PR에 로깅도 같이 올리고 이 PR을 머지해도 괜찮을까요??

### 📸 스크린샷, 없으면 이것 참,, 섭섭한데요?
![image](https://github.com/user-attachments/assets/cfe68866-877e-4a5a-ae04-58d9c7bb067e)
![image](https://github.com/user-attachments/assets/69c2c22c-5170-4ce4-8867-d584257175b3)
