### PR TITLE
fix: 프로필 수정 textarea 요청 안가는 이슈 해결

### DIFF
--- a/src/components/members/upload/FormSection/Tmi/index.tsx
+++ b/src/components/members/upload/FormSection/Tmi/index.tsx
@@ -62,7 +62,13 @@ export default function TmiFormSection() {
               />
             )}
           />
-          <StyledTextArea {...register('mbtiDescription')} placeholder='ex) 저는 극강의 EEE에요.' fixedHeight={100} />
+          <Controller
+            name='mbtiDescription'
+            control={control}
+            render={({ field }) => (
+              <StyledTextArea {...field} placeholder='ex) 저는 극강의 EEE에요.' fixedHeight={100} />
+            )}
+          />
         </MbtiWrapper>
       </StyledMemberFormItem>
 
@@ -100,10 +106,12 @@ export default function TmiFormSection() {
           <StyledTextField {...register('interest')} placeholder='ex) 요즘 넷플릭스 ‘더 글로리’에 빠졌어요.' />
         </Responsive>
         <Responsive only='mobile'>
-          <StyledTextArea
-            {...register('interest')}
-            placeholder='ex) 요즘 넷플릭스 ‘더 글로리’에 빠졌어요.'
-            fixedHeight={100}
+          <Controller
+            name='interest'
+            control={control}
+            render={({ field }) => (
+              <StyledTextArea {...field} placeholder='ex) 요즘 넷플릭스 ‘더 글로리’에 빠졌어요.' fixedHeight={100} />
+            )}
           />
         </Responsive>
       </StyledMemberFormItem>


### PR DESCRIPTION
### 🤫 쉿, 나한테만 말해줘요. 이슈넘버
- close #2004 

### 🧐 어떤 것을 변경했어요~?
<!-- 실제로 변경한 사항을 설명해주세요.-->
textarea에서 변경된 값을 인식할 수 있도록 controller로 제어하도록 고쳤어요

### 🤔 그렇다면, 어떻게 구현했어요~?
<!-- 실제로 구현한 로직에 대해 설명해주세요.-->
mbti를 변경하면서 텍스트를 변경하면 해당 값으로 변경이 되지만, 그냥 텍스트만 변경하면 요청이 가지 않았어요
해당 필드 변경이 isDirty 상태를 변경하지 않고 있었고, textarea에서 전체적으로 발생하고 있었어요
textarea의 변경사항을 정확하게 추적할 수 있도록 controller로 제어하도록 변경했어요

### ❤️‍🔥 당신이 생각하는 PR포인트, 내겐 매력포인트.
<!-- 해당 PR에서 논의가 필요한 사항을 적어주세요. -->

### 📸 스크린샷, 없으면 이것 참,, 섭섭한데요?
<img width="1660" height="936" alt="image" src="https://github.com/user-attachments/assets/1ff3e22c-ff2c-47e2-859b-781f7077d89e" />

<img width="825" height="497" alt="image" src="https://github.com/user-attachments/assets/cc5d309b-4eb1-4553-a05c-90a5bbc520d3" />
