### PR TITLE
fix: member activities 빈배열 처리

### DIFF
--- a/src/components/members/main/MemberList/index.tsx
+++ b/src/components/members/main/MemberList/index.tsx
@@ -89,8 +89,9 @@ const MemberList: FC<MemberListProps> = ({ banner }) => {
       memberProfileData?.pages.map((page) =>
         page.members.map((member) => ({
           ...member,
-          isActive: member.activities.map(({ generation }) => generation).includes(LATEST_GENERATION),
-          part: uniq(member.activities.map(({ part }) => part)).join(' / '),
+          activities: member.activities || [],
+          isActive: (member.activities || []).map(({ generation }) => generation).includes(LATEST_GENERATION),
+          part: uniq((member.activities || []).map(({ part }) => part)).join(' / '),
         })),
       ),
     [memberProfileData],


### PR DESCRIPTION
### 🤫 쉿, 나한테만 말해줘요. 이슈넘버
- close #1956

### 🧐 어떤 것을 변경했어요~?
<!-- 실제로 변경한 사항을 설명해주세요.-->
 - member.activities가 빈 배열일 때 발생할 수 있는 런타임 에러 방지
 - useMemo에서 activities 기본값을 빈 배열로 설정하여 한번에 처리 

### 🤔 그렇다면, 어떻게 구현했어요~?
<!-- 실제로 구현한 로직에 대해 설명해주세요.-->

### ❤️‍🔥 당신이 생각하는 PR포인트, 내겐 매력포인트.
<!-- 해당 PR에서 논의가 필요한 사항을 적어주세요. -->

### 📸 스크린샷, 없으면 이것 참,, 섭섭한데요?
