### PR TITLE
fix: 솝티클 수정로직 변경

### DIFF
--- a/src/components/feed/page/FeedUploadPage.tsx
+++ b/src/components/feed/page/FeedUploadPage.tsx
@@ -25,7 +25,7 @@ import LinkInput from '@/components/feed/upload/Input/LinkInput';
 import TitleInput from '@/components/feed/upload/Input/TitleInput';
 import DesktopFeedUploadLayout from '@/components/feed/upload/layout/DesktopFeedUploadLayout';
 import MobileFeedUploadLayout from '@/components/feed/upload/layout/MobileFeedUploadLayout';
-import { FeedDataType } from '@/components/feed/upload/types';
+import { PostedFeedDataType } from '@/components/feed/upload/types';
 import UsingRules from '@/components/feed/upload/UsingRules';
 import useImageUploader from '@/hooks/useImageUploader';
 import BackArrow from '@/public/icons/icon_chevron_left.svg';
@@ -34,8 +34,8 @@ import { textStyles } from '@/styles/typography';
 
 interface FeedUploadPageProp {
   editingId?: number;
-  defaultValue: FeedDataType;
-  onSubmit: ({ data, id }: { data: FeedDataType; id: number | null }) => void;
+  defaultValue: PostedFeedDataType;
+  onSubmit: ({ data, id }: { data: PostedFeedDataType; id: number | null }) => void;
 }
 
 export default function FeedUploadPage({ defaultValue, editingId, onSubmit }: FeedUploadPageProp) {
@@ -51,8 +51,8 @@ export default function FeedUploadPage({ defaultValue, editingId, onSubmit }: Fe
     removeImage,
     handleSaveTitle,
     handleSaveContent,
-    resetFeedData,
     checkReadyToUpload,
+    handleSaveSopticleUrl,
   } = useUploadFeedData(defaultValue);
 
   const mobileContentsRef = useRef<HTMLTextAreaElement>(null);
@@ -88,7 +88,7 @@ export default function FeedUploadPage({ defaultValue, editingId, onSubmit }: Fe
   const handleSubmit = (e: FormEvent<HTMLFormElement>) => {
     e.preventDefault();
 
-    if (isSopticle && !validateLink(feedData.content)) {
+    if (isSopticle && !validateLink(feedData.sopticleUrl)) {
       return;
     }
 
@@ -100,6 +100,7 @@ export default function FeedUploadPage({ defaultValue, editingId, onSubmit }: Fe
         isQuestion: feedData.isQuestion,
         isBlindWriter: feedData.isBlindWriter,
         images: feedData.images,
+        sopticleUrl: feedData.sopticleUrl,
       },
       id: editingId ?? null,
     });
@@ -186,10 +187,10 @@ export default function FeedUploadPage({ defaultValue, editingId, onSubmit }: Fe
                 <InputWrapper>
                   <LinkInput
                     onChange={(e) => {
-                      handleSaveContent(e);
+                      handleSaveSopticleUrl(e);
                       resetLinkError();
                     }}
-                    value={feedData.content}
+                    value={feedData.sopticleUrl}
                     isError={isLinkError}
                   />
                   <Callout type='information' hasIcon>
@@ -316,10 +317,10 @@ export default function FeedUploadPage({ defaultValue, editingId, onSubmit }: Fe
                   <InputWrapper>
                     <LinkInput
                       onChange={(e) => {
-                        handleSaveContent(e);
+                        handleSaveSopticleUrl(e);
                         resetLinkError();
                       }}
-                      value={feedData.content}
+                      value={feedData.sopticleUrl}
                       isError={isLinkError}
                     />
                     <CalloutWrapper>

--- a/src/components/feed/page/FeedUploadPage.tsx
+++ b/src/components/feed/page/FeedUploadPage.tsx
@@ -88,7 +88,7 @@ export default function FeedUploadPage({ defaultValue, editingId, onSubmit }: Fe
   const handleSubmit = (e: FormEvent<HTMLFormElement>) => {
     e.preventDefault();
 
-    if (isSopticle && !validateLink(feedData.sopticleUrl)) {
+    if (isSopticle && !validateLink(feedData.link)) {
       return;
     }
 
@@ -100,7 +100,7 @@ export default function FeedUploadPage({ defaultValue, editingId, onSubmit }: Fe
         isQuestion: feedData.isQuestion,
         isBlindWriter: feedData.isBlindWriter,
         images: feedData.images,
-        sopticleUrl: feedData.sopticleUrl,
+        link: feedData.link,
       },
       id: editingId ?? null,
     });
@@ -190,7 +190,7 @@ export default function FeedUploadPage({ defaultValue, editingId, onSubmit }: Fe
                       handleSaveSopticleUrl(e);
                       resetLinkError();
                     }}
-                    value={feedData.sopticleUrl}
+                    value={feedData.link}
                     isError={isLinkError}
                   />
                   <Callout type='information' hasIcon>
@@ -320,7 +320,7 @@ export default function FeedUploadPage({ defaultValue, editingId, onSubmit }: Fe
                         handleSaveSopticleUrl(e);
                         resetLinkError();
                       }}
-                      value={feedData.sopticleUrl}
+                      value={feedData.link}
                       isError={isLinkError}
                     />
                     <CalloutWrapper>

--- a/src/components/feed/upload/Input/LinkInput/index.tsx
+++ b/src/components/feed/upload/Input/LinkInput/index.tsx
@@ -4,7 +4,7 @@ import { ChangeEvent, KeyboardEvent } from 'react';
 
 interface LinkInputProps {
   onChange: (e: ChangeEvent<HTMLInputElement> | ChangeEvent<HTMLTextAreaElement>) => void;
-  value: string;
+  value: string | null;
   isError: boolean;
 }
 

--- a/src/components/feed/upload/hooks/useUploadFeedData.ts
+++ b/src/components/feed/upload/hooks/useUploadFeedData.ts
@@ -27,7 +27,7 @@ export default function useUploadFeedData(defaultValue: PostedFeedDataType) {
       ...feedData,
       categoryId,
       ...(isSopticle // / 솝티클이면 content와 title 초기화
-        ? { content: '', title: '' }
+        ? { content: 'content', title: '' }
         : {}),
     }));
   };

