### PR TITLE
fix: 게시글 생성 시 익명 상태 관리 수정

### DIFF
--- a/src/components/feed/upload/hooks/useUploadFeedData.ts
+++ b/src/components/feed/upload/hooks/useUploadFeedData.ts
@@ -21,10 +21,11 @@ export default function useUploadFeedData(defaultValue: PostedFeedDataType) {
   };
 
   const handleSaveCategory = (categoryId: number) => {
-    const isSopticle = findParentCategory(categoryId)?.id === SOPTICLE_CATEGORY_ID;
-    const isPrevSopticle = !isSopticle && feedData.content === 'content' && feedData.title === '';
-    const isQuestion = findParentCategory(categoryId)?.id === QUESTION_CATEGORY_ID;
     const parentCategory = findParentCategory(categoryId);
+    const isSopticle = parentCategory?.id === SOPTICLE_CATEGORY_ID;
+    const isQuestion = parentCategory?.id === QUESTION_CATEGORY_ID;
+    const hasBlind = parentCategory?.hasBlind ?? false;
+    const isPrevSopticle = !isSopticle && feedData.content === 'content' && feedData.title === '';
 
     setFeedData((feedData) => ({
       ...feedData,
@@ -33,7 +34,7 @@ export default function useUploadFeedData(defaultValue: PostedFeedDataType) {
         ? { content: 'content', title: '' }
         : isPrevSopticle && { content: '' }), // 이전 카테고리가 솝티클이었으면 content 다시 초기화
       isQuestion, // 질문 카테고리 여부에 따라 isQuestion 초기화
-      isBlindWriter: parentCategory?.hasBlind ? isQuestion : false, // hasBlind가 있는 카테고리 중 질문 카테고리이면 true
+      isBlindWriter: isSopticle ? false : hasBlind && isQuestion ? true : feedData.isBlindWriter,
     }));
   };
 


### PR DESCRIPTION
### 🤫 쉿, 나한테만 말해줘요. 이슈넘버
- close #1898

### 🧐 어떤 것을 변경했어요~?
<!-- 실제로 변경한 사항을 설명해주세요.-->
- 기존에는 질문 카테고리 선택시 익명이 활성화되고 다른 카테고리 선택시 익명이 비활성화되도록 구현하였는데 기획의 요청에 의해서
익명이 한번 선택된다면 익명을 직접 해제하기 전까지 익명이 풀리지 않도록 로직을 처리했어요(솝티클 카테고리 한정 익명 비활성화)

### 🤔 그렇다면, 어떻게 구현했어요~?
<!-- 실제로 구현한 로직에 대해 설명해주세요.-->

### ❤️‍🔥 당신이 생각하는 PR포인트, 내겐 매력포인트.
<!-- 해당 PR에서 논의가 필요한 사항을 적어주세요. -->

### 📸 스크린샷, 없으면 이것 참,, 섭섭한데요?
