### PR TITLE
fix: 누락된 바텀시트 트리거 아이콘 추가

### DIFF
--- a/src/components/coffeechat/upload/CoffeechatForm/BottomSheetSelect/index.tsx
+++ b/src/components/coffeechat/upload/CoffeechatForm/BottomSheetSelect/index.tsx
@@ -73,6 +73,19 @@ const BottomSheetSelect = ({
     return options.find((option) => option.value === value)?.label || value;
   };
 
+  const displayIcon = disabled
+    ? null
+    : icon ?? (
+        <IconChevronDown
+          style={{
+            width: 20,
+            height: 20,
+            transform: open ? 'rotate(-180deg)' : '',
+            transition: 'all 0.5s',
+          }}
+        />
+      );
+
   return (
     <Container>
       <InputField onClick={handleOpen} className={className} disabled={disabled}>
@@ -81,16 +94,7 @@ const BottomSheetSelect = ({
         ) : (
           <p style={{ color: '#808087' }}>{placeholder}</p>
         )}
-        {!icon && !disabled && (
-          <IconChevronDown
-            style={{
-              width: 20,
-              height: 20,
-              transform: open ? 'rotate(-180deg)' : '',
-              transition: 'all 0.5s',
-            }}
-          />
-        )}
+        {displayIcon}
       </InputField>
 
       {open && (


### PR DESCRIPTION
### 🤫 쉿, 나한테만 말해줘요. 이슈넘버
- close #2014

### 🧐 어떤 것을 변경했어요~?
<!-- 실제로 변경한 사항을 설명해주세요.-->
전달받은 아이콘을 보여주는 로직이 없어서 추가했습니다.

### 🤔 그렇다면, 어떻게 구현했어요~?
<!-- 실제로 구현한 로직에 대해 설명해주세요.-->

### ❤️‍🔥 당신이 생각하는 PR포인트, 내겐 매력포인트.
<!-- 해당 PR에서 논의가 필요한 사항을 적어주세요. -->

### 📸 스크린샷, 없으면 이것 참,, 섭섭한데요?
이랬는데
<img width="260" height="174" alt="image" src="https://github.com/user-attachments/assets/1c3127d3-2e1a-4636-8e8e-b9880b4d4442" /><br />
요래됐습니당~
<img width="298" height="190" alt="image" src="https://github.com/user-attachments/assets/fe457315-f2a5-4255-a56b-8904aa115f40" />
