### PR TITLE
feat: 커뮤니티 홈 인기글 컴포넌트 구현

### DIFF
--- a/src/api/endpoint/feed/getPopularPost.ts
+++ b/src/api/endpoint/feed/getPopularPost.ts
@@ -1,0 +1,33 @@
+import { useQuery } from '@tanstack/react-query';
+import { z } from 'zod';
+
+import { createEndpoint } from '@/api/typedAxios';
+
+const PopularPostSchema = z.array(
+  z.object({
+    id: z.number(),
+    category: z.string(),
+    title: z.string(),
+    member: z.object({
+      id: z.number(),
+      name: z.string(),
+      profileImage: z.string().nullable(),
+    }),
+    hits: z.number(),
+  }),
+);
+
+export const getPopularPost = createEndpoint({
+  request: () => ({
+    method: 'GET',
+    url: `api/v1/community/posts/popular`,
+  }),
+  serverResponseScheme: PopularPostSchema,
+});
+
+export const useGetPopularPost = () => {
+  return useQuery({
+    queryKey: getPopularPost.cacheKey(),
+    queryFn: () => getPopularPost.request(),
+  });
+};

--- a/src/components/feed/home/PopularCard/PopularCard.stories.tsx
+++ b/src/components/feed/home/PopularCard/PopularCard.stories.tsx
@@ -1,0 +1,19 @@
+import type { ComponentMeta, ComponentStory } from '@storybook/react';
+
+import PopularCard from './PopularCard';
+
+export default {
+  component: PopularCard,
+} as ComponentMeta<typeof PopularCard>;
+
+const Template: ComponentStory<typeof PopularCard> = (args) => <PopularCard {...args} />;
+
+export const Default = Template.bind({});
+Default.args = {
+  rank: 1,
+  category: '자유',
+  title: '여기는 제목입니다',
+  profileImage: 'https://avatars.githubusercontent.com/u/90364711?v=4',
+  name: '김솝트',
+  hits: 432,
+};

--- a/src/components/feed/home/PopularCard/PopularCard.tsx
+++ b/src/components/feed/home/PopularCard/PopularCard.tsx
@@ -20,6 +20,7 @@ interface PopularCardProps {
     };
   };
   isLoading?: boolean;
+  onClick?: () => void;
 }
 
 interface FeedInfoProps {
@@ -57,14 +58,14 @@ const PopularSkeleton = ({ rank }: { rank: number }) => {
   );
 };
 
