### PR TITLE
fix: 솝티클 링크 짤리는 이슈 height 고정값 삭제로 해결

### DIFF
--- a/src/components/feed/list/FeedUrlCard.tsx
+++ b/src/components/feed/list/FeedUrlCard.tsx
@@ -62,7 +62,6 @@ const FeedUrlCardBox = styled.div<{ isDetailFeedCard?: boolean; isFull?: boolean
 
   @media ${MOBILE_MEDIA_QUERY} {
     flex-direction: column;
-    height: 278px;
   }
 
   ${({ isDetailFeedCard }) =>


### PR DESCRIPTION
### 🤫 쉿, 나한테만 말해줘요. 이슈넘버
- close #2019

### 🧐 어떤 것을 변경했어요~?
<!-- 실제로 변경한 사항을 설명해주세요.-->
모바일 환경에서 솝티클을 고정해둔 코드 제거

### 🤔 그렇다면, 어떻게 구현했어요~?
<!-- 실제로 구현한 로직에 대해 설명해주세요.-->
fit한 height값을 갖도록 (title과 decription의 글자수 제한이 있어서 문제 없음)

### ❤️‍🔥 당신이 생각하는 PR포인트, 내겐 매력포인트.
<!-- 해당 PR에서 논의가 필요한 사항을 적어주세요. -->

### 📸 스크린샷, 없으면 이것 참,, 섭섭한데요?
<img width="654" height="446" alt="image" src="https://github.com/user-attachments/assets/ea2b890e-905b-41ad-96d6-d3dfc51260cd" />
