### PR TITLE
fix: makers 경로 로그인만료 처리 로직 진행하지 않도록 분기처리

### DIFF
--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -87,6 +87,10 @@ export const handleTokenError = async (error: AxiosError<unknown>) => {
   const { status } = error.response;
 
   if (status === 401) {
+    if (window.location.pathname === '/makers') {
+      // 메이커스 페이지는 로그인 필요 없음
+      return Promise.reject(error);
+    }
     /** 토큰이 없으면 refresh 시도하지 않고 바로 intro로 이동 */
     const currentToken = tokenStorage.get();
     if (currentToken === null && window.location.pathname !== '/intro') {


### PR DESCRIPTION
### 🤫 쉿, 나한테만 말해줘요. 이슈넘버
- close #2002 

### 🧐 어떤 것을 변경했어요~?
<!-- 실제로 변경한 사항을 설명해주세요.-->
메이커스 페이지는 공식홈페이지에서도 연결되어 있어서 솝트회원이 아닌 사람에게도 공개되어있어요.
<img width="662" height="194" alt="image" src="https://github.com/user-attachments/assets/33f4465e-03a3-489f-bf66-541ee60a2016" /><br />
<img width="940" height="660" alt="image" src="https://github.com/user-attachments/assets/026c0d2d-e07e-4411-8a54-aa3fd84bd95f" />

토큰 만료 갱신 로직이 추가되면서, 메이커스 페이지의 헤더에서 로그인 정보를 가져올 때 401이 발생하면 로그인으로 이동하게 되었어요.
따라서 메이커스 페이지는 로그인을 하지 않아도 로그인으로 이동하지 않도록 변경했어요.

### 🤔 그렇다면, 어떻게 구현했어요~?
<!-- 실제로 구현한 로직에 대해 설명해주세요.-->
api instance에서 401이 발생하면 로그인으로 이동하는 로직에서 makers 경로만 제외시키도록 수정했어요
헤더 컴포넌트는 다른 페이지와 공통으로 사용하고 있어서, 호출 부분을 수정하는 것보다 해당 경로만 제외시키는 것이 더 간단하다고 생각했어요

### ❤️‍🔥 당신이 생각하는 PR포인트, 내겐 매력포인트.
<!-- 해당 PR에서 논의가 필요한 사항을 적어주세요. -->

### 📸 스크린샷, 없으면 이것 참,, 섭섭한데요?