-const PopularCard = ({ rank, card, isLoading }: PopularCardProps) => {
+const PopularCard = ({ rank, card, isLoading, onClick }: PopularCardProps) => {
   if (isLoading || !card) return <PopularSkeleton rank={rank} />;
 
   const { category, title, hits, member } = card;
   const { name, profileImage } = member;
 
   return (
-    <PopularCardWrapper>
+    <PopularCardWrapper onClick={onClick} role='button'>
       <Text typography='SUIT_18_SB' color={colors.white} lineHeight={24} style={{ width: '16px' }}>
         {rank}
       </Text>
@@ -102,10 +103,16 @@ const PopularCardWrapper = styled.li`
   gap: 12px;
   align-items: center;
   justify-content: space-between;
+  transition: background 0.2s ease;
   border-radius: 12px;
   background: ${colors.gray900};
+  cursor: pointer;
   padding: 16px;
   width: 100%;
+
+  &:hover {
+    background: ${colors.gray800};
+  }
 `;
 
 const FeedInfo = styled.div<FeedInfoProps>`

--- a/src/components/feed/home/PopularCard/PopularCard.tsx
+++ b/src/components/feed/home/PopularCard/PopularCard.tsx
@@ -3,17 +3,23 @@ import { MOBILE_MEDIA_QUERY } from '@/styles/mediaQuery';
 import styled from '@emotion/styled';
 import { colors } from '@sopt-makers/colors';
 import { IconEye } from '@sopt-makers/icons';
-import { Tag } from '@sopt-makers/ui';
+import { Skeleton, Tag } from '@sopt-makers/ui';
 import ResizedImage from '@/components/common/ResizedImage';
 import { IconMember } from '@/components/feed/common/Icon';
 
 interface PopularCardProps {
   rank: number;
-  category: string;
-  title: string;
-  profileImage: string | null;
-  name: string;
-  hits: number;
+  card?: {
+    id: number;
+    category: string;
+    title: string;
+    hits: number;
+    member: {
+      name: string;
+      profileImage: string | null;
+    };
+  };
+  isLoading?: boolean;
 }
 
 interface FeedInfoProps {
@@ -21,7 +27,42 @@ interface FeedInfoProps {
   authorBox?: boolean;
 }
 
-const PopularCard = ({ rank, category, title, profileImage, name, hits }: PopularCardProps) => {
+const PopularSkeleton = ({ rank }: { rank: number }) => {
+  return (
+    <PopularCardWrapper>
+      <Text typography='SUIT_18_SB' color={colors.white} lineHeight={24} style={{ width: '16px' }}>
+        {rank}
+      </Text>
+      <FeedInfo titleBox>
+        <Category>
+          <Skeleton width={20} height={14} color={colors.gray700} />
+        </Category>
+        <TitleText typography='SUIT_14_SB' color={colors.white} lineHeight={18}>
+          <Skeleton width={300} height={18} color={colors.gray700} />
+        </TitleText>
+      </FeedInfo>
+      <FeedInfo authorBox>
+        <IconMember size={20} />
+        <Text typography='SUIT_14_SB' color={colors.gray50} lineHeight={18}>
+          <Skeleton width={40} height={18} color={colors.gray700} />
+        </Text>
+      </FeedInfo>
+      <HitsInfo>
+        <HitsIcon />
+        <Text typography='SUIT_14_SB' color={colors.gray400} lineHeight={18}>
+          <Skeleton width={25} height={18} color={colors.gray700} />
+        </Text>
+      </HitsInfo>
+    </PopularCardWrapper>
+  );
+};
+
+const PopularCard = ({ rank, card, isLoading }: PopularCardProps) => {
+  if (isLoading || !card) return <PopularSkeleton rank={rank} />;
+
+  const { category, title, hits, member } = card;
+  const { name, profileImage } = member;
+
   return (
     <PopularCardWrapper>
       <Text typography='SUIT_18_SB' color={colors.white} lineHeight={24} style={{ width: '16px' }}>

--- a/src/components/feed/home/PopularCard/PopularCard.tsx
+++ b/src/components/feed/home/PopularCard/PopularCard.tsx
@@ -1,0 +1,118 @@
+import Text from '@/components/common/Text';
+import { MOBILE_MEDIA_QUERY } from '@/styles/mediaQuery';
+import styled from '@emotion/styled';
+import { colors } from '@sopt-makers/colors';
+import { IconEye } from '@sopt-makers/icons';
+import { Tag } from '@sopt-makers/ui';
+
+interface PopularCardProps {
+  rank: number;
+  category: string;
+  title: string;
+  profileImage: string;
+  name: string;
+  hits: number;
+}
+
+interface FeedInfoProps {
+  titleBox?: boolean;
+  authorBox?: boolean;
+}
+
+const PopularCard = ({ rank, category, title, profileImage, name, hits }: PopularCardProps) => {
+  return (
+    <PopularCardWrapper>
+      <Text typography='SUIT_18_SB' color={colors.white} lineHeight={24} style={{ width: '16px' }}>
+        {rank}
+      </Text>
+      <FeedInfo titleBox>
+        <Category>{category}</Category>
+        <TitleText typography='SUIT_14_SB' color={colors.white} lineHeight={18}>
+          {title}
+        </TitleText>
+      </FeedInfo>
+      <FeedInfo authorBox>
+        <img src={profileImage} alt={name} />
+        <Text typography='SUIT_14_SB' color={colors.gray50} lineHeight={18}>
+          {name}
+        </Text>
+      </FeedInfo>
+      <HitsInfo>
+        <HitsIcon />
+        <Text typography='SUIT_14_SB' color={colors.gray400} lineHeight={18}>
+          {hits}
+        </Text>
+      </HitsInfo>
+    </PopularCardWrapper>
+  );
+};
+
+export default PopularCard;
+
+const PopularCardWrapper = styled.div`
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  align-items: center;
+  justify-content: space-between;
+  border-radius: 12px;
+  background: ${colors.gray900};
+  padding: 16px;
+  width: 100%;
+`;
+
+const FeedInfo = styled.div<FeedInfoProps>`
+  display: flex;
+  gap: 8px;
+  align-items: center;
+  min-width: 0;
+
+  ${({ titleBox }) =>
+    titleBox &&
+    `      
+    flex: 1;
+
+    @media ${MOBILE_MEDIA_QUERY} {
+      flex-basis: calc(100% - 16px - 12px);
+    }
+  `}
+
+  ${({ authorBox }) =>
+    authorBox &&
+    `
+    width: 128px;
+    flex-shrink: 0;
+  `}
+
+  img {
+    border-radius: 50%;
+    width: 20px;
+    height: 20px;
+  }
+`;
+
+const Category = styled(Tag)`
+  flex-shrink: 0;
+  width: fit-content;
+`;
+
+const TitleText = styled(Text)`
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+`;
+
+const HitsInfo = styled.div`
+  display: flex;
+  gap: 4px;
+  align-items: center;
+  width: fit-content;
+  min-width: 42px;
+  color: ${colors.gray400};
+`;
+
+const HitsIcon = styled(IconEye)`
+  flex-shrink: 0;
+  width: 16px;
+  height: 16px;
+`;

--- a/src/components/feed/home/PopularCard/PopularCard.tsx
+++ b/src/components/feed/home/PopularCard/PopularCard.tsx
@@ -4,12 +4,14 @@ import styled from '@emotion/styled';
 import { colors } from '@sopt-makers/colors';
 import { IconEye } from '@sopt-makers/icons';
 import { Tag } from '@sopt-makers/ui';
+import ResizedImage from '@/components/common/ResizedImage';
+import { IconMember } from '@/components/feed/common/Icon';
 
 interface PopularCardProps {
   rank: number;
   category: string;
   title: string;
-  profileImage: string;
+  profileImage: string | null;
   name: string;
   hits: number;
 }
@@ -32,7 +34,11 @@ const PopularCard = ({ rank, category, title, profileImage, name, hits }: Popula
         </TitleText>
       </FeedInfo>
       <FeedInfo authorBox>
-        <img src={profileImage} alt={name} />
+        {profileImage ? (
+          <ProfileImage width={20} height={20} src={profileImage} alt={name} />
+        ) : (
+          <IconMember size={20} />
+        )}
         <Text typography='SUIT_14_SB' color={colors.gray50} lineHeight={18}>
           {name}
         </Text>
@@ -49,7 +55,7 @@ const PopularCard = ({ rank, category, title, profileImage, name, hits }: Popula
 
 export default PopularCard;
 
-const PopularCardWrapper = styled.div`
+const PopularCardWrapper = styled.li`
   display: flex;
   flex-wrap: wrap;
   gap: 12px;
@@ -83,12 +89,12 @@ const FeedInfo = styled.div<FeedInfoProps>`
     width: 128px;
     flex-shrink: 0;
   `}
+`;
 
-  img {
-    border-radius: 50%;
-    width: 20px;
-    height: 20px;
-  }
+const ProfileImage = styled(ResizedImage)`
+  border-radius: 50%;
+  width: 20px;
+  height: 20px;
 `;
 
 const Category = styled(Tag)`

--- a/src/components/feed/home/PopularCard/PopularCardList.stories.tsx
+++ b/src/components/feed/home/PopularCard/PopularCardList.stories.tsx
@@ -1,0 +1,12 @@
+import type { ComponentMeta, ComponentStory } from '@storybook/react';
+
+import PopularCardList from './PopularCardList';
+
+export default {
+  component: PopularCardList,
+} as ComponentMeta<typeof PopularCardList>;
+
+const Template: ComponentStory<typeof PopularCardList> = (args) => <PopularCardList />;
+
+export const Default = Template.bind({});
+Default.args = {};

--- a/src/components/feed/home/PopularCard/PopularCardList.tsx
+++ b/src/components/feed/home/PopularCard/PopularCardList.tsx
@@ -4,9 +4,15 @@ import PopularCard from '@/components/feed/home/PopularCard/PopularCard';
 import { MB_SM_MEDIA_QUERY } from '@/styles/mediaQuery';
 import styled from '@emotion/styled';
 import { colors } from '@sopt-makers/colors';
+import { useRouter } from 'next/router';
 
 const PopularCardList = () => {
   const { data, isLoading, isError } = useGetPopularPost();
+  const router = useRouter();
+
+  const handleClickPopular = (id: number) => {
+    router.push(`/?feed=${id}`);
+  };
 
   return (
     <>
@@ -34,7 +40,7 @@ const PopularCardList = () => {
             <PopularCard key={`skeleton-${index}`} rank={index + 1} isLoading />
           ))}
         {data?.map((card, index) => (
-          <PopularCard key={card.id} rank={index + 1} card={card} />
+          <PopularCard key={card.id} rank={index + 1} card={card} onClick={() => handleClickPopular(card.id)} />
         ))}
       </ContentWrapper>
     </>

--- a/src/components/feed/home/PopularCard/PopularCardList.tsx
+++ b/src/components/feed/home/PopularCard/PopularCardList.tsx
@@ -1,48 +1,13 @@
+import { useGetPopularPost } from '@/api/endpoint/feed/getPopularPost';
 import Text from '@/components/common/Text';
 import PopularCard from '@/components/feed/home/PopularCard/PopularCard';
 import { MB_SM_MEDIA_QUERY } from '@/styles/mediaQuery';
 import styled from '@emotion/styled';
 import { colors } from '@sopt-makers/colors';
 
-const cardList = [
-  {
-    id: 358,
-    category: '솝티클',
-    title:
-      'feat: sp1관련 앰플리튜드 로깅 추가 by seong-hui · Pull Request #1830 · sopt-makers/sopt-playground-frontend',
-    member: {
-      id: 225,
-      name: '문성희',
-      profileImage: null,
-    },
-    hits: 244,
-  },
-  {
-    id: 363,
-    category: '자유',
-    title: 'asdf',
-    member: {
-      id: 221,
-      name: '임주민',
-      profileImage:
-        'https://s3.ap-northeast-2.amazonaws.com/sopt-makers-internal//dev/image/project/3468b344-631c-4492-b342-33538acac173-131675243_1285425091826888_4352205340244382184_n.jpg',
-    },
-    hits: 241,
-  },
-  {
-    id: 378,
-    category: '질문',
-    title: 'asdf',
-    member: {
-      id: 225,
-      name: '문성희',
-      profileImage: null,
-    },
-    hits: 236,
-  },
-];
-
 const PopularCardList = () => {
+  const { data, isLoading, isError } = useGetPopularPost();
+
   return (
     <>
       <TitleWrapper>
@@ -54,7 +19,7 @@ const PopularCardList = () => {
         </Text>
       </TitleWrapper>
       <ContentWrapper>
-        {cardList.map((card, index) => (
+        {data?.map((card, index) => (
           <PopularCard
             key={card.id}
             rank={index + 1}

--- a/src/components/feed/home/PopularCard/PopularCardList.tsx
+++ b/src/components/feed/home/PopularCard/PopularCardList.tsx
@@ -1,0 +1,90 @@
+import Text from '@/components/common/Text';
+import PopularCard from '@/components/feed/home/PopularCard/PopularCard';
+import { MB_SM_MEDIA_QUERY } from '@/styles/mediaQuery';
+import styled from '@emotion/styled';
+import { colors } from '@sopt-makers/colors';
+
+const cardList = [
+  {
+    id: 358,
+    category: '솝티클',
+    title:
+      'feat: sp1관련 앰플리튜드 로깅 추가 by seong-hui · Pull Request #1830 · sopt-makers/sopt-playground-frontend',
+    member: {
+      id: 225,
+      name: '문성희',
+      profileImage: null,
+    },
+    hits: 244,
+  },
+  {
+    id: 363,
+    category: '자유',
+    title: 'asdf',
+    member: {
+      id: 221,
+      name: '임주민',
+      profileImage:
+        'https://s3.ap-northeast-2.amazonaws.com/sopt-makers-internal//dev/image/project/3468b344-631c-4492-b342-33538acac173-131675243_1285425091826888_4352205340244382184_n.jpg',
+    },
+    hits: 241,
+  },
+  {
+    id: 378,
+    category: '질문',
+    title: 'asdf',
+    member: {
+      id: 225,
+      name: '문성희',
+      profileImage: null,
+    },
+    hits: 236,
+  },
+];
+
+const PopularCardList = () => {
+  return (
+    <>
+      <TitleWrapper>
+        <Text typography='SUIT_18_B' color={colors.white} lineHeight={28}>
+          실시간 인기글 🚀
+        </Text>
+        <Text typography='SUIT_12_SB' color={colors.gray400} lineHeight={16}>
+          이번 주 동안 가장 많은 솝트인이 봤어요!
+        </Text>
+      </TitleWrapper>
+      <ContentWrapper>
+        {cardList.map((card, index) => (
+          <PopularCard
+            key={card.id}
+            rank={index + 1}
+            category={card.category}
+            title={card.title}
+            profileImage={card.member.profileImage}
+            name={card.member.name}
+            hits={card.hits}
+          />
+        ))}
+      </ContentWrapper>
+    </>
+  );
+};
+
+export default PopularCardList;
+
+const TitleWrapper = styled.h1`
+  display: flex;
+  gap: 8px;
+  align-items: center;
+  margin-bottom: 16px;
+
+  @media ${MB_SM_MEDIA_QUERY} {
+    flex-direction: column;
+  }
+`;
+
+const ContentWrapper = styled.ul`
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+`;

--- a/src/components/feed/home/PopularCard/PopularCardList.tsx
+++ b/src/components/feed/home/PopularCard/PopularCardList.tsx
@@ -19,16 +19,22 @@ const PopularCardList = () => {
         </Text>
       </TitleWrapper>
       <ContentWrapper>
+        {isError && (
+          <Text
+            typography='SUIT_14_M'
+            color={colors.gray300}
+            lineHeight={16}
+            style={{ textAlign: 'center', padding: '80px' }}
+          >
+            인기글을 보여주는데 문제가 발생했어요.
+          </Text>
+        )}
+        {isLoading &&
+          Array.from({ length: 3 }).map((_, index) => (
+            <PopularCard key={`skeleton-${index}`} rank={index + 1} isLoading />
+          ))}
         {data?.map((card, index) => (
-          <PopularCard
-            key={card.id}
-            rank={index + 1}
-            category={card.category}
-            title={card.title}
-            profileImage={card.member.profileImage}
-            name={card.member.name}
-            hits={card.hits}
-          />
+          <PopularCard key={card.id} rank={index + 1} card={card} />
         ))}
       </ContentWrapper>
     </>

--- a/src/pages/popular/index.tsx
+++ b/src/pages/popular/index.tsx
@@ -1,0 +1,8 @@
+import PopularCardList from '@/components/feed/home/PopularCard/PopularCardList';
+
+// TODO: 페이지 합치면 삭제
+const Popular = () => {
+  return <PopularCardList />;
+};
+
+export default Popular;


### PR DESCRIPTION
### 🤫 쉿, 나한테만 말해줘요. 이슈넘버
- close #1846 

### 🧐 어떤 것을 변경했어요~?
<!-- 실제로 변경한 사항을 설명해주세요.-->
- 커뮤니티 홈에 들어가는 인기글 컴포넌트를 제작했습니다.
- api 연결까지 완료했습니다.
- /popular에서 테스트용으로 볼 수 있도록 했습니다. 머지하기 전에 지우겠습니다.

### 🤔 그렇다면, 어떻게 구현했어요~?
<!-- 실제로 구현한 로직에 대해 설명해주세요.-->
- 이전 코드랑 코드 방식 맞춰서 작성했습니다. 스켈레톤도 이전 코드랑 맞춰서 isLoading으로 분기처리로 보여주었습니다.
- 반응형의 경우 2줄과 1줄을 조정해야 했는데 타이틀박스가 차지하는 공간을 기준으로 조정했습니다.

### ❤️‍🔥 당신이 생각하는 PR포인트, 내겐 매력포인트.
<!-- 해당 PR에서 논의가 필요한 사항을 적어주세요. -->
- 서버로 받아오는 응답 중에 title이랑 member의 경우 변경될 가능성이 있어서 이 부분은 추후에 다시 반영하고 머지하겠습니다!
- 현재 title이 없는 글들은 빈 문자열로 받아오고 있고, 곧 변경될 예정입니다.
- 쿼리키가 상당히 찝찝하긴 하네요.... 저번에도 이야기 나왔던 것처럼 이 부분 날잡고 바꿔보면 좋을 것 같습니다!!

### 📸 스크린샷, 없으면 이것 참,, 섭섭한데요?
