### PR TITLE
feat: ask기능에 대한 로깅 추가

### DIFF
--- a/src/components/eventLogger/events.ts
+++ b/src/components/eventLogger/events.ts
@@ -226,6 +226,23 @@ export interface ClickEvents {
   TL_introduce: undefined;
   TL_appjam: undefined;
   refreshmember: undefined;
+  CTAAsk: {
+    id: number;
+    name: string;
+  };
+  TabAsk: {
+    id: number;
+    name: string;
+  };
+  TabProfile: {
+    id: number;
+    name: string;
+  };
+  AskUploadButton: undefined;
+  AnswerUploadButton: undefined;
+  AskLike: {
+    feedId: number;
+  };
 }
 
 export interface SubmitEvents {
@@ -291,6 +308,12 @@ export interface SubmitEvents {
 
   // 기획경선 특집
   balancegame: undefined;
+  submitAsk: {
+    feedId: number;
+  };
+  submitAnswer: {
+    feedId: number;
+  };
 }
 
 export interface PageViewEvents {
@@ -319,4 +342,7 @@ export interface ImpressionEvents {
 
   // 기획경선 특집
   balancegame: undefined;
+  AskCard: {
+    feedId: number;
+  };
 }

--- a/src/components/members/ask/AskFormPage.tsx
+++ b/src/components/members/ask/AskFormPage.tsx
@@ -6,13 +6,13 @@ import { ReactNode, useEffect, useRef, useState } from 'react';
 
 import Checkbox from '@/components/common/Checkbox';
 import Responsive from '@/components/common/Responsive';
+import CheckboxFormItem from '@/components/feed/upload/CheckboxFormItem';
 import ContentsInput from '@/components/feed/upload/Input/ContentsInput';
 import DesktopFeedUploadLayout from '@/components/feed/upload/layout/DesktopFeedUploadLayout';
 import MobileFeedUploadLayout from '@/components/feed/upload/layout/MobileFeedUploadLayout';
-import CheckboxFormItem from '@/components/feed/upload/CheckboxFormItem';
-import { MOBILE_MEDIA_QUERY } from '@/styles/mediaQuery';
-import BackArrow from '@/public/icons/icon_chevron_left.svg';
 import UsingRules from '@/components/feed/upload/UsingRules';
+import BackArrow from '@/public/icons/icon_chevron_left.svg';
+import { MOBILE_MEDIA_QUERY } from '@/styles/mediaQuery';
 
 interface AskFormValues {
   content: string;
@@ -38,7 +38,7 @@ export default function AskFormPage({
   commentSlot,
   description,
   hideAnonymousToggle = false,
-  placeholder
+  placeholder,
 }: AskFormPageProps) {
   const [content, setContent] = useState(defaultValues?.content ?? '');
   const [isAnonymous, setIsAnonymous] = useState(defaultValues?.isAnonymous ?? true);
@@ -71,25 +71,21 @@ export default function AskFormPage({
   const handleBack = () => {
     if (typeof window !== 'undefined') window.history.back();
   };
-  
+
   useEffect(() => {
-  const focusInput = () => {
-    const editableDiv = document.querySelector('[contenteditable="true"]') as HTMLElement;
-    if (editableDiv && editableDiv.offsetParent !== null) {
-      editableDiv.focus();
-    }
-  };
+    const focusInput = () => {
+      const editableDiv = document.querySelector('[contenteditable="true"]') as HTMLElement;
+      if (editableDiv && editableDiv.offsetParent !== null) {
+        editableDiv.focus();
+      }
+    };
 
-  const timers = [
-    setTimeout(focusInput, 100),
-    setTimeout(focusInput, 300),
-    setTimeout(focusInput, 500),
-  ];
+    const timers = [setTimeout(focusInput, 100), setTimeout(focusInput, 300), setTimeout(focusInput, 500)];
 
-  return () => {
-    timers.forEach(timer => clearTimeout(timer));
-  };
-}, []);
+    return () => {
+      timers.forEach((timer) => clearTimeout(timer));
+    };
+  }, []);
 
   return (
     <form onSubmit={handleSubmit}>
@@ -267,7 +263,6 @@ const TagAndCheckboxWrapper = styled.div`
   gap: 41px;
   align-items: end;
 `;
-
 
 const ReplyRow = styled.div`
   display: flex;

--- a/src/components/members/detail/ActivitySection/AskReply.tsx
+++ b/src/components/members/detail/ActivitySection/AskReply.tsx
@@ -13,7 +13,9 @@ import { MemberQuestion } from '@/api/endpoint/members/getMemberQuestions';
 import { usePostAnswerReaction } from '@/api/endpoint/members/postAnswerReaction';
 import useModalState from '@/components/common/Modal/useModalState';
 import ResizedImage from '@/components/common/ResizedImage';
+import Responsive from '@/components/common/Responsive/Responsive';
 import Text from '@/components/common/Text';
+import useEventLogger from '@/components/eventLogger/hooks/useEventLogger';
 import FeedDropdown from '@/components/feed/common/FeedDropdown';
 import FeedLike from '@/components/feed/common/FeedLike';
 import { useDeleteQuestionAnswer } from '@/components/feed/common/hooks/useDeleteQuestion';
@@ -21,7 +23,6 @@ import { getRelativeTime } from '@/components/feed/common/utils';
 import { MessageCategory } from '@/components/members/detail/MessageSection/MessageModal';
 import MessageModal from '@/components/members/detail/MessageSection/MessageModal';
 import { MOBILE_MEDIA_QUERY } from '@/styles/mediaQuery';
-import Responsive from '@/components/common/Responsive/Responsive';
 interface AskReplyProps {
   question: MemberQuestion;
   answererName: string;
@@ -33,6 +34,7 @@ export default function AskReply({ question, answererName, profileImage, isMyPro
   const answer = question.answer;
   const { isOpen: isOpenMessageModal, onOpen: onOpenMessageModal, onClose: onCloseMessageModal } = useModalState();
   const { mutate: handleToggleLikeAskAnswer } = usePostAnswerReaction();
+  const { logClickEvent } = useEventLogger();
   const router = useRouter();
   const { handleDeleteQuestionAnswer } = useDeleteQuestionAnswer();
   const [isExpanded, setIsExpanded] = useState(false);
@@ -140,18 +142,15 @@ export default function AskReply({ question, answererName, profileImage, isMyPro
           likes={reactionCount}
           type='helpful'
           onClick={() => {
+            logClickEvent('AskLike', { feedId: answerId });
             handleToggleLikeAskAnswer(answerId);
           }}
         ></FeedLike>
       </ButtonWrapper>
       {isMine && (
         <SendMailWrapper>
-           <Responsive only='desktop'>
-            더 궁금한 내용이 있다면 쪽지로 대화를 이어갈 수 있어요.
-           </Responsive>
-           <Responsive only='mobile'>
-             더 궁금한 내용이 있다면{'\n'}쪽지로 대화를 이어갈 수 있어요.
-          </Responsive>
+          <Responsive only='desktop'>더 궁금한 내용이 있다면 쪽지로 대화를 이어갈 수 있어요.</Responsive>
+          <Responsive only='mobile'>더 궁금한 내용이 있다면{'\n'}쪽지로 대화를 이어갈 수 있어요.</Responsive>
           <Button
             style={{
               padding: '9px 14px',
@@ -192,7 +191,7 @@ const AnswerName = styled(Text)`
   color: ${colors.white};
 
   @media ${MOBILE_MEDIA_QUERY} {
-      ${fonts.LABEL_14_SB}
+    ${fonts.LABEL_14_SB}
   }
 `;
 const ProfileImage = styled(ResizedImage)`
@@ -260,7 +259,7 @@ const SendMailWrapper = styled.div`
   width: 100%;
   ${fonts.LABEL_12_SB};
 
-  white-space: pre-line; 
+  white-space: pre-line;
 `;
 
 const AskReplyContainer = styled.div`

--- a/src/components/members/detail/ActivitySection/MemberDetail.tsx
+++ b/src/components/members/detail/ActivitySection/MemberDetail.tsx
@@ -35,7 +35,7 @@ const TABS: Tab[] = [
 
 const MemberDetail: FC<MemberDetailProps> = ({ memberId }) => {
   const router = useRouter();
-  const { logPageViewEvent } = useEventLogger();
+  const { logPageViewEvent, logClickEvent } = useEventLogger();
 
   const currentTab = (router.query.tab as TabType) || 'profile';
 
@@ -68,6 +68,19 @@ const MemberDetail: FC<MemberDetailProps> = ({ memberId }) => {
   }, [profile, memberId]);
 
   const handleTabChange = (tab: TabType) => {
+    if (profile) {
+      if (tab === 'ask') {
+        logClickEvent('TabAsk', {
+          id: Number(memberId),
+          name: profile.name,
+        });
+      } else if (tab === 'profile') {
+        logClickEvent('TabProfile', {
+          id: Number(memberId),
+          name: profile.name,
+        });
+      }
+    }
     router.push(
       {
         pathname: router.pathname,

--- a/src/components/members/main/AskOBMemberList/OBMemberCard.tsx
+++ b/src/components/members/main/AskOBMemberList/OBMemberCard.tsx
@@ -1,10 +1,10 @@
 import styled from '@emotion/styled';
 import { colors } from '@sopt-makers/colors';
-import { fonts } from '@sopt-makers/fonts';
 import { Button } from '@sopt-makers/ui';
 import { useRouter } from 'next/router';
 
 import Text from '@/components/common/Text';
+import useEventLogger from '@/components/eventLogger/hooks/useEventLogger';
 import { useVisibleBadges } from '@/components/members/main/hooks/useVisibleBadges';
 import MemberProfileImage from '@/components/members/main/MemberCard/MemberProfileImage';
 import IconAskCheck from '@/public/icons/icon_ask_check.svg';
@@ -39,6 +39,7 @@ export default function OBMemberCard({
   isAnswerGuaranteed,
 }: OBMemberCardProps) {
   const router = useRouter();
+  const { logClickEvent } = useEventLogger();
   const badges = [
     {
       content: `${latestActivity.generation}기 ${latestActivity.part}`,
@@ -53,6 +54,7 @@ export default function OBMemberCard({
   );
 
   const handleClickButton = () => {
+    logClickEvent('CTAAsk', { id, name });
     router.push(`/members/${id}?tab=ask`);
   };
   return (

--- a/src/pages/members/ask/upload.tsx
+++ b/src/pages/members/ask/upload.tsx
@@ -1,17 +1,19 @@
+import { useDialog } from '@sopt-makers/ui';
 import { useRouter } from 'next/router';
 import { FC, useMemo } from 'react';
 
-import AuthRequired from '@/components/auth/AuthRequired';
-import AskFormPage from '@/components/members/ask/AskFormPage';
 import { usePostMemberAsk } from '@/api/endpoint/members/postMemberQuestion';
+import AuthRequired from '@/components/auth/AuthRequired';
+import useEventLogger from '@/components/eventLogger/hooks/useEventLogger';
+import AskFormPage from '@/components/members/ask/AskFormPage';
 import useStringRouterQuery from '@/hooks/useStringRouterQuery';
 import { setLayout } from '@/utils/layout';
-import { useDialog } from '@sopt-makers/ui';
 
 const MemberAskUploadPage: FC = () => {
   const { status, query } = useStringRouterQuery(['memberId'] as const);
   const router = useRouter();
   const { open } = useDialog();
+  const { logSubmitEvent } = useEventLogger();
   const { mutateAsync: createQuestion, isPending } = usePostMemberAsk();
 
   const receiverId = useMemo(() => {
@@ -37,12 +39,14 @@ const MemberAskUploadPage: FC = () => {
 
         buttonFunction: async () => {
           try {
-            await createQuestion({
+            const result = await createQuestion({
               receiverId,
               content,
               isAnonymous,
               latestSoptActivity,
             });
+
+            logSubmitEvent('submitAsk', { feedId: result.questionId });
 
             open({
               title: '알림이 켜져 있는지 확인해 주세요.',


### PR DESCRIPTION
### 🤫 쉿, 나한테만 말해줘요. 이슈넘버
- close #2137

### 🧐 어떤 것을 변경했어요~?
<!-- 실제로 변경한 사항을 설명해주세요.-->

에스크(Ask) 기능에 대한 이벤트 로깅을 추가했어요
- Click Events
  - CTAAsk - OB 멤버 카드에서 "궁금한 점, 편하게 물어보세요!" 버튼 클릭 (id, name)
  - TabAsk - 멤버 상세에서 에스크 탭 클릭 (id, name)
  - TabProfile - 멤버 상세에서 프로필 탭 클릭 (id, name)
  - AskUploadButton - 질문 업로드 FAB 버튼 클릭
  - AnswerUploadButton - 답변 작성하기 버튼 클릭
  - AskLike - 질문/답변 좋아요 버튼 클릭 (feedId)

- Submit Events
  - submitAsk - 질문 등록 성공 (feedId)
  - submitAnswer - 답변 등록 성공 (feedId)

- Impression Events
  - AskCard - 질문 카드가 화면에 50% 이상 노출 시 (feedId, Intersection Observer 사용)

### 🤔 그렇다면, 어떻게 구현했어요~?
<!-- 실제로 구현한 로직에 대해 설명해주세요.-->

### ❤️‍🔥 당신이 생각하는 PR포인트, 내겐 매력포인트.
<!-- 해당 PR에서 논의가 필요한 사항을 적어주세요. -->

### 📸 스크린샷, 없으면 이것 참,, 섭섭한데요?
