### PR TITLE
fix: 파트톡, 홍보 카테고리의 좋아요 이슈

### DIFF
--- a/src/components/feed/common/utils.ts
+++ b/src/components/feed/common/utils.ts
@@ -91,3 +91,11 @@ export const categoryIdNameMap: Record<number, string> = {
   21: '솝티클',
   22: '질문',
 };
+
+export const getParentCategoryId = (
+  categoryData: { id: number; children: { id: number }[] }[] | undefined,
+  categoryId: number,
+): number | '' => {
+  // 자식이 없으면 ''을 부모로
+  return categoryData?.find((cat) => cat.children.some((child) => child.id === categoryId))?.id ?? '';
+};

--- a/src/components/feed/list/FeedListItems.tsx
+++ b/src/components/feed/list/FeedListItems.tsx
@@ -21,7 +21,7 @@ import { useDeleteFeed } from '@/components/feed/common/hooks/useDeleteFeed';
 import { useReportFeed } from '@/components/feed/common/hooks/useReportFeed';
 import { useShareFeed } from '@/components/feed/common/hooks/useShareFeed';
 import { useToggleLike } from '@/components/feed/common/hooks/useToggleLike';
-import { CategoryList, getMemberInfo } from '@/components/feed/common/utils';
+import { getMemberInfo, getParentCategoryId } from '@/components/feed/common/utils';
 import { QUESTION_CATEGORY_ID, SOPTICLE_CATEGORY_ID } from '@/components/feed/constants';
 import FeedCard from '@/components/feed/list/FeedCard';
 import FeedSkeleton from '@/components/feed/list/FeedSkeleton';
@@ -238,11 +238,13 @@ const FeedListItems: FC<FeedListItemsProps> = ({ categoryId, renderFeedDetailLin
                       onClick={(e) => {
                         e.stopPropagation();
                         e.preventDefault();
+                        const parentId = getParentCategoryId(categoryData, post.categoryId);
+
                         handleToggleLike({
                           postId: post.id,
                           isLiked: post.isLiked,
                           likes: post.likes,
-                          allPostsQueryKey: useGetPostsInfiniteQuery.getKey(''),
+                          allPostsQueryKey: useGetPostsInfiniteQuery.getKey(parentId.toString()),
                           postsQueryKey: useGetPostsInfiniteQuery.getKey(post.categoryId.toString()),
                           postQueryKey: getPost.cacheKey(post.id.toString()),
                           waitingQuestionQuerykey: getWaitingQuestions.cacheKey(),


### PR DESCRIPTION
### 🤫 쉿, 나한테만 말해줘요. 이슈넘버
- close #1876

### 🧐 어떤 것을 변경했어요~?
<!-- 실제로 변경한 사항을 설명해주세요.-->
- 파트talk, 홍보 카테고리에 한해서는 상세 카테고리가 존재해서 전체 카테고리가 존재했어요. 그런데 해당 전체 카테고리에 한해서만 좋아요를 눌러도 좋아요가 바로 반영되지 않는 문제(낙관적 업데이트 문제)를 해결했어요
  ![image](https://github.com/user-attachments/assets/c75b594e-3f3b-4ffa-a63b-e426333b73c0)


### 🤔 그렇다면, 어떻게 구현했어요~?
<!-- 실제로 구현한 로직에 대해 설명해주세요.-->
- 기존 로직에서는 allPostsQueryKey: useGetPostsInfiniteQuery.getKey('')처럼 전체 포스트의 쿼리키를 빈 문자열로 설정했어요.
그래서 ['posts', '']라는 쿼리Key만 낙관적으로 업데이트되고 있었어요. 하지만 자식 카테고리에 속한 게시글은, 실제로 부모 카테고리 ID를 기준으로 쿼리Key가 캐싱되기 때문에 ['posts', '']로는 해당 데이터를 찾아 업데이트할 수 없어 좋아요 상태가 반영되지 않았습니다.
- 이 문제를 해결하기 위해 getParentCategoryId 함수를 만들어 자식 카테고리는 부모 ID를, 자식이 없는 경우는 빈 문자열을 반환하도록 하고 allPostsQueryKey를 실제 캐싱된 쿼리Key와 일치하도록 수정했어요. 그 결과 낙관적 업데이트가 정상적으로 작동하게 되었습니다.

### ❤️‍🔥 당신이 생각하는 PR포인트, 내겐 매력포인트.
<!-- 해당 PR에서 논의가 필요한 사항을 적어주세요. -->

### 📸 스크린샷, 없으면 이것 참,, 섭섭한데요?
