### PR TITLE
fix: 모바일 프로필 수정 input 디자인 오류 해결

### DIFF
--- a/src/components/members/upload/FormSection/Basic/index.tsx
+++ b/src/components/members/upload/FormSection/Basic/index.tsx
@@ -135,11 +135,7 @@ export default function MemberBasicFormSection() {
           title='활동 지역'
           description={`가까운 지하철역을 작성해주세요. \n활동 지역이 여러개일 경우 쉼표(,)로 구분해서 적어주세요.`}
         >
-          <StyledTextField
-            {...register('address')}
-            placeholder='ex) 광나루역, 서울역, 홍대입구역'
-            style={{ marginTop: '4px' }}
-          />
+          <StyledTextField {...register('address')} placeholder='ex) 광나루역, 서울역, 홍대입구역' />
         </FormItem>
         <Responsive only='desktop'>
           <EducationInputWrapper>
@@ -227,6 +223,11 @@ const StyledImageUploader = styled(ImageUploader)`
 const StyledTextField = styled(TextField)`
   margin-top: 12px;
   width: 441px;
+  height: 48px;
+
+  & input {
+    height: 100%;
+  }
 
   @media ${MOBILE_MEDIA_QUERY} {
     margin-top: 10px;

--- a/src/components/members/upload/FormSection/Career.tsx
+++ b/src/components/members/upload/FormSection/Career.tsx
@@ -118,11 +118,14 @@ export default function CareerFormSection({ header }: CareerFormSectionProps) {
               >
                 <CareerItemWrapper>
                   <CareerInputWrapper>
-                    <TextField
+                    <StyledTextField
                       {...register(`careers.${index}.companyName`)}
                       placeholder='회사 입력 ex. 토스, 네이버, 당근, 쿠팡'
                     />
-                    <TextField {...register(`careers.${index}.title`)} placeholder='직무 입력 ex. 프로덕트 디자이너' />
+                    <StyledTextField
+                      {...register(`careers.${index}.title`)}
+                      placeholder='직무 입력 ex. 프로덕트 디자이너'
+                    />
                   </CareerInputWrapper>
                   <CareerDetail>
                     <IsCurrent>
@@ -215,7 +218,7 @@ export default function CareerFormSection({ header }: CareerFormSectionProps) {
                       </>
                     )}
                   />
-                  <TextField
+                  <StyledTextField
                     {...register(`links.${index}.url`)}
                     isError={errors?.links?.[index]?.hasOwnProperty('url')}
                     placeholder='https://'
@@ -304,7 +307,7 @@ const CareerDescription = styled(Text)`
 
 const SkillDescription = styled(Text)`
   display: block;
-  margin-top: 10px;
+  margin: 10px 0 12px;
   white-space: pre-line;
   color: ${colors.gray300};
 
@@ -332,8 +335,13 @@ const EndDateWrapper = styled.div`
 `;
 
 const StyledTextField = styled(TextField)`
-  margin-top: 12px;
-  width: 632px;
+  width: 100%;
+  max-width: 632px;
+  height: 48px;
+
+  & input {
+    height: 100%;
+  }
 
   @media ${MOBILE_MEDIA_QUERY} {
     margin-top: 10px;


### PR DESCRIPTION
### 🤫 쉿, 나한테만 말해줘요. 이슈넘버
- close #1843

### 🧐 어떤 것을 변경했어요~?
<!-- 실제로 변경한 사항을 설명해주세요.-->
- 아래와 같이 기존에 모바일 환경에서 input이 뚱뚱해지는 현상을 수정했어요.
<img width="557" alt="image" src="https://github.com/user-attachments/assets/6f0c8842-97bd-4d15-b015-400dbc557f04" />

### 🤔 그렇다면, 어떻게 구현했어요~?
<!-- 실제로 구현한 로직에 대해 설명해주세요.-->
- mds를 사용하고 있어서 이와 mds와 관련한 문제인 것 처럼 보이는데 TextField를 감싸는 스타일에 height를 지정하고 선택자를 통해서 input의 height를 100%로 해주니 해결되어서 이와 같은 방식으로 해결했어요

### ❤️‍🔥 당신이 생각하는 PR포인트, 내겐 매력포인트.
<!-- 해당 PR에서 논의가 필요한 사항을 적어주세요. -->

### 📸 스크린샷, 없으면 이것 참,, 섭섭한데요?
<img width="449" alt="image" src="https://github.com/user-attachments/assets/d69b26aa-56a1-4695-9b54-4588f54fa694" />
<img width="448" alt="image" src="https://github.com/user-attachments/assets/8c81ac03-78b5-45a8-8e84-2835450525b2" />