--- a/src/components/feed/upload/hooks/useUploadFeedData.ts
+++ b/src/components/feed/upload/hooks/useUploadFeedData.ts
@@ -53,7 +53,7 @@ export default function useUploadFeedData(defaultValue: PostedFeedDataType) {
   };
 
   const handleSaveSopticleUrl = (e: React.ChangeEvent<HTMLInputElement> | React.ChangeEvent<HTMLTextAreaElement>) => {
-    setFeedData((feedData) => ({ ...feedData, sopticleUrl: e.target.value }));
+    setFeedData((feedData) => ({ ...feedData, link: e.target.value }));
   };
 
   const saveImageUrls = (urls: string[]) => {
@@ -68,7 +68,7 @@ export default function useUploadFeedData(defaultValue: PostedFeedDataType) {
   const checkReadyToUpload = () => {
     return (
       (feedData.categoryId !== null && feedData.content.trim()) ||
-      (feedData.categoryId === SOPTICLE_CATEGORY_ID && feedData.sopticleUrl?.trim())
+      (feedData.categoryId === SOPTICLE_CATEGORY_ID && feedData.link?.trim())
     );
   };
 

--- a/src/components/feed/upload/hooks/useUploadFeedData.ts
+++ b/src/components/feed/upload/hooks/useUploadFeedData.ts
@@ -2,9 +2,10 @@ import { useState } from 'react';
 
 import useBlindWriterPromise from '@/components/feed/common/hooks/useBlindWriterPromise';
 import useCategory from '@/components/feed/common/hooks/useCategory';
-import { FeedDataType } from '@/components/feed/upload/types';
+import { SOPTICLE_CATEGORY_ID } from '@/components/feed/constants';
+import { PostedFeedDataType } from '@/components/feed/upload/types';
 
-export default function useUploadFeedData(defaultValue: FeedDataType) {
+export default function useUploadFeedData(defaultValue: PostedFeedDataType) {
   const [feedData, setFeedData] = useState(defaultValue);
   const { handleShowBlindWriterPromise } = useBlindWriterPromise();
   const { findParentCategory } = useCategory();
@@ -18,9 +19,17 @@ export default function useUploadFeedData(defaultValue: FeedDataType) {
   };
 
   const handleSaveCategory = (categoryId: number) => {
+    const isSopticle = findParentCategory(categoryId)?.id === SOPTICLE_CATEGORY_ID;
+
     resetIsBlindWriter(categoryId);
     resetIsQuestion(categoryId);
-    setFeedData((feedData) => ({ ...feedData, categoryId: categoryId }));
+    setFeedData((feedData) => ({
+      ...feedData,
+      categoryId,
+      ...(isSopticle // / 솝티클이면 content와 title 초기화
+        ? { content: '', title: '' }
+        : {}),
+    }));
   };
 
   const handleSaveIsQuestion = (isQuestion: boolean) => {
@@ -43,6 +52,10 @@ export default function useUploadFeedData(defaultValue: FeedDataType) {
     setFeedData((feedData) => ({ ...feedData, content: e.target.value }));
   };
 
+  const handleSaveSopticleUrl = (e: React.ChangeEvent<HTMLInputElement> | React.ChangeEvent<HTMLTextAreaElement>) => {
+    setFeedData((feedData) => ({ ...feedData, sopticleUrl: e.target.value }));
+  };
+
   const saveImageUrls = (urls: string[]) => {
     setFeedData((feedData) => ({ ...feedData, images: [...feedData.images, ...urls] }));
   };
@@ -53,7 +66,10 @@ export default function useUploadFeedData(defaultValue: FeedDataType) {
   };
 
   const checkReadyToUpload = () => {
-    return feedData.categoryId !== null && feedData.content.trim();
+    return (
+      (feedData.categoryId !== null && feedData.content.trim()) ||
+      (feedData.categoryId === SOPTICLE_CATEGORY_ID && feedData.sopticleUrl?.trim())
+    );
   };
 
   const resetFeedData = () => {
@@ -72,5 +88,6 @@ export default function useUploadFeedData(defaultValue: FeedDataType) {
     resetFeedData,
     checkReadyToUpload,
     findParentCategory,
+    handleSaveSopticleUrl,
   };
 }

--- a/src/components/feed/upload/types.ts
+++ b/src/components/feed/upload/types.ts
@@ -8,7 +8,7 @@ export interface FeedDataType {
 }
 
 export interface PostedFeedDataType extends FeedDataType {
-  id: number;
+  sopticleUrl: string | null;
 }
 
 export interface EditFeedDataType extends FeedDataType {

--- a/src/components/feed/upload/types.ts
+++ b/src/components/feed/upload/types.ts
@@ -8,7 +8,7 @@ export interface FeedDataType {
 }
 
 export interface PostedFeedDataType extends FeedDataType {
-  sopticleUrl: string | null;
+  link: string | null;
 }
 
 export interface EditFeedDataType extends FeedDataType {

--- a/src/pages/feed/edit/[id].tsx
+++ b/src/pages/feed/edit/[id].tsx
@@ -74,6 +74,7 @@ const FeedEdit: FC = () => {
                   isQuestion: data.posts.isQuestion,
                   isBlindWriter: data.posts.isBlindWriter,
                   images: data.posts.images,
+                  sopticleUrl: data.posts.sopticleUrl,
                 }}
                 onSubmit={handleEditSubmit}
                 editingId={data.posts.id}

--- a/src/pages/feed/edit/[id].tsx
+++ b/src/pages/feed/edit/[id].tsx
@@ -74,7 +74,7 @@ const FeedEdit: FC = () => {
                   isQuestion: data.posts.isQuestion,
                   isBlindWriter: data.posts.isBlindWriter,
                   images: data.posts.images,
-                  sopticleUrl: data.posts.sopticleUrl,
+                  link: data.posts.sopticleUrl,
                 }}
                 onSubmit={handleEditSubmit}
                 editingId={data.posts.id}

--- a/src/pages/feed/upload.tsx
+++ b/src/pages/feed/upload.tsx
@@ -9,7 +9,7 @@ import AuthRequired from '@/components/auth/AuthRequired';
 import Loading from '@/components/common/Loading';
 import useEventLogger from '@/components/eventLogger/hooks/useEventLogger';
 import FeedUploadPage, { LoadingWrapper } from '@/components/feed/page/FeedUploadPage';
-import { FeedDataType } from '@/components/feed/upload/types';
+import { PostedFeedDataType } from '@/components/feed/upload/types';
 import { setLayout } from '@/utils/layout';
 
 const FeedUpload: FC = () => {
@@ -18,10 +18,11 @@ const FeedUpload: FC = () => {
   const queryClient = useQueryClient();
 
   const { mutate, isPending } = useMutation({
-    mutationFn: (reqeustBody: { data: FeedDataType; id: number | null }) => uploadFeed.request({ ...reqeustBody.data }),
+    mutationFn: (reqeustBody: { data: PostedFeedDataType; id: number | null }) =>
+      uploadFeed.request({ ...reqeustBody.data }),
   });
 
-  const handlUploadSubmit = ({ data, id }: { data: FeedDataType; id: number | null }) => {
+  const handlUploadSubmit = ({ data, id }: { data: PostedFeedDataType; id: number | null }) => {
     mutate(
       { data: data, id: id },
       {
@@ -52,6 +53,7 @@ const FeedUpload: FC = () => {
           isQuestion: false,
           isBlindWriter: false,
           images: [],
+          sopticleUrl: null,
         }}
         onSubmit={handlUploadSubmit}
       />

--- a/src/pages/feed/upload.tsx
+++ b/src/pages/feed/upload.tsx
@@ -53,7 +53,7 @@ const FeedUpload: FC = () => {
           isQuestion: false,
           isBlindWriter: false,
           images: [],
-          sopticleUrl: null,
+          link: null,
         }}
         onSubmit={handlUploadSubmit}
       />


### PR DESCRIPTION
### 🤫 쉿, 나한테만 말해줘요. 이슈넘버
- close #1833

### 🧐 어떤 것을 변경했어요~?
<!-- 실제로 변경한 사항을 설명해주세요.-->
- 솝티클 생성 및 수정 로직 요청에 link 필드를 추가했어요.

### 🤔 그렇다면, 어떻게 구현했어요~?
<!-- 실제로 구현한 로직에 대해 설명해주세요.-->
- 기존에는 솝티클을 생성하거나 수정할 때 content 필드에 url을 담아 보내면 백엔드에서 해당 url을 크롤링해 title과 content를 채우고, sopticleUrl이라는 필드를 추가해 응답해주는 구조였어요.
하지만 이 구조에서는 게시글을 수정할 때 원래의 url이 아닌 크롤링된 content 값이 content 필드에 채워져 있어 사용자가 실제 url을 확인하거나 수정하는 데 어려움이 발생했고, 결국 수정 시에는 다시 URL을 별도로 감지해서 content에 넣어 보내야 하는 불편함이 있었어요.
이 문제를 해결하기 위해, 백엔드에 요청드려 솝티클 생성 및 수정 시 url을 명확히 전달할 수 있도록 link 필드를 별도로 추가하는 방향으로 구조를 개선했어요!


### ❤️‍🔥 당신이 생각하는 PR포인트, 내겐 매력포인트.
<!-- 해당 PR에서 논의가 필요한 사항을 적어주세요. -->
- 백엔드에서 content가 비워져 있을경우 에러메세지를 보내서 
```
 ...(isSopticle // / 솝티클이면 content와 title 초기화
        ? { content: 'content', title: '' }
        : {}),

```
이와 같이 카테고리가 sopticle일 경우  content: 'content'를 넣는 방식으로 처리를 해두었어요.

### 📸 스크린샷, 없으면 이것 참,, 섭섭한데요?
