### PR TITLE
fix: 플그 be 수정된 part 로직에 맞게 filter로 파트 정보 요청

### DIFF
--- a/src/components/members/main/MemberList/filters/constants.ts
+++ b/src/components/members/main/MemberList/filters/constants.ts
@@ -20,7 +20,7 @@ export const PART_VALUE = {
 } as const;
 
 export const TEAM_VALUE = {
-  임원진: 'MAKER',
+  임원진: 'MAKERS',
   운영팀: 'OPERATION',
   미디어팀: 'MEDIA',
 } as const;

--- a/src/components/members/main/MemberList/index.tsx
+++ b/src/components/members/main/MemberList/index.tsx
@@ -28,7 +28,6 @@ import {
   ORDER_OPTIONS,
   PART_DEFAULT_OPTION,
   PART_OPTIONS,
-  PART_VALUE,
   TEAM_OPTIONS,
   TEAM_VALUE,
 } from '@/components/members/main/MemberList/filters/constants';
@@ -109,13 +108,13 @@ const MemberList: FC<MemberListProps> = ({ banner }) => {
 
   useEffect(() => {
     if (router.isReady) {
-      const { generation, part, search, employed, team, mbti, orderBy } = router.query;
+      const { generation, filter, search, employed, team, mbti, orderBy } = router.query;
       if (typeof generation === 'string' || generation === undefined || null) {
         const generationOption = GENERATION_OPTIONS.find((option) => option.value === generation);
         setGeneration(generationOption as Option);
       }
-      if (typeof part === 'string' || part === undefined || null) {
-        const filterOption = PART_OPTIONS.find((option) => option.value === part);
+      if (typeof filter === 'string' || filter === undefined || null) {
+        const filterOption = PART_OPTIONS.find((option) => option.value === filter);
         setPart(filterOption as Option);
       }
       if (typeof search === 'string') {
@@ -154,12 +153,9 @@ const MemberList: FC<MemberListProps> = ({ banner }) => {
       }
     };
 
-  type PartKey = keyof typeof PART_VALUE;
-  type PartValue = (typeof PART_VALUE)[PartKey];
-  const handleSelectPart = createTypeSafeHandler<PartValue>((_part: PartValue) => {
-    const partKey = (Object.keys(PART_VALUE) as PartKey[]).find((key) => PART_VALUE[key] === _part);
-    addQueryParamsToUrl({ part: partKey });
-    logClickEvent('filterPart', { part: _part || 'all' });
+  const handleSelectPart = createTypeSafeHandler<string>((filter: string) => {
+    addQueryParamsToUrl({ filter });
+    logClickEvent('filterPart', { part: filter || 'all' });
   });
 
   const handleSelectGeneration = createTypeSafeHandler<string>((generation: string) => {


### PR DESCRIPTION
### 🤫 쉿, 나한테만 말해줘요. 이슈넘버
- close #1970 

### 🧐 어떤 것을 변경했어요~?
<!-- 실제로 변경한 사항을 설명해주세요.-->
백엔드에서 filter로 파트 정보를 보내면 enum으로 인증 서버로 보내도록 로직을 수정해주셔서 filter로 보내도록 변경했어요.
maker가 아닌 makers로 enum을 관리하고 있어서 오탈자를 수정했어요.
### 🤔 그렇다면, 어떻게 구현했어요~?
<!-- 실제로 구현한 로직에 대해 설명해주세요.-->

### ❤️‍🔥 당신이 생각하는 PR포인트, 내겐 매력포인트.
<!-- 해당 PR에서 논의가 필요한 사항을 적어주세요. -->

### 📸 스크린샷, 없으면 이것 참,, 섭섭한데요?
