### PR TITLE
fix: 실시간 인기글 categoryId undefined에러 수정

### DIFF
--- a/src/components/feed/common/utils.ts
+++ b/src/components/feed/common/utils.ts
@@ -35,15 +35,6 @@ export enum Category {
   꿀팁,
 }
 
-export const CategoryList = {
-  자유: '자유',
-  파트: '파트',
-  SOPT활동: 'SOPT활동',
-  홍보: '홍보',
-  취업_진로: '취업/진로',
-  솝티클: '솝티클',
-};
-
 const 특수임원List = [
   '메이커스 리드',
   '메이커스 팀장',
@@ -81,16 +72,6 @@ export function getMemberInfo(post: Post) {
 
   return defaultInfo;
 }
-
-export const categoryIdNameMap: Record<number, string> = {
-  1: '자유',
-  2: '파트',
-  3: 'SOPT 활동',
-  4: '홍보',
-  5: '취업/진로',
-  21: '솝티클',
-  22: '질문',
-};
 
 export const getParentCategoryId = (
   categoryData: { id: number; children: { id: number }[] }[] | undefined,
@@ -145,6 +126,16 @@ export function getParentCategoryIdById(id: number | null): number | undefined {
   for (const parent of CATEGORY_TREE) {
     if (parent.id === id) return parent.id;
     if (parent.children?.some((child) => child.id === id)) {
+      return parent.id;
+    }
+  }
+  return undefined;
+}
+
+export function getParentCategoryIdByName(name: string): number | undefined {
+  for (const parent of CATEGORY_TREE) {
+    if (parent.name === name) return parent.id;
+    if (parent.children?.some((child) => child.name === name)) {
       return parent.id;
     }
   }

--- a/src/components/feed/home/PopularArea/index.tsx
+++ b/src/components/feed/home/PopularArea/index.tsx
@@ -7,7 +7,7 @@ import { getCategory } from '@/api/endpoint/feed/getCategory';
 import { useGetPopularPost } from '@/api/endpoint/feed/getPopularPost';
 import Text from '@/components/common/Text';
 import { LoggingClick } from '@/components/eventLogger/components/LoggingClick';
-import { categoryIdNameMap } from '@/components/feed/common/utils';
+import { getParentCategoryIdByName } from '@/components/feed/common/utils';
 import PopularCard from '@/components/feed/home/PopularArea/PopularCard';
 import { MB_SM_MEDIA_QUERY } from '@/styles/mediaQuery';
 
@@ -16,7 +16,7 @@ const PopularArea = () => {
   const router = useRouter();
 
   const handleClickPopular = (category: string, feedId: number) => {
-    const categoryId = Object.entries(categoryIdNameMap).find(([_, name]) => name === category)?.[0];
+    const categoryId = getParentCategoryIdByName(category);
 
     if (!categoryId) {
       router.push(`/?feed=${feedId}`);

--- a/src/components/members/main/MemberList/index.tsx
+++ b/src/components/members/main/MemberList/index.tsx
@@ -209,7 +209,7 @@ const MemberList: FC<MemberListProps> = ({ banner }) => {
         <Responsive only='mobile'>{banner}</Responsive>
         <Responsive only='mobile' css={{ marginTop: '20px' }}>
           <StyledMemberSearch
-            placeholder='이름, 학교, 회사를 검색해보세요!'
+            placeholder='이름을 검색해보세요!'
             value={search || ''}
             onChange={handleSearchChange}
             onSubmit={() => handleSearchSubmit(search as string)}
@@ -353,7 +353,7 @@ const MemberList: FC<MemberListProps> = ({ banner }) => {
                   />
                 </StyledFilterWrapper>
                 <StyledMemberSearch
-                  placeholder='이름, 학교, 회사를 검색해보세요!'
+                  placeholder='이름을 검색해보세요!'
                   value={search || ''}
                   onChange={handleSearchChange}
                   onSubmit={() => handleSearchSubmit(search as string)}


### PR DESCRIPTION
### 🤫 쉿, 나한테만 말해줘요. 이슈넘버
- close #1975 

### 🧐 어떤 것을 변경했어요~?
<!-- 실제로 변경한 사항을 설명해주세요.-->
- 실시간 인기글의 경우 따로 서버로부터 categoryId를 받지 않고 자식 카테고리 이름으로 받게 되는 경우가 생겨 기존 로직으로 
부모 카테고리 id를 찾지못하는 상황이었습니다. 따라서 categoryIdNameMap을 통해 찾는 방식을 제거하고 string에 해당 하는 카테고리명을 넣으면 부모 카테고리에 해당하는 id에 해당 하는 값을 반환하는 util함수를 만들었어요

### 🤔 그렇다면, 어떻게 구현했어요~?
<!-- 실제로 구현한 로직에 대해 설명해주세요.-->

### ❤️‍🔥 당신이 생각하는 PR포인트, 내겐 매력포인트.
<!-- 해당 PR에서 논의가 필요한 사항을 적어주세요. -->

### 📸 스크린샷, 없으면 이것 참,, 섭섭한데요?
