### PR TITLE
feat: 멘션 기능 처리 추가

### DIFF
--- a/src/components/feed/common/utils/parseMention.tsx
+++ b/src/components/feed/common/utils/parseMention.tsx
@@ -33,10 +33,9 @@ export const parseMentionsToJSX = (text: string) => {
     const [full, name, id] = match;
 
     if (match.index > lastIndex) {
-      result.push(text.slice(lastIndex, match.index));
+      result.push(text.slice(lastIndex, match.index).replace(/&nbsp;/g, ' '));
     }
 
-    // span 태그로 변경
     result.push(
       <button
         key={`${name}-${id}-${match.index}`}
@@ -53,7 +52,7 @@ export const parseMentionsToJSX = (text: string) => {
   }
 
   if (lastIndex < text.length) {
-    result.push(text.slice(lastIndex));
+    result.push(text.slice(lastIndex).replace(/&nbsp;/g, ' '));
   }
 
   return result;

--- a/src/components/feed/common/utils/parseMention.tsx
+++ b/src/components/feed/common/utils/parseMention.tsx
@@ -1,4 +1,6 @@
+import { playgroundLink } from '@/constants/links';
 import { colors } from '@sopt-makers/colors';
+import { useRouter } from 'next/router';
 
 export const mentionRegex = /@([^\[\]\s@]+)\[(\d+)\]/g;
 const mentionSpanRegex = /<span[^>]*data-id="(\d+)"[^>]*>@([^<]+)<\/span>/g;
@@ -22,6 +24,7 @@ export const parseHTMLToMentions = (html: string) => {
 };
 
 export const parseMentionsToJSX = (text: string) => {
+  const router = useRouter();
   const result: React.ReactNode[] = [];
   let lastIndex = 0;
   let match: RegExpExecArray | null;
@@ -35,9 +38,15 @@ export const parseMentionsToJSX = (text: string) => {
 
     // span 태그로 변경
     result.push(
-      <span key={`${name}-${id}-${match.index}`} data-id={id} contentEditable={false} style={{ color: colors.success }}>
+      <button
+        key={`${name}-${id}-${match.index}`}
+        data-id={id}
+        contentEditable={false}
+        style={{ color: colors.success }}
+        onClick={() => router.push(playgroundLink.memberDetail(id))}
+      >
         @{name}
-      </span>,
+      </button>,
     );
 
     lastIndex = match.index + full.length;

--- a/src/components/feed/common/utils/parseMention.tsx
+++ b/src/components/feed/common/utils/parseMention.tsx
@@ -23,8 +23,7 @@ export const parseHTMLToMentions = (html: string) => {
     .replace(/<[^>]+>/g, '');
 };
 
-export const parseMentionsToJSX = (text: string) => {
-  const router = useRouter();
+export const parseMentionsToJSX = (text: string, router: ReturnType<typeof useRouter>) => {
   const result: React.ReactNode[] = [];
   let lastIndex = 0;
   let match: RegExpExecArray | null;

--- a/src/components/feed/detail/DetailFeedCard.tsx
+++ b/src/components/feed/detail/DetailFeedCard.tsx
@@ -40,6 +40,7 @@ import {
 import useMention, { Member } from '@/components/feed/common/hooks/useMention';
 import MentionDropdown from '@/components/feed/common/MentionDropdown';
 import { useCursorPosition } from '@/components/feed/common/hooks/useCursorPosition';
+import { useRouter } from 'next/router';
 
 const Base = ({ children }: PropsWithChildren<unknown>) => {
   return <StyledBase direction='column'>{children}</StyledBase>;
@@ -292,8 +293,9 @@ const Content = ({
   categoryId,
 }: ContentProps) => {
   const [openSlider, setOpenSlider] = useState(false);
+  const router = useRouter();
 
-  const parsedMentions = parseMentionsToJSX(content);
+  const parsedMentions = parseMentionsToJSX(content, router);
   const parsedMentionsAndLinks = parsedMentions.map((fragment, index) => parseTextToLink(fragment));
 
   return (
@@ -464,7 +466,8 @@ const Comment = ({
   moreIcon,
   memberId = 0,
 }: CommentProps) => {
-  const parsedMentions = parseMentionsToJSX(comment);
+  const router = useRouter();
+  const parsedMentions = parseMentionsToJSX(comment, router);
   const parsedMentionsAndLinks = parsedMentions.map((fragment, index) => parseTextToLink(fragment));
 
   return (

--- a/src/components/feed/home/RecentArea/RecentCard.tsx
+++ b/src/components/feed/home/RecentArea/RecentCard.tsx
@@ -10,6 +10,7 @@ import { parseMentionsToJSX } from '@/components/feed/common/utils/parseMention'
 import { QUESTION_CATEGORY_ID } from '@/components/feed/constants';
 import FeedIcon from '@/components/feed/home/RecentArea/FeedIcon';
 import VoteIcon from '@/public/icons/icon-vote.svg';
+import { useRouter } from 'next/router';
 
 interface RecentCardProps {
   recentPosts: RecentPosts;
@@ -20,6 +21,7 @@ const RecentCard = ({ recentPosts }: RecentCardProps) => {
     recentPosts;
   const isQuestion = QUESTION_CATEGORY_ID === categoryId;
   const isVotePost = totalVoteCount !== null;
+  const router = useRouter();
 
   return (
     <LoggingClick eventKey='feedCard' param={{ feedId: String(id), category: categoryName, referral: 'category_HOT' }}>
@@ -29,7 +31,7 @@ const RecentCard = ({ recentPosts }: RecentCardProps) => {
             <Tag>{categoryName}</Tag>
             {title}
           </TitleStyle>
-          <ContentStyle>{parseMentionsToJSX(content)}</ContentStyle>
+          <ContentStyle>{parseMentionsToJSX(content, router)}</ContentStyle>
         </CardContent>
 
         <CardFooter>

--- a/src/components/feed/list/FeedCard.tsx
+++ b/src/components/feed/list/FeedCard.tsx
@@ -15,6 +15,7 @@ import FeedUrlCard from '@/components/feed/list/FeedUrlCard';
 import { playgroundLink } from '@/constants/links';
 import { textStyles } from '@/styles/typography';
 import { parseMentionsToJSX } from '@/components/feed/common/utils/parseMention';
+import { useRouter } from 'next/router';
 interface RandomProfile {
   nickname: string;
   profileImgUrl: string;
@@ -248,8 +249,8 @@ const renderContent = (content: string) => {
     displayText = content.slice(0, 140) + '...';
     isLong = true;
   }
-
-  const parsed = parseMentionsToJSX(displayText);
+  const router = useRouter();
+  const parsed = parseMentionsToJSX(displayText, router);
 
   if (isLong) {
     parsed.push(

--- a/src/components/feed/list/FeedCard.tsx
+++ b/src/components/feed/list/FeedCard.tsx
@@ -69,6 +69,8 @@ const Base = forwardRef<HTMLDivElement, PropsWithChildren<BaseProps>>(
     },
     ref,
   ) => {
+    const router = useRouter();
+
     return (
       <Flex
         ref={ref}
@@ -154,7 +156,7 @@ const Base = forwardRef<HTMLDivElement, PropsWithChildren<BaseProps>>(
                       wordBreak: 'break-all',
                     }}
                   >
-                    {renderContent(content)}
+                    {renderContent(content, router)}
                   </Text>
                 </>
               )}
@@ -241,7 +243,7 @@ const Bottom = styled(Stack.Horizontal)`
   gap: 8px;
 `;
 
-const renderContent = (content: string) => {
+const renderContent = (content: string, router: ReturnType<typeof useRouter>) => {
   let displayText = content;
   let isLong = false;
 
@@ -249,7 +251,6 @@ const renderContent = (content: string) => {
     displayText = content.slice(0, 140) + '...';
     isLong = true;
   }
-  const router = useRouter();
   const parsed = parseMentionsToJSX(displayText, router);
 
   if (isLong) {


### PR DESCRIPTION
### 🤫 쉿, 나한테만 말해줘요. 이슈넘버
- close #1902

### 🧐 어떤 것을 변경했어요~?
<!-- 실제로 변경한 사항을 설명해주세요.-->
멘션을 클릭하면 해당 멤버페이지로 이동하도록 추가했습니다.
&nbsp;를 공백으로 변경해주었습니다.

### 🤔 그렇다면, 어떻게 구현했어요~?
<!-- 실제로 구현한 로직에 대해 설명해주세요.-->

### ❤️‍🔥 당신이 생각하는 PR포인트, 내겐 매력포인트.
<!-- 해당 PR에서 논의가 필요한 사항을 적어주세요. -->
근본적으로 &nbsp가 붙지 않고 넘기는 방법을 찾아야 하는데,
아직 찾지 못해서 일단 직접 파싱해서 뷰에 보여줄 때 공백으로 변경해서 보이도록 했습니다.ㅜㅜ

### 📸 스크린샷, 없으면 이것 참,, 섭섭한데요?
