### PR TITLE
fix: 프로젝트 팀원 정보 사용 로직 변경

### DIFF
--- a/src/api/endpoint_LEGACY/projects/type.ts
+++ b/src/api/endpoint_LEGACY/projects/type.ts
@@ -31,7 +31,8 @@ export type ProjectDetail = {
     memberDescription: string;
     isTeamMember: boolean;
     memberName: string;
-    memberGeneration: number;
+    memberGenerations: number[];
+    memberProfileImage: string;
     memberHasProfile?: boolean;
   }[];
   links: {

--- a/src/components/projects/main/ProjectDetail.tsx
+++ b/src/components/projects/main/ProjectDetail.tsx
@@ -9,7 +9,6 @@ import { useGetMemberOfMe } from '@/api/endpoint/members/getMemberOfMe';
 import { deleteProject } from '@/api/endpoint_LEGACY/projects';
 import useConfirm from '@/components/common/Modal/useConfirm';
 import MemberBlock from '@/components/members/common/MemberBlock';
-import WithMemberMetadata from '@/components/members/common/WithMemberMetadata';
 import { getLinkInfo } from '@/components/projects/constants';
 import { MemberRoleInfo } from '@/components/projects/constants';
 import ProjectImageSlider from '@/components/projects/main/ProjectImageSlider';
@@ -138,30 +137,23 @@ const ProjectDetail: FC<ProjectDetailProps> = ({ projectId }) => {
           </UserInfoWrapper>
           <UserList>
             <UserNameList>
-              {sortedMembers.map((member) => (
-                <WithMemberMetadata
-                  key={member.memberId}
-                  memberId={member.memberId}
-                  render={(metadata) => {
-                    const badges = [];
-                    if (metadata && metadata.generations.length > 0) {
-                      badges.push(metadata.generations.map(String).join(', ') + '기');
-                    }
-                    const memberBlock = (
-                      <MemberBlock
-                        name={member.memberName}
-                        position={MemberRoleInfo[member.memberRole]}
-                        imageUrl={metadata?.profileImage}
-                        badges={badges}
-                      />
-                    );
-                    if (member.memberHasProfile) {
-                      return <Link href={playgroundLink.memberDetail(member.memberId)}>{memberBlock}</Link>;
-                    }
-                    return memberBlock;
-                  }}
-                />
-              ))}
+              {sortedMembers.map((member) => {
+                const badges = [];
+                if (member.memberGenerations.length > 0) {
+                  badges.push(member.memberGenerations.map(String).join(', ') + '기');
+                }
+
+                return (
+                  <Link key={member.memberId} href={playgroundLink.memberDetail(member.memberId)}>
+                    <MemberBlock
+                      name={member.memberName}
+                      position={MemberRoleInfo[member.memberRole]}
+                      imageUrl={member.memberProfileImage}
+                      badges={badges ?? []}
+                    />
+                  </Link>
+                );
+              })}
             </UserNameList>
           </UserList>
         </UserWrapper>


### PR DESCRIPTION
### 🤫 쉿, 나한테만 말해줘요. 이슈넘버
- close #1862

### 🧐 어떤 것을 변경했어요~?
<!-- 실제로 변경한 사항을 설명해주세요.-->
프로젝트의 팀원 정보를 가져오는 방식을 변경했어요.
모든 회원정보를 가지고 와서 메타데이터를 만드는 것이 아닌,
프로젝트 상세 정보 내부에 있는 회원 정보를 사용하는 것으로 변경했어요.

### 🤔 그렇다면, 어떻게 구현했어요~?
<!-- 실제로 구현한 로직에 대해 설명해주세요.-->

### ❤️‍🔥 당신이 생각하는 PR포인트, 내겐 매력포인트.
<!-- 해당 PR에서 논의가 필요한 사항을 적어주세요. -->

### 📸 스크린샷, 없으면 이것 참,, 섭섭한데요?
