### PR TITLE
fix: iOS 앱 내 웹뷰인 경우 커뮤니티 상세페이지 이전 버튼 제거

### DIFF
--- a/src/components/feed/detail/DetailFeedCard.tsx
+++ b/src/components/feed/detail/DetailFeedCard.tsx
@@ -71,12 +71,12 @@ const Header = ({
   renderCategoryLink = (props) => props.children,
   hasChildren,
 }: HeaderProps) => {
-  const isIOSApp = /SOPT-iOS/.test(navigator.userAgent); // iOS 앱 내 웹뷰 여부
+  const isIOSApp = typeof navigator !== 'undefined' && /SOPT-iOS/.test(navigator.userAgent);
 
   return (
     <StyledHeader align='center' justify='space-between' as='header'>
       <Flex.Center css={{ gap: 8 }}>
-        {isIOSApp || <div css={{ width: '24px', height: '24px' }}>{left}</div>}
+        {!isIOSApp && <div css={{ width: '24px', height: '24px' }}>{left}</div>}
 
         {renderCategoryLink({
           children: (

--- a/src/components/resolution/submit/TimecapsopSubmitModalContent.tsx
+++ b/src/components/resolution/submit/TimecapsopSubmitModalContent.tsx
@@ -73,7 +73,7 @@ const TimecapsopSubmitModalContent: FC<TimecapsopSubmitModalProps> = ({ userName
   const formRef = useRef<HTMLFormElement>(null);
 
   useEffect(() => {
-    const isMobileIOS = /iPhone|iPad|iPod/i.test(navigator.userAgent);
+    const isMobileIOS = /iPhone|iPad|iPod|SOPT-iOS/i.test(navigator.userAgent);
 
     if (!isMobileIOS) return;
 


### PR DESCRIPTION
### 🤫 쉿, 나한테만 말해줘요. 이슈넘버
- close #2011 

### 🧐 어떤 것을 변경했어요~?
<!-- 실제로 변경한 사항을 설명해주세요.-->
iOS 웹뷰인 경우 user agent 값을 기준으로 예외처리 했습니다.

### 🤔 그렇다면, 어떻게 구현했어요~?
<!-- 실제로 구현한 로직에 대해 설명해주세요.-->
<img width="840" height="110" alt="image" src="https://github.com/user-attachments/assets/6dd8c0d1-daf1-44b5-8b78-28370817044a" />
위의 사진처럼 iOS 선생님들이 user agent에 SOPT-iOS 문자열을 추가해주셔서 해당 문자열로 비교했습니다.

### ❤️‍🔥 당신이 생각하는 PR포인트, 내겐 매력포인트.
<!-- 해당 PR에서 논의가 필요한 사항을 적어주세요. -->

### 📸 스크린샷, 없으면 이것 참,, 섭섭한데요?
<img width="3134" height="590" alt="image" src="https://github.com/user-attachments/assets/19488782-6635-4bca-8e43-48ee47ad4310" />
<br />
[user agent를 SOPT-iOS로 지정한 경우]

<img width="492" height="969" alt="image" src="https://github.com/user-attachments/assets/8c3bb932-1a9c-4fb9-a3ee-4c12c5dae933" />
<br />
[Safari로 iOS로 접속한 경우]