### PR TITLE
feat: 투표 수정 막기 로직 구현

### DIFF
--- a/src/api/endpoint/feed/postVote.ts
+++ b/src/api/endpoint/feed/postVote.ts
@@ -13,10 +13,10 @@ const OptionSchema = z.object({
 });
 
 export const postVote = createEndpoint({
-  request: (postId: number, reqeustBody: z.infer<typeof OptionSchema>) => ({
+  request: (postId: number, requestBody: z.infer<typeof OptionSchema>) => ({
     method: 'POST',
     url: `api/v1/community/posts/${postId}/vote`,
-    data: reqeustBody,
+    data: requestBody,
   }),
   serverResponseScheme: z.record(z.boolean()),
 });

--- a/src/api/endpoint/feed/postVote.ts
+++ b/src/api/endpoint/feed/postVote.ts
@@ -1,15 +1,32 @@
-import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { InfiniteData, useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { z } from 'zod';
 
-import { useGetPostsInfiniteQuery } from '@/api/endpoint/feed/getPosts';
+import { PostsType, useGetPostsInfiniteQuery } from '@/api/endpoint/feed/getPosts';
 import { getWaitingQuestions } from '@/api/endpoint/feed/getWaitingQuestions';
 import { createEndpoint } from '@/api/typedAxios';
-import { getPost } from '@/api/endpoint/feed/getPost';
+import { getPost, PostType } from '@/api/endpoint/feed/getPost';
 import { getParentCategoryId } from '@/components/feed/common/utils';
 import { getCategory } from '@/api/endpoint/feed/getCategory';
+import { produce } from 'immer';
 
 const OptionSchema = z.object({
   selectedOptions: z.array(z.number().int()).min(1).max(5),
+});
+
+const VoteResponseSchema = z.object({
+  id: z.number(),
+  isMultiple: z.boolean(),
+  hasVoted: z.boolean(),
+  totalParticipants: z.number(),
+  options: z.array(
+    z.object({
+      id: z.number(),
+      content: z.string(),
+      voteCount: z.number(),
+      votePercent: z.number(),
+      isSelected: z.boolean(),
+    }),
+  ),
 });
 
 export const postVote = createEndpoint({
@@ -18,7 +35,7 @@ export const postVote = createEndpoint({
     url: `api/v1/community/posts/${postId}/vote`,
     data: requestBody,
   }),
-  serverResponseScheme: z.record(z.boolean()),
+  serverResponseScheme: VoteResponseSchema,
 });
 
 export const usePostVoteMutation = (
@@ -38,11 +55,31 @@ export const usePostVoteMutation = (
 
   return useMutation({
     mutationFn: (requestBody: z.infer<typeof OptionSchema>) => postVote.request(postId, requestBody),
-    onSuccess: () => {
+    onSuccess: (data: z.infer<typeof VoteResponseSchema>) => {
       options?.onSuccess?.();
-      queryClient.refetchQueries({ queryKey: getPost.cacheKey(String(postId)) });
-      queryClient.refetchQueries({ queryKey: useGetPostsInfiniteQuery.getKey(parentCategoryId?.toString()) });
-      queryClient.refetchQueries({ queryKey: getWaitingQuestions.cacheKey() });
+      queryClient.setQueryData(getPost.cacheKey(String(postId)), (oldData: PostType) => {
+        return produce(oldData, (draft) => {
+          if (draft && draft.posts) {
+            draft.posts.vote = data;
+          }
+        });
+      });
+      queryClient.setQueryData(
+        useGetPostsInfiniteQuery.getKey(parentCategoryId?.toString()),
+        (oldData: InfiniteData<PostsType>) => {
+          return produce(oldData, (draft) => {
+            if (draft && draft.pages) {
+              draft.pages.forEach((page) => {
+                const post = page.posts.find((p) => p.id === postId);
+                if (post) {
+                  post.vote = data;
+                }
+              });
+            }
+          });
+        },
+      );
+      queryClient.invalidateQueries({ queryKey: getWaitingQuestions.cacheKey() });
     },
   });
 };

--- a/src/api/endpoint/feed/postVote.ts
+++ b/src/api/endpoint/feed/postVote.ts
@@ -38,13 +38,7 @@ export const postVote = createEndpoint({
   serverResponseScheme: VoteResponseSchema,
 });
 
-export const usePostVoteMutation = (
-  postId: number,
-  categoryId: number,
-  options?: {
-    onSuccess?: () => void;
-  },
-) => {
+export const usePostVoteMutation = (postId: number, categoryId: number) => {
   const queryClient = useQueryClient();
 
   const { data: categoryData } = useQuery({
@@ -56,7 +50,6 @@ export const usePostVoteMutation = (
   return useMutation({
     mutationFn: (requestBody: z.infer<typeof OptionSchema>) => postVote.request(postId, requestBody),
     onSuccess: (data: z.infer<typeof VoteResponseSchema>) => {
-      options?.onSuccess?.();
       queryClient.setQueryData(getPost.cacheKey(String(postId)), (oldData: PostType) => {
         return produce(oldData, (draft) => {
           if (draft && draft.posts) {

--- a/src/api/endpoint/feed/postVote.ts
+++ b/src/api/endpoint/feed/postVote.ts
@@ -34,13 +34,12 @@ export const usePostVoteMutation = (
     queryKey: getCategory.cacheKey(),
     queryFn: getCategory.request,
   });
-  const parentCategoryId = getParentCategoryId(categoryData, categoryId);
+  const parentCategoryId = getParentCategoryId(categoryData, categoryId) || categoryId;
 
   return useMutation({
     mutationFn: (requestBody: z.infer<typeof OptionSchema>) => postVote.request(postId, requestBody),
     onSuccess: () => {
       options?.onSuccess?.();
-      console.log(useGetPostsInfiniteQuery.getKey(parentCategoryId?.toString()));
       queryClient.refetchQueries({ queryKey: getPost.cacheKey(String(postId)) });
       queryClient.refetchQueries({ queryKey: useGetPostsInfiniteQuery.getKey(parentCategoryId?.toString()) });
       queryClient.refetchQueries({ queryKey: getWaitingQuestions.cacheKey() });

--- a/src/components/feed/common/hooks/useDeleteFeed.ts
+++ b/src/components/feed/common/hooks/useDeleteFeed.ts
@@ -8,6 +8,7 @@ import { useGetPostsInfiniteQuery } from '@/api/endpoint/feed/getPosts';
 import useConfirm from '@/components/common/Modal/useConfirm';
 import useToast from '@/components/common/Toast/useToast';
 import { useCategoryParam } from '@/components/feed/common/queryParam';
+import { zIndex } from '@/styles/zIndex';
 
 interface Options {
   postId: string;
@@ -31,6 +32,7 @@ export const useDeleteFeed = () => {
       okButtonText: '삭제하기',
       cancelButtonText: '취소',
       maxWidth: 324,
+      zIndex: zIndex.헤더,
     });
 
     if (result) {

--- a/src/components/feed/detail/DetailFeedCard.tsx
+++ b/src/components/feed/detail/DetailFeedCard.tsx
@@ -238,7 +238,7 @@ const Name = styled(Text)`
   }
 `;
 
-interface Vote {
+interface VoteData {
   id: number;
   isMultiple: boolean;
   hasVoted: boolean;
@@ -264,7 +264,7 @@ interface ContentProps {
   sopticleUrl: string;
   thumbnailUrl: string;
   isMine: boolean;
-  vote: Vote | null;
+  vote: VoteData | null;
   postId: number;
   categoryId: number;
 }

--- a/src/components/feed/list/FeedList.tsx
+++ b/src/components/feed/list/FeedList.tsx
@@ -101,7 +101,7 @@ const Container = styled.div`
 const CategoryArea = styled.div`
   position: sticky;
   top: ${layoutCSSVariable.globalHeaderHeight};
-  z-index: 1; /* Virtuoso가 sticky 위에 와버리는 문제때문에 z-index로 제어 */
+  z-index: 2; /* Virtuoso가 sticky 위에 와버리는 문제때문에 z-index로 제어 */
   border-radius: 14px 14px 0 0;
   background-color: ${colors.background};
 `;

--- a/src/components/feed/page/FeedUploadPage.tsx
+++ b/src/components/feed/page/FeedUploadPage.tsx
@@ -204,6 +204,7 @@ export default function FeedUploadPage({ defaultValue, editingId, onSubmit }: Fe
                   resetVote={resetVote}
                   optionsLength={feedData.vote.voteOptions.length}
                   isMultiple={feedData.vote.isMultiple}
+                  isDisable={isEdit}
                 />
               )}
               <TagAndCheckboxWrapper>
@@ -214,7 +215,7 @@ export default function FeedUploadPage({ defaultValue, editingId, onSubmit }: Fe
                       onClick={handleDesktopClickImageInput}
                       imageInputRef={desktopRef}
                     />
-                    <VoteUploadButton onClick={onOpenVoteModal} isDisabled={!hasVoteOptions} />
+                    <VoteUploadButton onClick={onOpenVoteModal} isDisabled={!!hasVoteOptions} />
                     <VoteModal
                       isOpen={isOpenVoteModal}
                       onClose={onCloseVoteModal}
@@ -300,6 +301,7 @@ export default function FeedUploadPage({ defaultValue, editingId, onSubmit }: Fe
                   resetVote={resetVote}
                   optionsLength={feedData.vote.voteOptions.length}
                   isMultiple={feedData.vote.isMultiple}
+                  isDisable={isEdit}
                 />
               )}
               <TagAndCheckboxWrapper>

--- a/src/components/feed/upload/votePreview/index.stories.tsx
+++ b/src/components/feed/upload/votePreview/index.stories.tsx
@@ -29,6 +29,7 @@ export const Default: Story = {
         }}
         optionsLength={3}
         isMultiple={true}
+        isDisable={false}
       />
     );
   },

--- a/src/components/feed/upload/votePreview/index.tsx
+++ b/src/components/feed/upload/votePreview/index.tsx
@@ -13,9 +13,10 @@ interface VotePreviewProps {
   resetVote: () => void;
   optionsLength: number;
   isMultiple: boolean;
+  isDisable: boolean;
 }
 
-const VotePreview = ({ onOpenVoteModal, resetVote, optionsLength, isMultiple }: VotePreviewProps) => {
+const VotePreview = ({ onOpenVoteModal, resetVote, optionsLength, isMultiple, isDisable }: VotePreviewProps) => {
   const selectionGuideText = isMultiple ? '복수 선택 가능' : '1개 선택 가능';
 
   const { openDialog, closeDialog } = useContext(DialogContext);
@@ -41,42 +42,44 @@ const VotePreview = ({ onOpenVoteModal, resetVote, optionsLength, isMultiple }: 
     <StyledVotePreview>
       <PreviewBox>
         <Flex>
-          <StyledIconCheckSquare />
+          <StyledIconCheckSquare color={isDisable ? colors.gray300 : colors.gray10} />
           <StyledContent>
-            <Text typography='SUIT_14_SB' color={colors.gray10}>
+            <Text typography='SUIT_14_SB' color={isDisable ? colors.gray300 : colors.gray10}>
               투표
             </Text>
-            <Text typography='SUIT_13_M' color={colors.gray100}>
+            <Text typography='SUIT_13_M' color={isDisable ? colors.gray400 : colors.gray100}>
               응답 {optionsLength}개, {selectionGuideText}
             </Text>
           </StyledContent>
         </Flex>
-        <FeedDropdown
-          trigger={
-            <button css={{ height: '20px' }}>
-              <StyledIconDotsVertical />
-            </button>
-          }
-        >
-          <FeedDropdown.Item
-            onClick={() => {
-              setTimeout(() => {
-                onOpenVoteModal();
-              }, 0);
-            }}
+        {!isDisable && (
+          <FeedDropdown
+            trigger={
+              <button css={{ height: '20px' }}>
+                <StyledIconDotsVertical />
+              </button>
+            }
           >
-            <Flex align='center' css={{ gap: '10px', color: `${colors.gray10}` }}>
-              <IconWrite css={{ width: '16px', height: '16px' }} />
-              수정
-            </Flex>
-          </FeedDropdown.Item>
-          <FeedDropdown.Item type='danger' onClick={() => setTimeout(() => handleDeleteClick(), 0)}>
-            <Flex align='center' css={{ gap: '10px' }}>
-              <IconTrash css={{ width: '16px', height: '16px' }} />
-              삭제
-            </Flex>
-          </FeedDropdown.Item>
-        </FeedDropdown>
+            <FeedDropdown.Item
+              onClick={() => {
+                setTimeout(() => {
+                  onOpenVoteModal();
+                }, 0);
+              }}
+            >
+              <Flex align='center' css={{ gap: '10px', color: `${colors.gray10}` }}>
+                <IconWrite css={{ width: '16px', height: '16px' }} />
+                수정
+              </Flex>
+            </FeedDropdown.Item>
+            <FeedDropdown.Item type='danger' onClick={() => setTimeout(() => handleDeleteClick(), 0)}>
+              <Flex align='center' css={{ gap: '10px' }}>
+                <IconTrash css={{ width: '16px', height: '16px' }} />
+                삭제
+              </Flex>
+            </FeedDropdown.Item>
+          </FeedDropdown>
+        )}
       </PreviewBox>
 
       <AlertBox>

--- a/src/components/feed/upload/votePreview/index.tsx
+++ b/src/components/feed/upload/votePreview/index.tsx
@@ -48,7 +48,7 @@ const VotePreview = ({ onOpenVoteModal, resetVote, optionsLength, isMultiple, is
               투표
             </Text>
             <Text typography='SUIT_13_M' color={isDisable ? colors.gray400 : colors.gray100}>
-              응답 {optionsLength}개, {selectionGuideText}
+              {optionsLength}개 항목, {selectionGuideText}
             </Text>
           </StyledContent>
         </Flex>

--- a/src/components/vote/RadioBox.tsx
+++ b/src/components/vote/RadioBox.tsx
@@ -34,10 +34,10 @@ const RadioBox = ({
       </Text>
       {isResult && (
         <>
+          <Bar votePercent={votePercent} isWinner={isWinner} />
           <VoteResult isWinner={isWinner}>
             {votePercent}% ({voteCount}표)
           </VoteResult>
-          <Bar votePercent={votePercent} isWinner={isWinner} />
         </>
       )}
     </Container>
@@ -72,6 +72,7 @@ const Container = styled.div<{ mode: 'select' | 'view'; isSelected: boolean }>`
 `;
 
 const CheckedIcon = styled(IconCheck)`
+  z-index: 1;
   width: 16px;
   height: 16px;
   color: ${colors.secondary};
@@ -80,6 +81,7 @@ const CheckedIcon = styled(IconCheck)`
 const VoteResult = styled.span<{ isWinner: boolean }>`
   position: absolute;
   right: 12px;
+  z-index: 1;
   color: ${({ isWinner }) => (isWinner ? colors.secondary : colors.gray100)};
   font: ${fonts.BODY_13_M};
 `;
@@ -97,7 +99,6 @@ const Bar = styled.div<{ votePercent: number; isWinner: boolean }>`
   position: absolute;
   top: 0;
   left: 0;
-  z-index: 0;
   background-color: ${({ isWinner }) => (isWinner ? colors.orangeAlpha300 : colors.gray700)};
   height: 100%;
   animation: ${({ votePercent }) => createWidthAnimation(votePercent)} 0.8s ease-out forwards;

--- a/src/components/vote/RadioBox.tsx
+++ b/src/components/vote/RadioBox.tsx
@@ -72,7 +72,6 @@ const Container = styled.div<{ mode: 'select' | 'view'; isSelected: boolean }>`
 `;
 
 const CheckedIcon = styled(IconCheck)`
-  z-index: 1;
   width: 16px;
   height: 16px;
   color: ${colors.secondary};
@@ -81,7 +80,6 @@ const CheckedIcon = styled(IconCheck)`
 const VoteResult = styled.span<{ isWinner: boolean }>`
   position: absolute;
   right: 12px;
-  z-index: 1;
   color: ${({ isWinner }) => (isWinner ? colors.secondary : colors.gray100)};
   font: ${fonts.BODY_13_M};
 `;

--- a/src/components/vote/index.tsx
+++ b/src/components/vote/index.tsx
@@ -94,7 +94,7 @@ const Vote = ({ postId, categoryId, isMine, hasVoted, options, isMultiple, total
               투표하기
             </Button>
           )}
-          {isMine && !isResult && (
+          {isMine && !hasVoted && (
             <Button
               size='sm'
               theme='black'

--- a/src/components/vote/index.tsx
+++ b/src/components/vote/index.tsx
@@ -1,11 +1,15 @@
+import { getCategory } from '@/api/endpoint/feed/getCategory';
+import { useGetPostsInfiniteQuery } from '@/api/endpoint/feed/getPosts';
 import { usePostVoteMutation } from '@/api/endpoint/feed/postVote';
 import Text from '@/components/common/Text';
+import { getParentCategoryId } from '@/components/feed/common/utils';
 import RadioBox from '@/components/vote/RadioBox';
 import styled from '@emotion/styled';
 import { colors } from '@sopt-makers/colors';
 import { fonts } from '@sopt-makers/fonts';
 import { IconCheckSquare } from '@sopt-makers/icons';
 import { Button } from '@sopt-makers/ui';
+import { useQuery } from '@tanstack/react-query';
 import { useEffect, useState } from 'react';
 
 type VoteOption = {
@@ -32,11 +36,11 @@ const Vote = ({ postId, categoryId, isMine, hasVoted, options, isMultiple, total
   const [selectedIds, setSelectedIds] = useState<number[]>([]);
 
   const maxVoteCount = Math.max(...options.map((o) => o.voteCount));
+
   const { mutate: vote } = usePostVoteMutation(postId, categoryId, {
     onSuccess: () => {
       setIsResult(true);
       setMode('view');
-      setSelectedIds([]);
     },
   });
 
@@ -48,6 +52,11 @@ const Vote = ({ postId, categoryId, isMine, hasVoted, options, isMultiple, total
       setSelectedIds([id]);
     }
   };
+
+  useEffect(() => {
+    setIsResult(hasVoted);
+    setMode(hasVoted ? 'view' : 'select');
+  }, [hasVoted]);
 
   return (
     <Container>
@@ -85,7 +94,7 @@ const Vote = ({ postId, categoryId, isMine, hasVoted, options, isMultiple, total
               투표하기
             </Button>
           )}
-          {isMine && !hasVoted && (
+          {isMine && !isResult && (
             <Button
               size='sm'
               theme='black'

--- a/src/components/vote/index.tsx
+++ b/src/components/vote/index.tsx
@@ -37,12 +37,7 @@ const Vote = ({ postId, categoryId, isMine, hasVoted, options, isMultiple, total
 
   const maxVoteCount = Math.max(...options.map((o) => o.voteCount));
 
-  const { mutate: vote } = usePostVoteMutation(postId, categoryId, {
-    onSuccess: () => {
-      setIsResult(true);
-      setMode('view');
-    },
-  });
+  const { mutate: vote } = usePostVoteMutation(postId, categoryId);
 
   const toggleOption = (id: number) => {
     if (mode !== 'select') return;
@@ -56,6 +51,7 @@ const Vote = ({ postId, categoryId, isMine, hasVoted, options, isMultiple, total
   useEffect(() => {
     setIsResult(hasVoted);
     setMode(hasVoted ? 'view' : 'select');
+    setSelectedIds([]);
   }, [hasVoted]);
 
   return (

--- a/src/pages/feed/edit/[id].tsx
+++ b/src/pages/feed/edit/[id].tsx
@@ -47,8 +47,8 @@ const FeedEdit: FC = () => {
   const voteForForm = useMemo(() => {
     if (!data) return null;
 
-    const vpteData = data.posts.vote;
-    return vpteData ? { isMultiple: vpteData.isMultiple, voteOptions: vpteData.options.map((o) => o.content) } : null;
+    const voteData = data.posts.vote;
+    return voteData ? { isMultiple: voteData.isMultiple, voteOptions: voteData.options.map((o) => o.content) } : null;
   }, [data]);
 
   if (isPending) {

--- a/src/pages/feed/edit/[id].tsx
+++ b/src/pages/feed/edit/[id].tsx
@@ -1,7 +1,7 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { useRouter } from 'next/router';
 import { playgroundLink } from 'playground-common/export';
-import { FC } from 'react';
+import { FC, useMemo } from 'react';
 
 import { editFeed } from '@/api/endpoint/feed/editFeed';
 import { getPost, useGetPostQuery } from '@/api/endpoint/feed/getPost';
@@ -44,6 +44,13 @@ const FeedEdit: FC = () => {
     );
   };
 
+  const voteForForm = useMemo(() => {
+    if (!data) return null;
+
+    const vpteData = data.posts.vote;
+    return vpteData ? { isMultiple: vpteData.isMultiple, voteOptions: vpteData.options.map((o) => o.content) } : null;
+  }, [data]);
+
   if (isPending) {
     return (
       <LoadingWrapper>
@@ -75,8 +82,7 @@ const FeedEdit: FC = () => {
                   isBlindWriter: data.posts.isBlindWriter,
                   images: data.posts.images,
                   link: data.posts.sopticleUrl,
-                  // TODO get으로 vote정보 받아오면 그걸로 수정하기
-                  vote: null,
+                  vote: voteForForm,
                 }}
                 onSubmit={handleEditSubmit}
                 editingId={data.posts.id}


### PR DESCRIPTION
### 🤫 쉿, 나한테만 말해줘요. 이슈넘버
- close #1882

### 🧐 어떤 것을 변경했어요~?
<!-- 실제로 변경한 사항을 설명해주세요.-->
- 게시글을 수정하는 경우에는 투표항목을 수정할 수 없도록 처리했어요

### 🤔 그렇다면, 어떻게 구현했어요~?
<!-- 실제로 구현한 로직에 대해 설명해주세요.-->
- get으로 받아오는 투표정보와 post를 위해 필요한 투표정보가 달라서 게시글 수정할 때 데이터 형태를 변환해서 전달했어요
- 데이터가 바뀔때만 계산하도록 useMemo로 만들었어요
```tsx
  const voteForForm = useMemo(() => {
    if (!data) return null;

    const voteData = data.posts.vote;
    return voteData ? { isMultiple: voteData.isMultiple, voteOptions: voteData.options.map((o) => o.content) } : null;
  }, [data]);
```
- 업로드화면에서 isEdit일 경우 투표 Preview폼을 disable처리 했어요

### ❤️‍🔥 당신이 생각하는 PR포인트, 내겐 매력포인트.
<!-- 해당 PR에서 논의가 필요한 사항을 적어주세요. -->

### 📸 스크린샷, 없으면 이것 참,, 섭섭한데요?
![image](https://github.com/user-attachments/assets/5024d7f6-8ab9-4430-b3e8-eabae2086591)
