### PR TITLE
refactor: 멤버 필터링 초기화 추가

### DIFF
--- a/src/components/members/main/MemberList/filters/constants.ts
+++ b/src/components/members/main/MemberList/filters/constants.ts
@@ -116,6 +116,10 @@ export const EMPLOYED_OPTIONS: Option[] = [{ value: '1', label: '재직 중' }];
 
 export const ORDER_OPTIONS: Option[] = [
   {
+    value: '0',
+    label: '멤버 전체',
+  },
+  {
     value: '1',
     label: '최근등록순',
   },

--- a/src/components/members/main/MemberList/index.tsx
+++ b/src/components/members/main/MemberList/index.tsx
@@ -139,7 +139,14 @@ const MemberList: FC<MemberListProps> = ({ banner }) => {
     }
   }, [router.isReady, router.query, router]);
 
-  const handleSearchChange = (e: ChangeEvent<HTMLInputElement>) => setSearch(e.target.value);
+  const handleSearchChange = (e: ChangeEvent<HTMLInputElement>) => {
+    const { value } = e.target;
+    setSearch(value);
+    if (value === '') {
+      addQueryParamsToUrl({ search: undefined });
+    }
+  };
+
   const handleSearchReset = () => {
     setSearch('');
     addQueryParamsToUrl({ search: '' });

--- a/src/components/members/main/MemberList/index.tsx
+++ b/src/components/members/main/MemberList/index.tsx
@@ -181,7 +181,7 @@ const MemberList: FC<MemberListProps> = ({ banner }) => {
   });
 
   const handleSelectOrderBy = createTypeSafeHandler<string>((orderBy: string) => {
-    addQueryParamsToUrl({ orderBy });
+    addQueryParamsToUrl({ orderBy: orderBy === '0' ? undefined : orderBy });
     logClickEvent('filterOrderBy', { orderBy });
   });
 


### PR DESCRIPTION
### 🤫 쉿, 나한테만 말해줘요. 이슈넘버
- close #1993

### 🧐 어떤 것을 변경했어요~?
<!-- 실제로 변경한 사항을 설명해주세요.-->
- 정렬에 "멤버 전체"를 추가했습니다
- 검색에 빈문자열 입력시 검색 필터링을 제거했습니다
- 
### 🤔 그렇다면, 어떻게 구현했어요~?
<!-- 실제로 구현한 로직에 대해 설명해주세요.-->
- 멤버 전체를 클릭하면 정렬이 되지 않도록 url 파라미터를 비워줬습니다.
- 멤버 검색이 onSubmit으로 동작해서 빈 문자열 입력 후 엔터를 누르면 이벤트가 발생하지 않습니다. 따라서 검색어가 변경될 때 빈문자열이면 검색 필터링을 제거하도록 했습니다.

### ❤️‍🔥 당신이 생각하는 PR포인트, 내겐 매력포인트.
<!-- 해당 PR에서 논의가 필요한 사항을 적어주세요. -->

### 📸 스크린샷, 없으면 이것 참,, 섭섭한데요?
<img width="370" height="386" alt="image" src="https://github.com/user-attachments/assets/af57e4bc-66a5-45b0-9a13-4946f827d5dd" />
